### PR TITLE
Wallet new config

### DIFF
--- a/exe-common/src/config.rs
+++ b/exe-common/src/config.rs
@@ -2,34 +2,35 @@ pub mod net {
     use blockchain::{HeaderHash,EpochId};
     use wallet_crypto::config::{ProtocolMagic};
     use std::{path::{Path}, fs::{File}, fmt, slice::{Iter}};
+    use storage::tmpfile::{TmpFile};
     use serde_yaml;
     use serde;
 
 
     /// A blockchain may have multiple Peer of different kind. Here we define the list
     /// of possible kind of peer we may connect to.
-    /// 
+    ///
     /// # Kinds
-    /// 
+    ///
     /// ## Native
-    /// 
+    ///
     /// The `Peer::Native` kinds are the peer implementing the native peer to peer
     /// protocol. While a native peer may be slower to sync the whole blockchain it
     /// provides more functionalities such as being able to send transactions and
     /// beeing able to keep a connection alive to keep new block as they are created.
-    /// 
+    ///
     /// ## Http
-    /// 
+    ///
     /// Here we expect to connect to [Hermes](https://github.com/input-output-hk/cardano-rust)
     /// server and to be able to fetch specific blocks or specific EPOCH(s) packed. This method
     /// to sync is blazing fast and allows a clean install to download within seconds the whole
     /// blockchain history. However, it is not possible to send transaction via Hermes.
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// ```
     /// use exe_common::config::net::{Peer};
-    /// 
+    ///
     /// let http_peer = Peer::new("http://hermes.iohk.io".to_string());
     /// assert!(http_peer.is_http());
     ///
@@ -156,7 +157,7 @@ pub mod net {
     }
 
     /// collection of named `Peer`.
-    /// 
+    ///
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Peers(Vec<NamedPeer>);
     impl Peers {
@@ -218,8 +219,9 @@ pub mod net {
             serde_yaml::from_reader(&mut file).unwrap()
         }
         pub fn to_file<P: AsRef<Path>>(&self, p: P) {
-            let mut file = File::create(p.as_ref()).unwrap();
+            let mut file = TmpFile::create(p.as_ref().parent().unwrap().to_path_buf()).unwrap();
             serde_yaml::to_writer(&mut file, &self).unwrap();
+            file.render_permanent(&p.as_ref().to_path_buf()).unwrap();
         }
     }
 }

--- a/exe-common/src/config.rs
+++ b/exe-common/src/config.rs
@@ -1,7 +1,7 @@
 pub mod net {
     use blockchain::{HeaderHash,EpochId};
     use wallet_crypto::config::{ProtocolMagic};
-    use std::{path::{Path}, fs::{File}, fmt, slice::{Iter}};
+    use std::{path::{Path}, fs::{self, File}, fmt, slice::{Iter}};
     use storage::tmpfile::{TmpFile};
     use serde_yaml;
     use serde;
@@ -219,7 +219,9 @@ pub mod net {
             serde_yaml::from_reader(&mut file).unwrap()
         }
         pub fn to_file<P: AsRef<Path>>(&self, p: P) {
-            let mut file = TmpFile::create(p.as_ref().parent().unwrap().to_path_buf()).unwrap();
+            let dir = p.as_ref().parent().unwrap().to_path_buf();
+            fs::DirBuilder::new().recursive(true).create(dir.clone()).unwrap();
+            let mut file = TmpFile::create(dir).unwrap();
             serde_yaml::to_writer(&mut file, &self).unwrap();
             file.render_permanent(&p.as_ref().to_path_buf()).unwrap();
         }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -12,7 +12,7 @@ pub mod config;
 pub mod pack;
 pub mod tag;
 pub mod refpack;
-mod tmpfile;
+pub mod tmpfile;
 mod compression;
 mod bitmap;
 mod bloom;

--- a/wallet-cli/src/command/wallet/address.rs
+++ b/wallet-cli/src/command/wallet/address.rs
@@ -2,50 +2,59 @@ use wallet_crypto::{bip44,};
 use wallet_crypto::util::base58;
 use command::{HasCommand};
 use clap::{ArgMatches, Arg, App};
-use config::{Config};
-use account::{Account};
+use super::util::{create_new_account};
+
+use super::config;
 
 pub struct Generate;
 
 impl HasCommand for Generate {
-    type Output = Option<Config>;
-    type Config = Config;
+    type Output = ();
+    type Config = ();
 
     const COMMAND : &'static str = "address";
 
     fn clap_options<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
         app.about("create an address with the given options")
             .arg(Arg::with_name("is_internal").long("internal").help("to generate an internal address (see BIP44)"))
-            .arg(Arg::with_name("account").help("account to generate an address in").index(1).required(true))
+            .arg(Arg::with_name("WALLET NAME").help("the name of the new wallet").index(1).required(true))
+            .arg(Arg::with_name("WALLET ACCOUNT").help("account to generate an address in").index(2).required(true))
             .arg(Arg::with_name("indices")
                 .help("list of indices for the addresses to create")
                 .multiple(true)
             )
     }
-    fn run(cfg: Config, args: &ArgMatches) -> Self::Output {
-        match &cfg.wallet {
-            &None => panic!("No wallet created, see `wallet generate` command"),
-            &Some(ref wallet) => {
-                let addr_type = if args.is_present("is_internal") {
-                    bip44::AddrType::Internal
-                } else {
-                    bip44::AddrType::External
-                };
-                let account_name = args.value_of("account")
-                    .and_then(|s| Some(Account::new(s.to_string())))
-                    .unwrap();
-                let account = match cfg.find_account(&account_name) {
-                    None => panic!("no account {:?}", account_name),
-                    Some(r) => r,
-                };
-                let indices = values_t!(args.values_of("indices"), u32).unwrap_or_else(|_| vec![0]);
+    fn run(_: Self::Config, args: &ArgMatches) -> Self::Output {
+        let name         = value_t!(args.value_of("WALLET NAME"), String).unwrap();
+        let account_name = value_t!(args.value_of("WALLET ACCOUNT"), String).unwrap();
+        let addr_type = if args.is_present("is_internal") {
+            bip44::AddrType::Internal
+        } else {
+            bip44::AddrType::External
+        };
+        let indices = values_t!(args.values_of("indices"), u32).unwrap_or_else(|_| vec![0]);
 
-                let addresses = wallet.0.gen_addresses(account, addr_type, indices).unwrap();
-                for addr in addresses {
-                    println!("{}", base58::encode(&addr.to_bytes()));
-                };
-                None // we don't need to update the wallet
+        let wallet = config::Config::from_file(&name).unwrap();
+        let mut known_accounts = config::Accounts::from_files(&name).unwrap();
+
+        let account = known_accounts.get_account_alias(&account_name)
+            .or_else(|_| name.parse::<u32>().map_err(|_| config::Error::AccountAliasNotFound(account_name.clone())).and_then(|idx| known_accounts.get_account_index(idx)));
+        let account = match account {
+            Ok(account) => account,
+            Err(config::Error::AccountAliasNotFound(alias)) => {
+                let account = create_new_account(&mut known_accounts, &wallet, Some(alias));
+                known_accounts.to_files(&name).unwrap();
+                account
+            },
+            Err(err) => {
+                error!("error when retrieving an account: {:?}", err);
+                panic!()
             }
-        }
+        };
+
+        let addresses = account.gen_addresses(addr_type, indices).unwrap();
+        for addr in addresses {
+            println!("{}", base58::encode(&addr.to_bytes()));
+        };
     }
 }

--- a/wallet-cli/src/command/wallet/address.rs
+++ b/wallet-cli/src/command/wallet/address.rs
@@ -42,7 +42,7 @@ impl HasCommand for Generate {
         let account = match account {
             Ok(account) => account,
             Err(config::Error::AccountAliasNotFound(alias)) => {
-                let account = create_new_account(&mut known_accounts, &wallet, Some(alias));
+                let account = create_new_account(&mut known_accounts, &wallet, alias);
                 known_accounts.to_files(&name).unwrap();
                 account
             },

--- a/wallet-cli/src/command/wallet/config.rs
+++ b/wallet-cli/src/command/wallet/config.rs
@@ -1,0 +1,246 @@
+//! wallet configuration
+//!
+//! defines everything that correspond to a wallet per se in the prometheus
+//! and more specifically in the ariadne environment.
+//!
+
+#![allow(dead_code)]
+
+use wallet_crypto::{
+    self,
+    hdwallet::{XPrv},
+    tx::fee::{SelectionPolicy},
+    wallet::{self, Wallet, Account},
+    bip44
+};
+use exe_common::config::{net};
+use std::{io, slice::{Iter}, result, path::{PathBuf, Path}, env::{VarError, self, home_dir}, fs};
+use std::{num::{ParseIntError}, collections::{BTreeMap}};
+use storage::tmpfile::{TmpFile};
+use serde_yaml;
+
+#[derive(Debug)]
+pub enum Error {
+    IoError(io::Error),
+    VarError(VarError),
+    WalletError(wallet::Error),
+    Bip44Error(bip44::Error),
+    YamlError(serde_yaml::Error),
+    ParseIntError(ParseIntError),
+    AccountIndexNotFound(bip44::Account),
+    AccountAliasNotFound(String),
+    BlockchainConfigError(&'static str)
+}
+impl From<VarError> for Error {
+    fn from(e: VarError) -> Error { Error::VarError(e) }
+}
+impl From<ParseIntError> for Error {
+    fn from(e: ParseIntError) -> Error { Error::ParseIntError(e) }
+}
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Error { Error::IoError(e) }
+}
+impl From<wallet::Error> for Error {
+    fn from(e: wallet::Error) -> Error { Error::WalletError(e) }
+}
+impl From<bip44::Error> for Error {
+    fn from(e: bip44::Error) -> Error { Error::Bip44Error(e) }
+}
+impl From<serde_yaml::Error> for Error {
+    fn from(e: serde_yaml::Error) -> Error { Error::YamlError(e) }
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+/// config of a given Wallet
+///
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Config {
+    /// the name of the local associated network
+    ///
+    /// it can be a string, a relative path or an absolute path.
+    pub blockchain: PathBuf,
+
+    /// useful for spending, so far only
+    pub selection_fee_policy: SelectionPolicy,
+
+    /// TODO, this needs to be encrypted in the very near future
+    pub cached_root_key: XPrv,
+}
+impl Config {
+    /// construct a wallet configuration from the given wallet and blockchain name
+    ///
+    pub fn from_wallet(wallet: Wallet, blockchain: PathBuf) -> Self {
+        Config {
+            blockchain: blockchain,
+            selection_fee_policy: wallet.selection_policy,
+            cached_root_key: wallet.cached_root_key
+        }
+    }
+
+    /// retrieve the blockchain configuration associated to the wallet
+    pub fn blockchain_config(&self) -> Result<net::Config> {
+        let path = ariadne_path()?.join("networks").join(&self.blockchain);
+        match net::Config::from_file(path) {
+            None => Err(Error::BlockchainConfigError("unable to parse wallet config file")),
+            Some(cfg) => Ok(cfg)
+        }
+    }
+
+    /// construct the wallet object from the wallet configuration
+    pub fn wallet(&self) -> Result<Wallet> {
+        let blockchain_config = self.blockchain_config()?;
+        let wallet_cfg = wallet_crypto::config::Config::new(blockchain_config.protocol_magic);
+        Ok(Wallet::new(self.cached_root_key.clone(), wallet_cfg, self.selection_fee_policy))
+    }
+
+    pub fn to_file<P: AsRef<Path>>(&self, name: &P) -> Result<()> {
+        let path = ariadne_path()?.join("wallets").join(name);
+        let mut tmpfile = TmpFile::create(path.clone())?;
+        serde_yaml::to_writer(&mut tmpfile, self)?;
+        tmpfile.render_permanent(&path.join("config.yml"))?;
+        Ok(())
+    }
+
+    pub fn from_file<P: AsRef<Path>>(&self, name: &P) -> Result<Self> {
+        let path = ariadne_path()?.join("wallets").join(name).join("config.yml");
+        let mut file = fs::File::open(path)?;
+        serde_yaml::from_reader(&mut file).map_err(Error::YamlError)
+    }
+}
+
+#[derive(Debug)]
+pub struct Accounts(Vec<account::Config>);
+impl Accounts {
+    pub fn new() -> Self { Accounts(Vec::new()) }
+
+    pub fn new_account(&mut self, wallet: &Wallet, alias: Option<String>) -> Result<Account> {
+        let account_index = self.0.len() as u32;
+        let account = wallet.account(account_index)?;
+        let account_cfg = account::Config::from_account(account.clone(), alias);
+        self.0.push(account_cfg);
+        Ok(account)
+    }
+
+    pub fn iter(&self) -> Iter<account::Config> { self.0.iter() }
+
+    pub fn get_account_index(&self, account_index: u32) -> Result<Account> {
+        let account = bip44::Account::new(account_index)?;
+
+        match self.0.get(account_index as usize) {
+            None => Err(Error::AccountIndexNotFound(account)),
+            Some(cfg) => Ok(Account::new(account, cfg.cached_root_key.clone()))
+        }
+    }
+
+    pub fn get_account_alias(&self, alias: &str) -> Result<Account> {
+        let alias_ = Some(alias.to_owned());
+        match self.iter().position(|cfg| cfg.alias == alias_) {
+            None => Err(Error::AccountAliasNotFound(alias.to_owned())),
+            Some(idx) => self.get_account_index(idx as u32)
+        }
+    }
+
+    pub fn to_files<P: AsRef<Path>>(&self, name: P) -> Result<()> {
+        let dir = ariadne_path()?.join("wallets").join(name);
+        for index in 0..self.0.len() {
+            let account_cfg = &self.0[index];
+            let account = bip44::Account::new(index as u32)?;
+
+            let mut tmpfile = TmpFile::create(dir.clone())?;
+            serde_yaml::to_writer(&mut tmpfile, account_cfg)?;
+            tmpfile.render_permanent(&dir.join(format!("wallet-{}.yml", account)))?;
+        }
+        Ok(())
+    }
+
+    pub fn from_files<P: AsRef<Path>>(name: &P) -> Result<Self> {
+        let dir = ariadne_path()?.join("wallets").join(name);
+        let mut accounts = Self::new();
+
+        let mut to_read = BTreeMap::new();
+        let mut indices = 0;
+
+        for entry in fs::read_dir(dir.clone())? {
+            let entry = entry?;
+            if ! entry.file_type()?.is_dir() { continue; }
+            let name = entry.file_name();
+            if let Some(name) = name.to_str() {
+                if name.starts_with("wallet-") && name.ends_with(".yml") {
+                    let index = name.trim_left_matches("wallet-").trim_right_matches(".yml").parse::<u32>()?;
+                    to_read.insert(index, name.to_owned());
+                    indices += 1;
+                }
+            }
+        }
+
+        let mut expected_index = 0;
+        for (index, filename) in to_read {
+            assert!(index == expected_index);
+            let path = dir.join(filename);
+            let mut file = fs::File::open(path)?;
+            accounts.0.push(serde_yaml::from_reader(file)?);
+            expected_index = index + 1;
+        }
+        assert_eq!(indices, expected_index);
+
+        Ok(accounts)
+    }
+}
+
+pub mod account {
+    use wallet_crypto::{bip44, coin::Coin, wallet::{Account}, hdwallet::{XPub}};
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Config {
+        pub alias: Option<String>,
+        pub addresses: Vec<bip44::Addressing>,
+        pub balance: Coin,
+        pub cached_root_key: XPub
+    }
+    impl Config {
+        pub fn from_account(account: Account, alias: Option<String>) -> Self {
+            Config {
+                alias: alias,
+                addresses: Vec::new(),
+                balance: Coin::zero(),
+                cached_root_key: account.cached_account_key
+            }
+        }
+    }
+}
+
+// ***************************************** TO MOVE IN ANOTHER MODULE ************************************************** //
+//                                                                                                                        //
+// The following should be accessible in every other module of this binary.                                               //
+// Move this to another file.                                                                                             //
+//                                                                                                                        //
+// ********************************************************************************************************************** //
+
+/// the environment variable to define where the Ariadne files are stores
+///
+/// this will include all the cardano network you will connect to (mainnet, testnet, ...),
+/// the different wallets you will create and all metadata.
+pub static ARIADNE_PATH_ENV : &'static str = "ARIADNE_PATH";
+
+/// the home directory hidden directory where to find Ariadne files.
+///
+/// # TODO
+///
+/// This is not standard on windows, set the appropriate setting here
+///
+pub static ARIADNE_HOME_PATH : &'static str = ".ariadne";
+
+/// get the root directory of all the ariadne path
+///
+/// it is either environment variable `ARIADNE_PATH` or the `${HOME}/.ariadne`
+pub fn ariadne_path() -> Result<PathBuf> {
+    match env::var(ARIADNE_PATH_ENV) {
+        Ok(path) => Ok(PathBuf::from(path)),
+        Err(VarError::NotPresent) => match home_dir() {
+            None => Err(Error::BlockchainConfigError("no home directory to base ariadne root dir. Set ARIADNE_PATH` variable environment to fix the problem.")),
+            Some(path) => Ok(path.join(ARIADNE_HOME_PATH))
+        },
+        Err(err) => Err(Error::VarError(err))
+    }
+}

--- a/wallet-cli/src/command/wallet/config.rs
+++ b/wallet-cli/src/command/wallet/config.rs
@@ -103,7 +103,7 @@ impl Config {
         Ok(())
     }
 
-    pub fn from_file<P: AsRef<Path>>(&self, name: &P) -> Result<Self> {
+    pub fn from_file<P: AsRef<Path>>(name: &P) -> Result<Self> {
         let path = ariadne_path()?.join("wallets").join(name).join("config.yml");
         let mut file = fs::File::open(path)?;
         serde_yaml::from_reader(&mut file).map_err(Error::YamlError)

--- a/wallet-cli/src/command/wallet/config.rs
+++ b/wallet-cli/src/command/wallet/config.rs
@@ -168,7 +168,7 @@ impl Accounts {
 
         for entry in fs::read_dir(dir.clone())? {
             let entry = entry?;
-            if ! entry.file_type()?.is_dir() { continue; }
+            if entry.file_type()?.is_dir() { continue; }
             let name = entry.file_name();
             if let Some(name) = name.to_str() {
                 if name.starts_with("wallet-") && name.ends_with(".yml") {

--- a/wallet-cli/src/command/wallet/config.rs
+++ b/wallet-cli/src/command/wallet/config.rs
@@ -80,9 +80,12 @@ impl Config {
 
     /// retrieve the blockchain configuration associated to the wallet
     pub fn blockchain_config(&self) -> Result<net::Config> {
-        let path = ariadne_path()?.join("networks").join(&self.blockchain);
-        match net::Config::from_file(path) {
-            None => Err(Error::BlockchainConfigError("unable to parse wallet config file")),
+        let path = ariadne_path()?.join("networks").join(&self.blockchain).join("config.yml");
+        match net::Config::from_file(path.clone()) {
+            None => {
+                error!("error with blockchain config file {:?}", path);
+                Err(Error::BlockchainConfigError("unable to parse wallet config file"))
+            },
             Some(cfg) => Ok(cfg)
         }
     }

--- a/wallet-cli/src/command/wallet/config.rs
+++ b/wallet-cli/src/command/wallet/config.rs
@@ -96,6 +96,7 @@ impl Config {
 
     pub fn to_file<P: AsRef<Path>>(&self, name: &P) -> Result<()> {
         let path = ariadne_path()?.join("wallets").join(name);
+        fs::DirBuilder::new().recursive(true).create(path.clone())?;
         let mut tmpfile = TmpFile::create(path.clone())?;
         serde_yaml::to_writer(&mut tmpfile, self)?;
         tmpfile.render_permanent(&path.join("config.yml"))?;
@@ -143,6 +144,7 @@ impl Accounts {
 
     pub fn to_files<P: AsRef<Path>>(&self, name: P) -> Result<()> {
         let dir = ariadne_path()?.join("wallets").join(name);
+        fs::DirBuilder::new().recursive(true).create(dir.clone())?;
         for index in 0..self.0.len() {
             let account_cfg = &self.0[index];
             let account = bip44::Account::new(index as u32)?;

--- a/wallet-cli/src/command/wallet/config.rs
+++ b/wallet-cli/src/command/wallet/config.rs
@@ -70,9 +70,9 @@ pub struct Config {
 impl Config {
     /// construct a wallet configuration from the given wallet and blockchain name
     ///
-    pub fn from_wallet(wallet: Wallet, blockchain: PathBuf) -> Self {
+    pub fn from_wallet<P: Into<PathBuf>>(wallet: Wallet, blockchain: P) -> Self {
         Config {
-            blockchain: blockchain,
+            blockchain: blockchain.into(),
             selection_fee_policy: wallet.selection_policy,
             cached_root_key: wallet.cached_root_key
         }

--- a/wallet-cli/src/command/wallet/mod.rs
+++ b/wallet-cli/src/command/wallet/mod.rs
@@ -24,7 +24,7 @@ impl HasCommand for Wallet {
         app.about("wallet management")
             .subcommand(new::CommandNewWallet::mk_command())
             .subcommand(recover::Recover::mk_command())
-            // .subcommand(address::Generate::mk_command())
+            .subcommand(address::Generate::mk_command())
             // TODO: move this command to the blockchain
             // .subcommand(FindAddress::mk_command())
     }
@@ -32,10 +32,8 @@ impl HasCommand for Wallet {
         match args.subcommand() {
             (new::CommandNewWallet::COMMAND, Some(opts)) => new::CommandNewWallet::run((), opts),
             (recover::Recover::COMMAND, Some(opts)) => recover::Recover::run((), opts),
+            (address::Generate::COMMAND, Some(opts)) => address::Generate::run((), opts),
             /*
-            (address::Generate::COMMAND, Some(opts)) => {
-                address::Generate::run(cfg, opts)
-            },
             (FindAddress::COMMAND, Some(opts)) => {
                 FindAddress::run((), opts);
                 None

--- a/wallet-cli/src/command/wallet/mod.rs
+++ b/wallet-cli/src/command/wallet/mod.rs
@@ -9,6 +9,8 @@ mod address;
 mod find_address;
 mod util;
 
+mod config;
+
 use self::find_address::{FindAddress};
 pub use self::definition::{Wallet};
 

--- a/wallet-cli/src/command/wallet/mod.rs
+++ b/wallet-cli/src/command/wallet/mod.rs
@@ -15,24 +15,23 @@ use self::find_address::{FindAddress};
 pub use self::definition::{Wallet};
 
 impl HasCommand for Wallet {
-    type Output = Option<Config>;
-    type Config = Config;
+    type Output = ();
+    type Config = ();
 
     const COMMAND : &'static str = "wallet";
 
     fn clap_options<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
         app.about("wallet management")
             .subcommand(new::CommandNewWallet::mk_command())
-            .subcommand(recover::Recover::mk_command())
-            .subcommand(address::Generate::mk_command())
+            // .subcommand(recover::Recover::mk_command())
+            // .subcommand(address::Generate::mk_command())
             // TODO: move this command to the blockchain
-            .subcommand(FindAddress::mk_command())
+            // .subcommand(FindAddress::mk_command())
     }
-    fn run(cfg: Config, args: &ArgMatches) -> Self::Output {
+    fn run(_: Self::Config, args: &ArgMatches) -> Self::Output {
         match args.subcommand() {
-            (new::CommandNewWallet::COMMAND, Some(opts)) => {
-                new::CommandNewWallet::run(cfg, opts)
-            },
+            (new::CommandNewWallet::COMMAND, Some(opts)) => new::CommandNewWallet::run((), opts),
+            /*
             (recover::Recover::COMMAND, Some(opts)) => {
                 recover::Recover::run(cfg, opts)
             },
@@ -43,6 +42,7 @@ impl HasCommand for Wallet {
                 FindAddress::run((), opts);
                 None
             },
+            */
             _ => {
                 println!("{}", args.usage());
                 ::std::process::exit(1);

--- a/wallet-cli/src/command/wallet/mod.rs
+++ b/wallet-cli/src/command/wallet/mod.rs
@@ -23,7 +23,7 @@ impl HasCommand for Wallet {
     fn clap_options<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
         app.about("wallet management")
             .subcommand(new::CommandNewWallet::mk_command())
-            // .subcommand(recover::Recover::mk_command())
+            .subcommand(recover::Recover::mk_command())
             // .subcommand(address::Generate::mk_command())
             // TODO: move this command to the blockchain
             // .subcommand(FindAddress::mk_command())
@@ -31,10 +31,8 @@ impl HasCommand for Wallet {
     fn run(_: Self::Config, args: &ArgMatches) -> Self::Output {
         match args.subcommand() {
             (new::CommandNewWallet::COMMAND, Some(opts)) => new::CommandNewWallet::run((), opts),
+            (recover::Recover::COMMAND, Some(opts)) => recover::Recover::run((), opts),
             /*
-            (recover::Recover::COMMAND, Some(opts)) => {
-                recover::Recover::run(cfg, opts)
-            },
             (address::Generate::COMMAND, Some(opts)) => {
                 address::Generate::run(cfg, opts)
             },

--- a/wallet-cli/src/command/wallet/new.rs
+++ b/wallet-cli/src/command/wallet/new.rs
@@ -1,63 +1,66 @@
-use wallet_crypto::{bip39};
+use wallet_crypto::{bip39, wallet};
 use command::{HasCommand};
 use clap::{ArgMatches, Arg, App};
-use config::{Config};
 
 use super::util::{generate_entropy};
-use super::Wallet;
+use super::config;
 
 pub struct CommandNewWallet;
 
 impl HasCommand for CommandNewWallet {
-    type Output = Option<Config>;
-    type Config = Config;
+    type Output = ();
+    type Config = ();
 
-    const COMMAND : &'static str = "generate";
+    const COMMAND : &'static str = "new";
 
     fn clap_options<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
-        app.about("generate a new wallet")
-                .arg(Arg::with_name("LANGUAGE")
-                    .long("language")
-                    .takes_value(true)
-                    .value_name("LANGUAGE")
-                    .possible_values(&["english"])
-                    .help("use the given language for the mnemonic")
-                    .required(false)
-                    .default_value(r"english")
-                )
-                .arg(Arg::with_name("NO PAPER WALLET")
-                    .long("no-paper-wallet")
-                    .takes_value(false)
-                    .help("if this option is set, the interactive mode won't ask you about generating a paperwallet")
-                    .required(false)
-                )
-                .arg(Arg::with_name("MNEMONIC SIZE")
-                    .long("number-of-mnemonic-words")
-                    .takes_value(true)
-                    .value_name("MNEMONIC_SIZE")
-                    .possible_values(&["12", "15", "18", "21", "24"])
-                    .help("set the number of the mnemonic words")
-                    .required(false)
-                    .default_value(r"15")
-                )
-                .arg(Arg::with_name("PASSWORD")
-                    .long("--password")
-                    .takes_value(true)
-                    .value_name("PASSWORD")
-                    .help("set the password from the CLI instead of prompting for it. It is quite unsafe as the password can be visible from your shell history.")
-                    .required(false)
-                )
+        app.about("create a new wallet")
+            .arg(Arg::with_name("LANGUAGE")
+                .long("language")
+                .takes_value(true)
+                .value_name("LANGUAGE")
+                .possible_values(&["english"])
+                .help("use the given language for the mnemonic")
+                .required(false)
+                .default_value(r"english")
+            )
+            .arg(Arg::with_name("NO PAPER WALLET")
+                .long("no-paper-wallet")
+                .takes_value(false)
+                .help("if this option is set, the interactive mode won't ask you about generating a paperwallet")
+                .required(false)
+            )
+            .arg(Arg::with_name("MNEMONIC SIZE")
+                .long("number-of-mnemonic-words")
+                .takes_value(true)
+                .value_name("MNEMONIC_SIZE")
+                .possible_values(&["12", "15", "18", "21", "24"])
+                .help("set the number of the mnemonic words")
+                .required(false)
+                .default_value(r"15")
+            )
+            .arg(Arg::with_name("PASSWORD")
+                .long("--password")
+                .takes_value(true)
+                .value_name("PASSWORD")
+                .help("set the password from the CLI instead of prompting for it. It is quite unsafe as the password can be visible from your shell history.")
+                .required(false)
+            )
+            .arg(Arg::with_name("WALLET NAME").help("the name of the new wallet").index(1).required(true))
+            .arg(Arg::with_name("BLOCKCHAIN").help("the name of the associated blockchain (see command `blockchain')").index(2).required(true))
     }
-    fn run(config: Config, args: &ArgMatches) -> Self::Output {
-        let mut cfg = config;
-        assert!(cfg.wallet.is_none());
+    fn run(_: Self::Config, args: &ArgMatches) -> Self::Output {
+        let name        = value_t!(args.value_of("WALLET NAME"), String).unwrap();
+        let blockchain  = value_t!(args.value_of("BLOCKCHAIN"), String).unwrap();
         let language    = value_t!(args.value_of("LANGUAGE"), String).unwrap(); // we have a default value
         let mnemonic_sz = value_t!(args.value_of("MNEMONIC SIZE"), bip39::Type).unwrap();
         let password    = value_t!(args.value_of("PASSWORD"), String).ok();
         let without_paper_wallet = args.is_present("NO PAPER WALLET");
         let seed = generate_entropy(language, password, mnemonic_sz, without_paper_wallet);
-        cfg.wallet = Some(Wallet::generate(seed));
-        let _storage = cfg.get_storage().unwrap();
-        Some(cfg) // we need to update the config's wallet
+        let wallet = wallet::Wallet::new_from_bip39(&seed);
+
+        let config = config::Config::from_wallet(wallet, blockchain);
+
+        config.to_file(&name).unwrap();
     }
 }

--- a/wallet-cli/src/command/wallet/util.rs
+++ b/wallet-cli/src/command/wallet/util.rs
@@ -1,9 +1,11 @@
-use wallet_crypto::{bip39, paperwallet};
+use wallet_crypto::{bip39, paperwallet, wallet};
 use rand;
 
 use termion::{style, color, clear, cursor};
 use termion::input::TermRead;
 use std::io::{Write, stdout, stdin};
+
+use super::config;
 
 pub fn get_password() -> String {
     let stdout = stdout();
@@ -229,4 +231,20 @@ pub fn recover_entropy(language: String, opt_pwd: Option<String>) -> bip39::Seed
     let mnemonics_str = mnemonics.to_string(dic);
 
     bip39::Seed::from_mnemonic_string(&mnemonics_str, pwd.as_bytes())
+}
+
+pub fn create_new_account(accounts: &mut config::Accounts, wallet: &config::Config, alias: Option<String>) -> wallet::Account {
+    let known_accounts : Vec<String> = accounts.iter().filter(|acc| acc.alias.is_some()).map(|acc| acc.alias.clone().unwrap()).collect();
+    println!("{}", style::Italic);
+    println!("We are about to create a new wallet account.");
+    println!("This will allow `{}' to cache some metadata and not require your private keys when", crate_name!());
+    println!("performing public operations (like creating addresses).");
+    println!("{}", style::NoItalic);
+    println!("");
+    println!("Here is the list of existing accounts: {:?}", known_accounts);
+
+    // 1. check if the proprosed alias is there and ask user to use this one
+    // 2. check if the user input does not clash existing ones
+
+    accounts.new_account(&wallet.wallet().unwrap(), alias).unwrap()
 }

--- a/wallet-cli/src/main.rs
+++ b/wallet-cli/src/main.rs
@@ -21,15 +21,11 @@ mod config;
 mod account;
 mod command;
 
-use config::{Config};
 use command::{HasCommand};
 use exe_common::network::{Network};
 
-use std::env::{home_dir};
-use std::path::{PathBuf};
-
 fn main() {
-    use clap::{App, Arg};
+    use clap::{App};
 
     env_logger::init();
     trace!("Starting application, {}-{}", crate_name!(), crate_version!());
@@ -38,38 +34,16 @@ fn main() {
         .version(crate_version!())
         .author(crate_authors!())
         .about(crate_description!())
-        .arg(Arg::with_name("config").short("c").long("config").value_name("FILE").help("Sets a custom config file").takes_value(true))
-        .subcommand(Config::mk_command())
         .subcommand(command::Wallet::mk_command())
         .subcommand(Network::mk_command())
         .get_matches();
 
-    let cfg_path = matches.value_of("config")
-        .map_or(get_default_config(), |s| PathBuf::from(s));
-    let cfg = Config::from_file(&cfg_path);
-
     match matches.subcommand() {
-        (Config::COMMAND, Some(sub_matches)) => {
-            if let Some(cfg2) = Config::run(cfg, sub_matches) {
-                cfg2.to_file(&cfg_path);
-            };
-        },
-        (command::Wallet::COMMAND, Some(sub_matches)) => {
-            if let Some(cfg2) = command::Wallet::run(cfg, sub_matches) {
-                cfg2.to_file(&cfg_path);
-            };
-        },
-        (Network::COMMAND, Some(sub_matches)) => { Network::run((), sub_matches); },
+        (command::Wallet::COMMAND, Some(sub_matches)) => command::Wallet::run((), sub_matches),
+        (Network::COMMAND,         Some(sub_matches)) => Network::run((), sub_matches),
         _ => {
             println!("{}", matches.usage());
             ::std::process::exit(1);
         },
-    }
-}
-
-fn get_default_config() -> PathBuf {
-    match home_dir() {
-        None => panic!("Unable to retrieve your home directory, set the --config option"),
-        Some(mut d) => {d.push(".ariadne/wallet.yml"); d }
     }
 }

--- a/wallet-crypto/src/bip44.rs
+++ b/wallet-crypto/src/bip44.rs
@@ -99,6 +99,11 @@ impl Account {
         Change::new(*self, 0)
     }
 }
+impl fmt::Display for Account {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 impl serde::Serialize for Account
 {
     #[inline]

--- a/wallet-crypto/src/hdwallet.rs
+++ b/wallet-crypto/src/hdwallet.rs
@@ -242,6 +242,9 @@ impl PartialEq for XPrv {
     fn eq(&self, rhs: &XPrv) -> bool { fixed_time_eq(self.as_ref(), rhs.as_ref()) }
 }
 impl Eq for XPrv {}
+impl Clone for XPrv {
+    fn clone(&self) -> Self { Self::from_slice(self.as_ref()).expect("it is already a safely constructed XPrv") }
+}
 impl fmt::Debug for XPrv {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", hex::encode(self.as_ref()))

--- a/wallet-crypto/src/wallet.rs
+++ b/wallet-crypto/src/wallet.rs
@@ -53,16 +53,16 @@ pub type Result<T> = result::Result<T, Error>;
 /// the Wallet object
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct Wallet {
-    cached_root_key: hdwallet::XPrv,
+    pub cached_root_key: hdwallet::XPrv,
 
-    config: config::Config,
-    selection_policy: tx::fee::SelectionPolicy,
+    pub config: config::Config,
+    pub selection_policy: tx::fee::SelectionPolicy,
 }
 
 impl Wallet {
-    /// generate a new wallet
-    ///
-    pub fn new() -> Self { unimplemented!() }
+    pub fn new(cached_root_key: hdwallet::XPrv, config: config::Config, policy: tx::fee::SelectionPolicy) -> Self {
+        Wallet { cached_root_key: cached_root_key, config: config, selection_policy: policy }
+    }
 
     /// create a new wallet from the given seed
     pub fn new_from_seed(seed: &hdwallet::Seed) -> Self {
@@ -168,13 +168,13 @@ impl Wallet {
 /// Account associated to a given wallet.
 ///
 /// Already contains the derived public key for the account of the wallet (see bip44).
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Account {
-    account: bip44::Account,
-    cached_account_key: hdwallet::XPub
+    pub account: bip44::Account,
+    pub cached_account_key: hdwallet::XPub
 }
 impl Account {
-    fn new(account: bip44::Account, xpub: hdwallet::XPub) -> Self { Account { account: account, cached_account_key: xpub } }
+    pub fn new(account: bip44::Account, xpub: hdwallet::XPub) -> Self { Account { account: account, cached_account_key: xpub } }
 
     /// create an extended address from the given addressing
     ///


### PR DESCRIPTION
This introduce a new model of wallet configuration, in the same spirit as the blockchain/network configuration file.

This way, we introduce new features and possibilities for future improvements:

* we can now have multiple wallets, stored by aliases;
* we can now properly specify the wallet's associated blockchain (mainnet, testnet, ...);
* address generation won't need the wallet root secret key anymore, we will use an intermediate account with a cached public key;
    - it means that soon we will be able to encrypt the root cached secret and yet perform public operation easily on the wallet's accounts;
    - a more efficient way to understand the different account and the recovery per account

# Still missing

- [x] addresses generation rewrite to use the new model/account's public key

closes #100 