### PR TITLE
More pretty printer features

### DIFF
--- a/blockchain/src/genesis.rs
+++ b/blockchain/src/genesis.rs
@@ -123,7 +123,7 @@ impl cbor::CborValue for Block {
 
 #[derive(Debug, Clone)]
 pub struct Consensus {
-    pub epoch: u32,
+    pub epoch: types::EpochId,
     pub chain_difficulty: ChainDifficulty,
 }
 impl cbor::CborValue for Consensus {

--- a/blockchain/src/lib.rs
+++ b/blockchain/src/lib.rs
@@ -11,7 +11,7 @@ extern crate test;
 extern crate serde_derive;
 extern crate serde;
 
-mod types;
+pub mod types;
 pub mod genesis; /* genesis block related value */
 pub mod normal; /* normal block related value */
 mod block;

--- a/wallet-cli/README.md
+++ b/wallet-cli/README.md
@@ -27,7 +27,7 @@ jYTLseJK1m2RmsXD44EZVe2EqGtBnQyFnPwjS2Q36c3iLwWCPGmAVWKR9ufE
 jYTLseJK1m2eYuy16w7tjPNqtVdAaQ5bnb4Cyya2YH9AqJoNPQ1VLgE4MaXL
 ```
 
-Make a network configuration (from a template).
+Make a blockchain network configuration (from a template).
 
 ```sh-session
 $ ariadne blockchain new foo --template testnet
@@ -35,7 +35,7 @@ $ ariadne blockchain new foo --template testnet
 # see `ariadne network new --help` for more info.
 ```
 
-Download the blockchain (takes awhile).
+Download a blockchain specified by network configuration name (takes awhile).
 
 ```sh-session
 $ ariadne blockchain sync foo
@@ -50,7 +50,7 @@ downloading epoch 0 b36...
  
 ```
 
-cat a block in a given blockchain:
+Show a block from a given blockchain:
 
 ```sh-sesssion
 $ ariadne blockchain cat foo "c9942ae..."

--- a/wallet-cli/src/command/pretty.rs
+++ b/wallet-cli/src/command/pretty.rs
@@ -24,6 +24,7 @@ pub enum Val<'a> {
     // terminals
     Raw(String),
     Hash(&'a [u8]),
+    Epoch(u32),
 
     // recursive
     List(Vec<Val<'a>>),
@@ -56,7 +57,7 @@ fn fmt_val(
 ) -> fmt::Result {
     match val {
         // write terminals inline
-        Val::Raw(_) | Val::Hash(_) => {
+        Val::Raw(_) | Val::Hash(_) | Val::Epoch(_) => {
             write!(f, " ")?;
             fmt_pretty(val, f, indent_size, indent_level)?;
             write!(f, "\n")
@@ -84,6 +85,7 @@ fn fmt_pretty(
             "{}",
             Colour::Green.paint(wallet_crypto::util::hex::encode(hash))
         ),
+        Val::Epoch(epoch) => write!(f, "{}", Colour::Blue.paint(format!("{}", epoch))),
 
         // format pretty-val as a set of key-vals
         Val::Tree(ast) => {
@@ -258,7 +260,7 @@ impl Pretty for normal::Consensus {
 impl Pretty for genesis::Consensus {
     fn to_pretty(&self) -> Val {
         Val::Tree(vec![
-            ("epoch".to_string(), Val::Raw(format!("{}", self.epoch))),
+            ("epoch".to_string(), Val::Epoch(self.epoch)),
             (
                 "chain difficulty".to_string(),
                 Val::Raw(format!("{}", self.chain_difficulty)),

--- a/wallet-cli/src/command/pretty.rs
+++ b/wallet-cli/src/command/pretty.rs
@@ -82,11 +82,7 @@ fn fmt_pretty(
         Val::Hash(hash) => write!(f, "{}", Colour::Green.paint(hex::encode(hash.as_ref()))),
         Val::Epoch(epoch) => write!(f, "{}", Colour::Blue.paint(format!("{}", epoch))),
         Val::SlotId(slotid) => write!(f, "{}", Colour::Purple.paint(format!("{}", slotid))),
-        Val::BlockSig(block_signature) => write!(
-            f,
-            "{}",
-            Colour::Cyan.paint(format!("{:?}", block_signature))
-        ),
+        Val::BlockSig(blksig) => write!(f, "{}", Colour::Cyan.paint(format!("{:?}", blksig))),
 
         // format pretty-val as a set of key-vals
         Val::Tree(ast) => {

--- a/wallet-cli/src/command/pretty.rs
+++ b/wallet-cli/src/command/pretty.rs
@@ -260,18 +260,20 @@ mod tests {
     }
     #[test]
     fn longest_key_length_works() {
-        let mut input = Vec::new();
-        input.push(("name".to_string(), Raw("zaphod".to_string())));
-        input.push(("age".to_string(), Raw(format!("{}", 42))));
+        let input = vec![
+            ("name".to_string(), Raw("zaphod".to_string())),
+            ("age".to_string(), Raw(format!("{}", 42))),
+        ];
         assert_eq!(longest_key_length(&input), 4);
     }
     #[test]
     fn test_display_flat_pairs() {
-        let mut input = Vec::new();
-        input.push(("name".to_string(), Raw("zaphod".to_string())));
-        input.push(("age".to_string(), Raw(format!("{}", 42))));
+        let input = Tree(vec![
+            ("name".to_string(), Raw("zaphod".to_string())),
+            ("age".to_string(), Raw(format!("{}", 42))),
+        ]);
         assert_eq!(
-            format!("{}", Tree(input)),
+            format!("{}", input),
             "\
 - name: zaphod
 - age : 42
@@ -280,14 +282,18 @@ mod tests {
     }
     #[test]
     fn test_display_nested_pairs() {
-        let mut nested = Vec::new();
-        nested.push(("name".to_string(), Raw("zaphod".to_string())));
-        nested.push(("age".to_string(), Raw(format!("{}", 42))));
-        let mut input = Vec::new();
-        input.push(("character".to_string(), Tree(nested)));
-        input.push(("crook".to_string(), Raw("yes".to_string())));
+        let input = Tree(vec![
+            (
+                "character".to_string(),
+                Tree(vec![
+                    ("name".to_string(), Raw("zaphod".to_string())),
+                    ("age".to_string(), Raw(format!("{}", 42))),
+                ]),
+            ),
+            ("crook".to_string(), Raw("yes".to_string())),
+        ]);
         assert_eq!(
-            format!("{}", Tree(input)),
+            format!("{}", input),
             "\
 - character:
     - name: zaphod

--- a/wallet-cli/src/command/pretty.rs
+++ b/wallet-cli/src/command/pretty.rs
@@ -7,6 +7,8 @@ use blockchain::normal;
 use blockchain::{Block, SscProof};
 use wallet_crypto;
 
+use ansi_term::Colour;
+
 // Constants for the fmt::Display instance
 static DISPLAY_INDENT_SIZE: usize = 4; // spaces
 static DISPLAY_INDENT_LEVEL: usize = 0; // beginning starts at zero
@@ -136,9 +138,13 @@ impl Pretty for normal::BlockHeader {
             ),
             (
                 "previous hash".to_string(),
-                Val::Raw(wallet_crypto::util::hex::encode(
-                    self.previous_header.as_ref(),
-                )),
+                Val::Raw(
+                    Colour::Green
+                        .paint(wallet_crypto::util::hex::encode(
+                            self.previous_header.as_ref(),
+                        ))
+                        .to_string(),
+                ),
             ),
             ("body proof".to_string(), self.body_proof.to_pretty()),
             ("consensus".to_string(), self.consensus.to_pretty()),

--- a/wallet-cli/src/command/pretty.rs
+++ b/wallet-cli/src/command/pretty.rs
@@ -206,7 +206,11 @@ impl Pretty for normal::Consensus {
             ),
             (
                 "block signature".to_string(),
-                Val::Raw(format!("{:?}", self.block_signature)),
+                Val::Raw(
+                    Colour::Cyan
+                        .paint(format!("{:?}", self.block_signature))
+                        .to_string(),
+                ),
             ),
         ])
     }

--- a/wallet-cli/src/command/pretty.rs
+++ b/wallet-cli/src/command/pretty.rs
@@ -157,6 +157,36 @@ impl Pretty for normal::BlockHeader {
     }
 }
 
+impl Pretty for genesis::BlockHeader {
+    fn to_pretty(&self) -> Val {
+        Val::Tree(vec![
+            (
+                "protocol magic".to_string(),
+                Val::Raw(format!("{}", self.protocol_magic)),
+            ),
+            (
+                "previous hash".to_string(),
+                Val::Raw(
+                    Colour::Green
+                        .paint(wallet_crypto::util::hex::encode(
+                            self.previous_header.as_ref(),
+                        ))
+                        .to_string(),
+                ),
+            ),
+            (
+                "body proof".to_string(),
+                Val::Raw(format!("{:?}", self.body_proof)),
+            ),
+            ("consensus".to_string(), self.consensus.to_pretty()),
+            (
+                "extra data".to_string(),
+                Val::Raw(format!("TODO {:?}", self.extra_data)),
+            ),
+        ])
+    }
+}
+
 impl Pretty for normal::BodyProof {
     fn to_pretty(&self) -> Val {
         Val::Tree(vec![
@@ -217,6 +247,18 @@ impl Pretty for normal::Consensus {
     }
 }
 
+impl Pretty for genesis::Consensus {
+    fn to_pretty(&self) -> Val {
+        Val::Tree(vec![
+            ("epoch".to_string(), Val::Raw(format!("{}", self.epoch))),
+            (
+                "chain difficulty".to_string(),
+                Val::Raw(format!("{}", self.chain_difficulty)),
+            ),
+        ])
+    }
+}
+
 impl Pretty for normal::Body {
     fn to_pretty(&self) -> Val {
         Val::Tree(vec![
@@ -231,6 +273,17 @@ impl Pretty for normal::Body {
                 Val::Raw(format!("TODO {:?}", self.update)),
             ),
         ])
+    }
+}
+
+impl Pretty for genesis::Body {
+    fn to_pretty(&self) -> Val {
+        Val::List(
+            self.slot_leaders
+                .iter()
+                .map(|cbor| Val::Raw(format!("{:?}", cbor)))
+                .collect(),
+        )
     }
 }
 
@@ -292,13 +345,10 @@ impl Pretty for wallet_crypto::tx::Tx {
 impl Pretty for genesis::Block {
     fn to_pretty(&self) -> Val {
         Val::Tree(vec![
-            (
-                "header".to_string(),
-                Val::Raw(format!("TODO {}", self.header)),
-            ),
+            ("header".to_string(), self.header.to_pretty()),
             (
                 "body".to_string(),
-                Val::Raw(format!("TODO {:?}", self.body)),
+                self.body.to_pretty(),
             ),
             (
                 "extra".to_string(),

--- a/wallet-cli/src/command/pretty.rs
+++ b/wallet-cli/src/command/pretty.rs
@@ -346,10 +346,7 @@ impl Pretty for genesis::Block {
     fn to_pretty(&self) -> Val {
         Val::Tree(vec![
             ("header".to_string(), self.header.to_pretty()),
-            (
-                "body".to_string(),
-                self.body.to_pretty(),
-            ),
+            ("body".to_string(), self.body.to_pretty()),
             (
                 "extra".to_string(),
                 Val::Raw(format!("TODO {:?}", self.extra)),
@@ -360,8 +357,6 @@ impl Pretty for genesis::Block {
 
 #[cfg(test)]
 mod tests {
-    use std::vec::Vec;
-
     use command::pretty::Val::*;
     use command::pretty::*;
 

--- a/wallet-cli/src/command/pretty.rs
+++ b/wallet-cli/src/command/pretty.rs
@@ -220,10 +220,7 @@ impl Pretty for normal::Consensus {
 impl Pretty for normal::Body {
     fn to_pretty(&self) -> Val {
         Val::Tree(vec![
-            (
-                "tx-payload".to_string(),
-                Val::Raw(format!("TODO {}", self.tx)),
-            ),
+            ("tx payload".to_string(), self.tx.to_pretty()),
             ("scc".to_string(), Val::Raw(format!("TODO {:?}", self.scc))),
             (
                 "delegation".to_string(),
@@ -232,6 +229,61 @@ impl Pretty for normal::Body {
             (
                 "update".to_string(),
                 Val::Raw(format!("TODO {:?}", self.update)),
+            ),
+        ])
+    }
+}
+
+impl Pretty for normal::TxPayload {
+    fn to_pretty(&self) -> Val {
+        Val::List(
+            self.iter()
+                .map(|txaux| {
+                    Val::Tree(vec![
+                        ("tx".to_string(), txaux.tx.to_pretty()),
+                        (
+                            "witnesses".to_string(),
+                            txaux.witnesses.to_pretty()
+                            //Val::Raw(format!("{:?}", txaux.witnesses)),
+                        ),
+                    ])
+                })
+                .collect(),
+        )
+    }
+}
+
+// XXX: impl for a parameterized generic type, Vec.. not sure if idiomatic
+impl Pretty for Vec<wallet_crypto::tx::TxInWitness> {
+    fn to_pretty(&self) -> Val {
+        Val::List(
+            self.iter()
+                .map(|witness| Val::Raw(format!("TODO {}", witness)))
+                .collect(),
+        )
+    }
+}
+
+impl Pretty for wallet_crypto::tx::Tx {
+    fn to_pretty(&self) -> Val {
+        Val::Tree(vec![
+            (
+                "inputs".to_string(),
+                Val::List(
+                    self.inputs
+                        .iter()
+                        .map(|input| Val::Raw(format!("{}", input)))
+                        .collect(),
+                ),
+            ),
+            (
+                "outputs".to_string(),
+                Val::List(
+                    self.outputs
+                        .iter()
+                        .map(|input| Val::Raw(format!("{}", input)))
+                        .collect(),
+                ),
             ),
         ])
     }

--- a/wallet-cli/src/command/pretty.rs
+++ b/wallet-cli/src/command/pretty.rs
@@ -32,21 +32,12 @@ fn longest_key_length(ast: &[(Key, Val)]) -> usize {
         .fold(0, |longest, (key, _)| std::cmp::max(longest, key.len()))
 }
 
-fn fmt_key(
-    key: &Key,
-    f: &mut fmt::Formatter,
-    indent_size: usize,
-    indent_level: usize,
-    key_width: usize,
-) -> fmt::Result {
-    write!(
-        f,
-        "{:>iw$}- {:<kw$}:",
-        "",
-        key,
-        kw = key_width,
-        iw = indent_size * indent_level,
-    )
+fn fmt_indent(f: &mut fmt::Formatter, indent_size: usize, indent_level: usize) -> fmt::Result {
+    write!(f, "{:>iw$}", "", iw = indent_size * indent_level,)
+}
+
+fn fmt_key(key: &Key, f: &mut fmt::Formatter, key_width: usize) -> fmt::Result {
+    write!(f, "- {:<kw$}:", key, kw = key_width,)
 }
 
 fn fmt_val(
@@ -80,12 +71,13 @@ fn fmt_pretty(
     match p {
         // format pretty-val as a terminal
         Val::Raw(display) => write!(f, "{}", display),
-        // format pretty-val as a set of  key-vals
+        // format pretty-val as a set of key-vals
         Val::Tree(ast) => {
             let key_width = longest_key_length(ast);
             ast.iter().fold(Ok(()), |prev_result, (key, val)| {
                 prev_result.and_then(|()| {
-                    fmt_key(key, f, indent_size, indent_level, key_width)?;
+                    fmt_indent(f, indent_size, indent_level)?;
+                    fmt_key(key, f, key_width)?;
                     fmt_val(val, f, indent_size, indent_level + 1)
                 })
             })

--- a/wallet-cli/src/command/pretty.rs
+++ b/wallet-cli/src/command/pretty.rs
@@ -26,6 +26,7 @@ pub enum Val<'a> {
     Hash(&'a [u8]),
     Epoch(u32),
     SlotId(u32),
+    BlockSig(normal::BlockSignature),
 
     // recursive
     List(Vec<Val<'a>>),
@@ -58,7 +59,7 @@ fn fmt_val(
 ) -> fmt::Result {
     match val {
         // write terminals inline
-        Val::Raw(_) | Val::Hash(_) | Val::Epoch(_) | Val::SlotId(_) => {
+        Val::Raw(_) | Val::Hash(_) | Val::Epoch(_) | Val::SlotId(_) | Val::BlockSig(_) => {
             write!(f, " ")?;
             fmt_pretty(val, f, indent_size, indent_level)?;
             write!(f, "\n")
@@ -88,6 +89,11 @@ fn fmt_pretty(
         ),
         Val::Epoch(epoch) => write!(f, "{}", Colour::Blue.paint(format!("{}", epoch))),
         Val::SlotId(slotid) => write!(f, "{}", Colour::Purple.paint(format!("{}", slotid))),
+        Val::BlockSig(block_signature) => write!(
+            f,
+            "{}",
+            Colour::Cyan.paint(format!("{:?}", block_signature))
+        ),
 
         // format pretty-val as a set of key-vals
         Val::Tree(ast) => {
@@ -246,13 +252,15 @@ impl Pretty for normal::Consensus {
             ),
             (
                 "block signature".to_string(),
-                Val::Raw(
-                    Colour::Cyan
-                        .paint(format!("{:?}", self.block_signature))
-                        .to_string(),
-                ),
+                self.block_signature.to_pretty(),
             ),
         ])
+    }
+}
+
+impl Pretty for normal::BlockSignature {
+    fn to_pretty(&self) -> Val {
+        Val::BlockSig(self.clone())
     }
 }
 


### PR DESCRIPTION
implementing aux requests noted in [a comment in #90](https://github.com/input-output-hk/rust-cardano/issues/90#issuecomment-392023896); also see commit messages

  - [x] add color to `previous_hash` (field of `BlockHeader`)
  - [x] add color to `block_signature` (field of `Consensus`)
  - [x] extend the AST to allow `Val::List<Vec<Value>>`, use it for lists like transactions and the long list in genesisblocks
  - [x] implement `Pretty` for genesis blocks (use same approach as `blockchain::normal::Block` implementations)


## main block

![image](https://user-images.githubusercontent.com/1078772/40625972-a7847d18-6283-11e8-90d4-33bfa2c1a103.png)

## genesis block

![image](https://user-images.githubusercontent.com/1078772/40625978-aefa8754-6283-11e8-9c44-ea552723ece3.png)
