### PR TITLE
update network's config to handle different peers

### DIFF
--- a/exe-common/src/config.rs
+++ b/exe-common/src/config.rs
@@ -140,12 +140,13 @@ pub mod net {
 
                 #[inline]
                 fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
-                    where V: serde::de::MapAccess<'de>
+                    where V: serde::de::MapAccess<'de>,
+                          V::Error: serde::de::Error
                 {
                     if let Some((k, v)) = visitor.next_entry()? {
                         Ok(NamedPeer::new(k, v))
                     } else {
-                        Err(unimplemented!())
+                        Err(serde::de::Error::invalid_length(0, &"one and only one entry"))
                     }
                 }
             }

--- a/exe-common/src/config.rs
+++ b/exe-common/src/config.rs
@@ -3,6 +3,7 @@ pub mod net {
     use wallet_crypto::config::{ProtocolMagic};
     use std::{path::{Path}, fs::{File}, fmt, collections::btree_map::{Iter, BTreeMap}, iter::{Filter, Map}};
     use serde_yaml;
+    use serde;
 
     /// A blockchain may have multiple Peer of different kind. Here we define the list
     /// of possible kind of peer we may connect to.
@@ -35,7 +36,7 @@ pub mod net {
     /// assert!(http_peer.is_native());
     /// ```
     ///
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
     pub enum Peer {
         Native(String),
         Http(String)
@@ -88,6 +89,22 @@ pub mod net {
                 &Peer::Native(ref addr) => { write!(f, "native: {}", addr) }
                 &Peer::Http(  ref addr) => { write!(f, "http: {}", addr) }
             }
+        }
+    }
+    impl serde::Serialize for Peer {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where S: serde::Serializer
+        {
+            self.get_address().serialize(serializer)
+        }
+
+    }
+    impl<'de> serde::Deserialize<'de> for Peer {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+           where D: serde::Deserializer<'de>
+        {
+            let addr = String::deserialize(deserializer)?;
+            Ok(Self::new(addr))
         }
     }
 

--- a/exe-common/src/config.rs
+++ b/exe-common/src/config.rs
@@ -1,35 +1,146 @@
 pub mod net {
     use blockchain::{HeaderHash,EpochId};
     use wallet_crypto::config::{ProtocolMagic};
-    use std::{path::{Path}, fs::{File}};
+    use std::{path::{Path}, fs::{File}, fmt, collections::btree_map::{Iter, BTreeMap}, iter::{Filter, Map}};
     use serde_yaml;
+
+    /// A blockchain may have multiple Peer of different kind. Here we define the list
+    /// of possible kind of peer we may connect to.
+    /// 
+    /// # Kinds
+    /// 
+    /// ## Native
+    /// 
+    /// The `Peer::Native` kinds are the peer implementing the native peer to peer
+    /// protocol. While a native peer may be slower to sync the whole blockchain it
+    /// provides more functionalities such as being able to send transactions and
+    /// beeing able to keep a connection alive to keep new block as they are created.
+    /// 
+    /// ## Http
+    /// 
+    /// Here we expect to connect to [Hermes](https://github.com/input-output-hk/cardano-rust)
+    /// server and to be able to fetch specific blocks or specific EPOCH(s) packed. This method
+    /// to sync is blazing fast and allows a clean install to download within seconds the whole
+    /// blockchain history. However, it is not possible to send transaction via Hermes.
+    /// 
+    /// # Example
+    /// 
+    /// ```
+    /// use exe_common::config::{Peer};
+    /// 
+    /// let http_peer = Peer::new("http://hermes.iohk.io");
+    /// assert!(http_peer.is_http());
+    /// 
+    /// let native_peer = Peer::new("mainnet.iohk.io");
+    /// assert!(http_peer.is_native());
+    /// ```
+    ///
+    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+    pub enum Peer {
+        Native(String),
+        Http(String)
+    }
+    impl Peer {
+        /// analyse the content of the given `addr` and construt the correct kind
+        /// of `Peer` accordingly.
+        pub fn new(addr: String) -> Self {
+            if addr.starts_with(r"http://") || addr.starts_with(r"https://") {
+                Peer::http(addr)
+            } else {
+                Peer::native(addr)
+            }
+        }
+
+        /// force constructing a native `Peer`.
+        pub fn native(addr: String) -> Self { Peer::Native(addr) }
+        /// force constructing a http `Peer`.
+        pub fn http(addr: String) -> Self { Peer::Http(addr) }
+        /// return the content of the native peer if the given object is a native peer.
+        pub fn get_native(&self) -> Option<&str> {
+            match self {
+                &Peer::Native(ref addr) => Some(addr.as_ref()),
+                _ => None
+            }
+        }
+        /// return the content of the http peer if the given object is a http peer.
+        pub fn get_http(&self) -> Option<&str> {
+            match self {
+                &Peer::Http(ref addr) => Some(addr.as_ref()),
+                _ => None
+            }
+        }
+        /// get the address, indifferent to whether the `Peer` is a native or
+        /// a http `Peer`.
+        pub fn get_address(&self) -> &str {
+            match self {
+                &Peer::Native(ref addr) => addr.as_ref(),
+                &Peer::Http(ref addr) => addr.as_ref(),
+            }
+        }
+        /// test if the `Peer` is a native `Peer`.
+        pub fn is_native(&self) -> bool { self.get_native().is_some() }
+        /// test if the `Peer` is a http `Peer`.
+        pub fn is_http(&self) -> bool { self.get_http().is_some() }
+    }
+    impl fmt::Display for Peer {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            match self {
+                &Peer::Native(ref addr) => { write!(f, "native: {}", addr) }
+                &Peer::Http(  ref addr) => { write!(f, "http: {}", addr) }
+            }
+        }
+    }
+
+    /// collection of named `Peer`.
+    /// 
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Peers(BTreeMap<String, Peer>);
+    impl Peers {
+        /// create an empty collection of peers
+        pub fn new() -> Self { Peers(BTreeMap::new()) }
+
+        /// add a new peer in the `Peers` set
+        pub fn push(&mut self, name: String, peer: Peer) { self.0.insert(name, peer); }
+
+        /// get an iterator over the peers
+        pub fn iter(&self) -> Iter<String, Peer> { self.0.iter() }
+
+        pub fn natives<'a>(&'a self) -> Vec<&'a str> {
+            self.iter().filter_map(|(_, v)| v.get_native()).collect()
+        }
+    }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Config {
-        pub domain: String,
         pub genesis: HeaderHash,
         pub genesis_prev: HeaderHash,
         pub protocol_magic: ProtocolMagic,
         pub epoch_start: EpochId,
+        pub peers: Peers
     }
     impl Config {
         pub fn mainnet() -> Self {
+            let mut peers = Peers::new();
+            peers.push("iohk-hosts".to_string(), Peer::native("relays.cardano-mainnet.iohk.io:3000".to_string()));
             Config {
-                domain: "relays.cardano-mainnet.iohk.io:3000".to_string(),
                 genesis: HeaderHash::from_hex(&"89D9B5A5B8DDC8D7E5A6795E9774D97FAF1EFEA59B2CAF7EAF9F8C5B32059DF4").unwrap(),
                 genesis_prev: HeaderHash::from_hex(&"5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb").unwrap(),
                 protocol_magic: ProtocolMagic::default(),
                 epoch_start: 0,
+                peers: peers
             }
         }
 
         pub fn testnet() -> Self {
+            let mut peers = Peers::new();
+            peers.push("iohk-hosts".to_string(), Peer::native("relays.awstest.iohkdev.io:3000".to_string()));
+            peers.push("hermes".to_string(), Peer::http("http://hermes.dev.iohkdev.io".to_string()));
             Config {
-                domain: "relays.awstest.iohkdev.io:3000".to_string(),
                 genesis: HeaderHash::from_hex(&"B365F1BE6863B453F12B93E1810909B10C79A95EE44BF53414888513FE172C90").unwrap(),
                 genesis_prev: HeaderHash::from_hex(&"c6a004d3d178f600cd8caa10abbebe1549bef878f0665aea2903472d5abf7323").unwrap(),
                 protocol_magic: ProtocolMagic::new(633343913),
                 epoch_start: 0,
+                peers: peers
             }
         }
 

--- a/exe-common/src/config.rs
+++ b/exe-common/src/config.rs
@@ -28,13 +28,13 @@ pub mod net {
     /// # Example
     /// 
     /// ```
-    /// use exe_common::config::{Peer};
+    /// use exe_common::config::net::{Peer};
     /// 
-    /// let http_peer = Peer::new("http://hermes.iohk.io");
+    /// let http_peer = Peer::new("http://hermes.iohk.io".to_string());
     /// assert!(http_peer.is_http());
-    /// 
-    /// let native_peer = Peer::new("mainnet.iohk.io");
-    /// assert!(http_peer.is_native());
+    ///
+    /// let native_peer = Peer::new("mainnet.iohk.io".to_string());
+    /// assert!(native_peer.is_native());
     /// ```
     ///
     #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/exe-common/src/mstream.rs
+++ b/exe-common/src/mstream.rs
@@ -44,7 +44,7 @@ impl fmt::Display for MetricStats {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let x = self.duration.as_secs() * 1_000_000_000 + self.duration.subsec_nanos() as u64;
         let s = self.bytes_transfered * 1_000_000_000 / x;
-        write!(f, "{} bytes transfered in {}.{:03} seconds. {}/s", self.bytes_transfered, self.duration.as_secs(), self.duration.subsec_millis(), size_print(s))
+        write!(f, "{} bytes transfered in {}.{:03} seconds. {}/s", self.bytes_transfered, self.duration.as_secs(), self.duration.subsec_nanos() / 1_000_000, size_print(s))
     }
 }
 

--- a/exe-common/src/mstream.rs
+++ b/exe-common/src/mstream.rs
@@ -56,7 +56,7 @@ pub struct MStream {
 }
 
 impl MStream {
-    pub fn init(dest: &String) -> Self {
+    pub fn init(dest: &str) -> Self {
         let stream = TcpStream::connect(dest).unwrap();
         stream.set_nodelay(true).unwrap();
         //let lock = RwLock::new(5);

--- a/exe-common/src/network.rs
+++ b/exe-common/src/network.rs
@@ -6,7 +6,7 @@ use rand;
 pub struct Network(pub protocol::Connection<MStream>);
 
 impl Network {
-    pub fn new(protocol_magic: ProtocolMagic, host: &String) -> Self {
+    pub fn new(protocol_magic: ProtocolMagic, host: &str) -> Self {
         let drg_seed = rand::random();
         let mut hs = protocol::packet::Handshake::default();
         hs.protocol_magic = protocol_magic;

--- a/wallet-cli/src/command/blockchain.rs
+++ b/wallet-cli/src/command/blockchain.rs
@@ -17,7 +17,13 @@ use exe_common::{config::{net}, network::{Network}};
 use ansi_term::Colour::*;
 
 pub fn new_network(cfg: &net::Config) -> Network {
-    Network::new(cfg.protocol_magic, &cfg.domain.clone())
+    let natives = cfg.peers.natives();
+
+    for native in natives {
+        return Network::new(cfg.protocol_magic, native);
+    }
+
+    panic!("no native peer to connect to")
 }
 
 // TODO return BlockHeader not MainBlockHeader

--- a/wallet-cli/src/command/blockchain.rs
+++ b/wallet-cli/src/command/blockchain.rs
@@ -49,7 +49,7 @@ fn network_get_blocks_headers(net: &mut Network, from: &blockchain::HeaderHash, 
 }
 
 fn duration_print(d: Duration) -> String {
-    format!("{}.{:03} seconds", d.as_secs(), d.subsec_millis())
+    format!("{}.{:03} seconds", d.as_secs(), d.subsec_nanos() / 1_000_000)
 }
 
 fn find_earliest_epoch(storage: &storage::Storage, minimum_epochid: blockchain::EpochId, start_epochid: blockchain::EpochId)


### PR DESCRIPTION
**breaking change**: after merging this, every devs using `ariadne` will need to update their network configuration file:

for example, for testnet's config file:

```diff
- domain: relays.awstest.iohkdev.io:3000
+ peers:
+   - main: "relays.awstest.iohkdev.io:3000"
```

Other than that we will still use the first `Native` entry available and will take the first IP address this peer will resolve too.