### PR TITLE
Add test vectors bip39 english

### DIFF
--- a/wallet-crypto/Cargo.toml
+++ b/wallet-crypto/Cargo.toml
@@ -13,7 +13,6 @@ serde = "1.0"
 serde_derive = "1.0"
 log = "0.4"
 bit-vec = "0.5"
-bitreader = "0.3"
 rcw = { path = "../rcw" }
 
 [dev-dependencies]

--- a/wallet-crypto/Cargo.toml
+++ b/wallet-crypto/Cargo.toml
@@ -12,7 +12,6 @@ keywords = [ "Cardano", "Wallet" ]
 serde = "1.0"
 serde_derive = "1.0"
 log = "0.4"
-bit-vec = "0.5"
 rcw = { path = "../rcw" }
 
 [dev-dependencies]

--- a/wallet-crypto/src/bip39.rs
+++ b/wallet-crypto/src/bip39.rs
@@ -273,6 +273,11 @@ impl Seed {
         Self::from_bytes(result)
     }
 }
+impl PartialEq for Seed {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_ref() == other.0.as_ref()
+    }
+}
 impl fmt::Debug for Seed {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", hex::encode(self.as_ref()))
@@ -359,7 +364,7 @@ impl Type {
             256 => Ok(Type::Type24Words),
             _  => Err(Error::WrongKeySize(len))
         }
-    } 
+    }
 
     pub fn to_key_size(&self) -> usize {
         match self {
@@ -369,7 +374,7 @@ impl Type {
             &Type::Type21Words => 224,
             &Type::Type24Words => 256,
         }
-    } 
+    }
 
     pub fn checksum_size_bits(&self) -> usize {
         match self {
@@ -547,4 +552,135 @@ mod test {
         let entropy2 = Entropy::from_mnemonics(&mnemonics).unwrap();
         assert_eq!(entropy, entropy2);
     }
+
+
+    struct TestVector {
+        entropy: &'static str,
+        mnemonics: &'static str,
+        seed: &'static str,
+    }
+
+    fn mk_test(test: &'static TestVector) {
+        let mnemonics_str = MnemonicString::new(&dictionary::ENGLISH, test.mnemonics.to_owned())
+                            .expect("valid mnemonics string");
+        let mnemonics_ref = Mnemonics::from_string(&dictionary::ENGLISH, test.mnemonics)
+                            .expect("valid mnemonics");
+        let entropy_ref = Entropy::from_slice(&hex::decode(test.entropy).unwrap())
+                            .expect("decode entropy from hex");
+        let seed_ref = Seed::from_slice(&hex::decode(test.seed).unwrap())
+                            .expect("decode seed from hex");
+
+        assert!(mnemonics_ref.get_type() == entropy_ref.get_type());
+
+        assert!(entropy_ref == Entropy::from_mnemonics(&mnemonics_ref).expect("retrieve entropy from mnemonics"));
+
+        assert!(seed_ref == Seed::from_mnemonic_string(&mnemonics_str, b"TREZOR"));
+    }
+
+    #[test]
+    fn test_vectors() {
+        for test in TEST_VECTORS {
+            mk_test(test);
+        }
+    }
+
+    const TEST_VECTORS : &'static [TestVector] = &
+        [ TestVector {
+            entropy: "00000000000000000000000000000000",
+            mnemonics: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+            seed: "c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04",
+        },TestVector {
+            entropy: "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
+            mnemonics: "legal winner thank year wave sausage worth useful legal winner thank yellow",
+            seed: "2e8905819b8723fe2c1d161860e5ee1830318dbf49a83bd451cfb8440c28bd6fa457fe1296106559a3c80937a1c1069be3a3a5bd381ee6260e8d9739fce1f607",
+        },TestVector {
+            entropy: "80808080808080808080808080808080",
+            mnemonics: "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
+            seed: "d71de856f81a8acc65e6fc851a38d4d7ec216fd0796d0a6827a3ad6ed5511a30fa280f12eb2e47ed2ac03b5c462a0358d18d69fe4f985ec81778c1b370b652a8",
+        },TestVector {
+            entropy: "ffffffffffffffffffffffffffffffff",
+            mnemonics: "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
+            seed: "ac27495480225222079d7be181583751e86f571027b0497b5b5d11218e0a8a13332572917f0f8e5a589620c6f15b11c61dee327651a14c34e18231052e48c069",
+        },TestVector {
+            entropy: "000000000000000000000000000000000000000000000000",
+            mnemonics: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent",
+            seed: "035895f2f481b1b0f01fcf8c289c794660b289981a78f8106447707fdd9666ca06da5a9a565181599b79f53b844d8a71dd9f439c52a3d7b3e8a79c906ac845fa",
+        },TestVector {
+            entropy: "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
+            mnemonics: "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will",
+            seed: "f2b94508732bcbacbcc020faefecfc89feafa6649a5491b8c952cede496c214a0c7b3c392d168748f2d4a612bada0753b52a1c7ac53c1e93abd5c6320b9e95dd",
+        },TestVector {
+            entropy: "808080808080808080808080808080808080808080808080",
+            mnemonics: "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter always",
+            seed: "107d7c02a5aa6f38c58083ff74f04c607c2d2c0ecc55501dadd72d025b751bc27fe913ffb796f841c49b1d33b610cf0e91d3aa239027f5e99fe4ce9e5088cd65",
+        },TestVector {
+            entropy: "ffffffffffffffffffffffffffffffffffffffffffffffff",
+            mnemonics: "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo when",
+            seed: "0cd6e5d827bb62eb8fc1e262254223817fd068a74b5b449cc2f667c3f1f985a76379b43348d952e2265b4cd129090758b3e3c2c49103b5051aac2eaeb890a528",
+        },TestVector {
+            entropy: "0000000000000000000000000000000000000000000000000000000000000000",
+            mnemonics: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
+            seed: "bda85446c68413707090a52022edd26a1c9462295029f2e60cd7c4f2bbd3097170af7a4d73245cafa9c3cca8d561a7c3de6f5d4a10be8ed2a5e608d68f92fcc8",
+        },TestVector {
+            entropy: "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
+            mnemonics: "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title",
+            seed: "bc09fca1804f7e69da93c2f2028eb238c227f2e9dda30cd63699232578480a4021b146ad717fbb7e451ce9eb835f43620bf5c514db0f8add49f5d121449d3e87",
+        },TestVector {
+            entropy: "8080808080808080808080808080808080808080808080808080808080808080",
+            mnemonics: "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless",
+            seed: "c0c519bd0e91a2ed54357d9d1ebef6f5af218a153624cf4f2da911a0ed8f7a09e2ef61af0aca007096df430022f7a2b6fb91661a9589097069720d015e4e982f",
+        },TestVector {
+            entropy: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            mnemonics: "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote",
+            seed: "dd48c104698c30cfe2b6142103248622fb7bb0ff692eebb00089b32d22484e1613912f0a5b694407be899ffd31ed3992c456cdf60f5d4564b8ba3f05a69890ad",
+        },TestVector {
+            entropy: "9e885d952ad362caeb4efe34a8e91bd2",
+            mnemonics: "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic",
+            seed: "274ddc525802f7c828d8ef7ddbcdc5304e87ac3535913611fbbfa986d0c9e5476c91689f9c8a54fd55bd38606aa6a8595ad213d4c9c9f9aca3fb217069a41028",
+        },TestVector {
+            entropy: "6610b25967cdcca9d59875f5cb50b0ea75433311869e930b",
+            mnemonics: "gravity machine north sort system female filter attitude volume fold club stay feature office ecology stable narrow fog",
+            seed: "628c3827a8823298ee685db84f55caa34b5cc195a778e52d45f59bcf75aba68e4d7590e101dc414bc1bbd5737666fbbef35d1f1903953b66624f910feef245ac",
+        },TestVector {
+            entropy: "68a79eaca2324873eacc50cb9c6eca8cc68ea5d936f98787c60c7ebc74e6ce7c",
+            mnemonics: "hamster diagram private dutch cause delay private meat slide toddler razor book happy fancy gospel tennis maple dilemma loan word shrug inflict delay length",
+            seed: "64c87cde7e12ecf6704ab95bb1408bef047c22db4cc7491c4271d170a1b213d20b385bc1588d9c7b38f1b39d415665b8a9030c9ec653d75e65f847d8fc1fc440",
+        },TestVector {
+            entropy: "c0ba5a8e914111210f2bd131f3d5e08d",
+            mnemonics: "scheme spot photo card baby mountain device kick cradle pact join borrow",
+            seed: "ea725895aaae8d4c1cf682c1bfd2d358d52ed9f0f0591131b559e2724bb234fca05aa9c02c57407e04ee9dc3b454aa63fbff483a8b11de949624b9f1831a9612",
+        },TestVector {
+            entropy: "6d9be1ee6ebd27a258115aad99b7317b9c8d28b6d76431c3",
+            mnemonics: "horn tenant knee talent sponsor spell gate clip pulse soap slush warm silver nephew swap uncle crack brave",
+            seed: "fd579828af3da1d32544ce4db5c73d53fc8acc4ddb1e3b251a31179cdb71e853c56d2fcb11aed39898ce6c34b10b5382772db8796e52837b54468aeb312cfc3d",
+        },TestVector {
+            entropy: "9f6a2878b2520799a44ef18bc7df394e7061a224d2c33cd015b157d746869863",
+            mnemonics: "panda eyebrow bullet gorilla call smoke muffin taste mesh discover soft ostrich alcohol speed nation flash devote level hobby quick inner drive ghost inside",
+            seed: "72be8e052fc4919d2adf28d5306b5474b0069df35b02303de8c1729c9538dbb6fc2d731d5f832193cd9fb6aeecbc469594a70e3dd50811b5067f3b88b28c3e8d",
+        },TestVector {
+            entropy: "23db8160a31d3e0dca3688ed941adbf3",
+            mnemonics: "cat swing flag economy stadium alone churn speed unique patch report train",
+            seed: "deb5f45449e615feff5640f2e49f933ff51895de3b4381832b3139941c57b59205a42480c52175b6efcffaa58a2503887c1e8b363a707256bdd2b587b46541f5",
+        },TestVector {
+            entropy: "8197a4a47f0425faeaa69deebc05ca29c0a5b5cc76ceacc0",
+            mnemonics: "light rule cinnamon wrap drastic word pride squirrel upgrade then income fatal apart sustain crack supply proud access",
+            seed: "4cbdff1ca2db800fd61cae72a57475fdc6bab03e441fd63f96dabd1f183ef5b782925f00105f318309a7e9c3ea6967c7801e46c8a58082674c860a37b93eda02",
+        },TestVector {
+            entropy: "066dca1a2bb7e8a1db2832148ce9933eea0f3ac9548d793112d9a95c9407efad",
+            mnemonics: "all hour make first leader extend hole alien behind guard gospel lava path output census museum junior mass reopen famous sing advance salt reform",
+            seed: "26e975ec644423f4a4c4f4215ef09b4bd7ef924e85d1d17c4cf3f136c2863cf6df0a475045652c57eb5fb41513ca2a2d67722b77e954b4b3fc11f7590449191d",
+        },TestVector {
+            entropy: "f30f8c1da665478f49b001d94c5fc452",
+            mnemonics: "vessel ladder alter error federal sibling chat ability sun glass valve picture",
+            seed: "2aaa9242daafcee6aa9d7269f17d4efe271e1b9a529178d7dc139cd18747090bf9d60295d0ce74309a78852a9caadf0af48aae1c6253839624076224374bc63f",
+        },TestVector {
+            entropy: "c10ec20dc3cd9f652c7fac2f1230f7a3c828389a14392f05",
+            mnemonics: "scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump",
+            seed: "7b4a10be9d98e6cba265566db7f136718e1398c71cb581e1b2f464cac1ceedf4f3e274dc270003c670ad8d02c4558b2f8e39edea2775c9e232c7cb798b069e88",
+        },TestVector {
+            entropy: "f585c11aec520db57dd353c69554b21a89b20fb0650966fa0a9d6f74fd989d8f",
+            mnemonics: "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
+            seed: "01f5bced59dec48e362f2c45b5de68b9fd6c92c6634f44d6d40aab69056506f0e35524a518034ddc1192e1dacd32c1ed3eaa3c3b131c88ed8e7e54c49a5d0998",
+        }
+    ];
 }

--- a/wallet-crypto/src/bip39.rs
+++ b/wallet-crypto/src/bip39.rs
@@ -24,7 +24,6 @@ use rcw::sha2::{Sha512};
 use rcw::pbkdf2::{pbkdf2};
 use std::{fmt, result, str};
 use util::{hex};
-use bit_vec::{BitVec};
 
 pub enum Error {
     WrongNumberOfWords(usize),
@@ -153,22 +152,12 @@ impl Entropy {
     }
 
     pub fn from_mnemonics(mnemonics: &Mnemonics) -> Result<Self> {
+        use util::bits::BitWriterBy11;
         let t = mnemonics.get_type();
 
-        fn bit_from_u16_as_u11(input: u16, position: u16) -> bool {
-            if position < 11 {
-                input & (1 << (10 - position)) != 0
-            } else {
-                false
-            }
-        }
-
-        let mut to_validate: BitVec = BitVec::new();
+        let mut to_validate = BitWriterBy11::new();
         for mnemonic in mnemonics.0.iter() {
-            let n = mnemonic.0;
-            for i in 0..11 {
-                to_validate.push(bit_from_u16_as_u11(n, i));
-            }
+            to_validate.write(mnemonic.0);
         }
 
         let mut r = to_validate.to_bytes();

--- a/wallet-crypto/src/lib.rs
+++ b/wallet-crypto/src/lib.rs
@@ -14,7 +14,6 @@ extern crate log;
 extern crate test;
 
 extern crate bit_vec;
-extern crate bitreader;
 
 extern crate rcw;
 

--- a/wallet-crypto/src/lib.rs
+++ b/wallet-crypto/src/lib.rs
@@ -13,8 +13,6 @@ extern crate log;
 #[cfg(feature = "with-bench")]
 extern crate test;
 
-extern crate bit_vec;
-
 extern crate rcw;
 
 mod crc32;

--- a/wallet-crypto/src/util.rs
+++ b/wallet-crypto/src/util.rs
@@ -333,11 +333,6 @@ a9876543 210a9876 543210a9 87654321 0a987654 3210a987 6543210a 98765432 10a98765
  */
     const NUM_BITS_PER_BLOCK : usize = 11;
 
-    pub struct BitReaderBy11<'a> {
-        buffer: &'a [u8],
-        state: State
-    }
-
     #[derive(Debug, PartialEq, Eq, Copy, Clone)]
     enum State {
         S0, S1, S2, S3, S4, S5, S6, S7
@@ -355,6 +350,101 @@ a9876543 210a9876 543210a9 87654321 0a987654 3210a987 6543210a 98765432 10a98765
                 State::S7 => 5
             }
         }
+    }
+
+    pub struct BitWriterBy11 {
+        buffer: Vec<u8>,
+        state: State
+    }
+
+    impl BitWriterBy11 {
+        pub fn new() -> Self { BitWriterBy11 { buffer: Vec::new(), state: State::S0 } }
+
+        pub fn to_bytes(self) -> Vec<u8> { self.buffer }
+
+        pub fn write(&mut self, e: u16) {
+            match self.state {
+                State::S0 => {
+                    let x = e >> 3 & 0b1111_1111;
+                    let y = e << 5 & 0b1110_0000;
+                    self.buffer.push(x as u8);
+                    self.buffer.push(y as u8);
+                    self.state = State::S1;
+                },
+                State::S1 => {
+                    let x = e >> 6 & 0b0001_1111;
+                    let y = e << 2 & 0b1111_1100;
+                    if let Some(last) = self.buffer.last_mut() {
+                        *last |= x as u8;
+                    } else { unreachable!() }
+                    self.buffer.push(y as u8);
+                    self.state = State::S2;
+                },
+                State::S2 => {
+                    let x = e >> 9 & 0b0000_0011;
+                    let y = e >> 1 & 0b1111_1111;
+                    let z = e << 7 & 0b1000_0000;
+                    if let Some(last) = self.buffer.last_mut() {
+                        *last |= x as u8;
+                    } else { unreachable!() }
+                    self.buffer.push(y as u8);
+                    self.buffer.push(z as u8);
+                    self.state = State::S3;
+                },
+                State::S3 => {
+                    let x = e >> 4 & 0b0111_1111;
+                    let y = e << 4 & 0b1111_0000;
+                    if let Some(last) = self.buffer.last_mut() {
+                        *last |= x as u8;
+                    } else { unreachable!() }
+                    self.buffer.push(y as u8);
+                    self.state = State::S4;
+                },
+                State::S4 => {
+                    let x = e >> 7 & 0b0000_1111;
+                    let y = e << 1 & 0b1111_1110;
+                    if let Some(last) = self.buffer.last_mut() {
+                        *last |= x as u8;
+                    } else { unreachable!() }
+                    self.buffer.push(y as u8);
+                    self.state = State::S5;
+                },
+                State::S5 => {
+                    let x = e >> 10 & 0b0000_0001;
+                    let y = e >>  2 & 0b1111_1111;
+                    let z = e <<  6 & 0b1100_0000;
+                    if let Some(last) = self.buffer.last_mut() {
+                        *last |= x as u8;
+                    } else { unreachable!() }
+                    self.buffer.push(y as u8);
+                    self.buffer.push(z as u8);
+                    self.state = State::S6;
+                },
+                State::S6 => {
+                    let x = e >> 5 & 0b0011_1111;
+                    let y = e << 3 & 0b1111_1000;
+                    if let Some(last) = self.buffer.last_mut() {
+                        *last |= x as u8;
+                    } else { unreachable!() }
+                    self.buffer.push(y as u8);
+                    self.state = State::S7;
+                },
+                State::S7 => {
+                    let x = e >> 8 & 0b0000_0111;
+                    let y = e      & 0b1111_1111;
+                    if let Some(last) = self.buffer.last_mut() {
+                        *last |= x as u8;
+                    } else { unreachable!() }
+                    self.buffer.push(y as u8);
+                    self.state = State::S0;
+                },
+            }
+        }
+    }
+
+    pub struct BitReaderBy11<'a> {
+        buffer: &'a [u8],
+        state: State
     }
 
     impl<'a> BitReaderBy11<'a> {

--- a/wallet-crypto/src/util.rs
+++ b/wallet-crypto/src/util.rs
@@ -322,3 +322,167 @@ pub mod base58 {
         Ok(bytes)
     }
 }
+
+pub mod bits {
+/*!
+    1        2        3       4         5        6       7        8         9       10       11
+01234567 01234567 01234567 01234567 01234567 01234567 01234567 01234567 01234567 01234567 01234567
+a9876543 210a9876 543210a9 87654321 0a987654 3210a987 6543210a 98765432 10a98765 43210a98 76543210
+           ^           ^            ^           ^           ^            ^           ^           ^
+           1           2            3           4           5            6           7
+ */
+    const NUM_BITS_PER_BLOCK : usize = 11;
+
+    pub struct BitReaderBy11<'a> {
+        buffer: &'a [u8],
+        state: State
+    }
+
+    #[derive(Debug, PartialEq, Eq, Copy, Clone)]
+    enum State {
+        S0, S1, S2, S3, S4, S5, S6, S7
+    }
+    impl State {
+        fn index(&self) -> usize {
+            match self {
+                State::S0 => 0,
+                State::S1 => 3,
+                State::S2 => 6,
+                State::S3 => 1,
+                State::S4 => 4,
+                State::S5 => 7,
+                State::S6 => 2,
+                State::S7 => 5
+            }
+        }
+    }
+
+    impl<'a> BitReaderBy11<'a> {
+        pub fn new(bytes: &'a [u8]) -> Self {
+            BitReaderBy11 {
+                buffer: bytes,
+                state: State::S0
+            }
+        }
+
+        pub fn size(&self) -> usize { ((self.buffer.len() * 8) - self.state.index()) / NUM_BITS_PER_BLOCK }
+
+        pub fn read(&mut self) -> u16 {
+            match self.state {
+                State::S0 => {
+                    assert!(self.buffer.len() > 1);
+                    let x = self.buffer[0] as u16 & 0b1111_1111;
+                    let y = self.buffer[1] as u16 & 0b1110_0000;
+                    self.state = State::S1;
+                    self.buffer = &self.buffer[1..];
+                    (x << 3) | (y >> 5)
+                },
+                State::S1 => {
+                    assert!(self.buffer.len() > 1);
+                    let x = self.buffer[0] as u16 & 0b0001_1111;
+                    let y = self.buffer[1] as u16 & 0b1111_1100;
+                    self.state = State::S2;
+                    self.buffer = &self.buffer[1..];
+                    (x << 6) | (y >> 2)
+                },
+                State::S2 => {
+                    assert!(self.buffer.len() > 2);
+                    let x = self.buffer[0] as u16 & 0b0000_0011;
+                    let y = self.buffer[1] as u16 & 0b1111_1111;
+                    let z = self.buffer[2] as u16 & 0b1000_0000;
+                    self.state = State::S3;
+                    self.buffer = &self.buffer[2..];
+                    (x << 9) | (y << 1) | (z >> 7)
+                },
+                State::S3 => {
+                    assert!(self.buffer.len() > 1);
+                    let x = self.buffer[0] as u16 & 0b0111_1111;
+                    let y = self.buffer[1] as u16 & 0b1111_0000;
+                    self.state = State::S4;
+                    self.buffer = &self.buffer[1..];
+                    (x << 4) | (y >> 4)
+                },
+                State::S4 => {
+                    assert!(self.buffer.len() > 1);
+                    let x = self.buffer[0] as u16 & 0b0000_1111;
+                    let y = self.buffer[1] as u16 & 0b1111_1110;
+                    self.state = State::S5;
+                    self.buffer = &self.buffer[1..];
+                    (x << 7) | (y >> 1)
+                },
+                State::S5 => {
+                    assert!(self.buffer.len() > 2);
+                    let x = self.buffer[0] as u16 & 0b0000_0001;
+                    let y = self.buffer[1] as u16 & 0b1111_1111;
+                    let z = self.buffer[2] as u16 & 0b1100_0000;
+                    self.state = State::S6;
+                    self.buffer = &self.buffer[2..];
+                    (x << 10) | (y << 2) | (z >> 6)
+                },
+                State::S6 => {
+                    assert!(self.buffer.len() > 1);
+                    let x = self.buffer[0] as u16 & 0b0011_1111;
+                    let y = self.buffer[1] as u16 & 0b1111_1000;
+                    self.state = State::S7;
+                    self.buffer = &self.buffer[1..];
+                    (x << 5) | (y >> 3)
+                },
+                State::S7 => {
+                    assert!(self.buffer.len() > 1);
+                    let x = self.buffer[0] as u16 & 0b0000_0111;
+                    let y = self.buffer[1] as u16 & 0b1111_1111;
+                    self.state = State::S0;
+                    self.buffer = &self.buffer[2..];
+                    (x << 8) | y
+                },
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod test {
+        use super::*;
+
+        #[test]
+        fn bit_read_by_11() {
+            const BYTES : &'static [u8] = &
+                [ 0b0000_0000, 0b0010_0000, 0b0000_0100, 0b0000_0000, 0b1000_0000, 0b0001_0000, 0b0000_0010, 0b0000_0000, 0b0100_0000, 0b0000_1000, 0b0000_0001
+                , 0b1000_0000, 0b0011_0000, 0b0000_0110, 0b0000_0000, 0b1100_0000, 0b0001_1000, 0b0000_0011, 0b0000_0000, 0b0110_0000, 0b0000_1100, 0b0000_0001
+                ];
+            let mut reader = BitReaderBy11::new(BYTES);
+
+            let byte = reader.read();
+            assert_eq!(byte, 0b000_0000_0001);
+            let byte = reader.read();
+            assert_eq!(byte, 0b000_0000_0001);
+            let byte = reader.read();
+            assert_eq!(byte, 0b000_0000_0001);
+            let byte = reader.read();
+            assert_eq!(byte, 0b000_0000_0001);
+            let byte = reader.read();
+            assert_eq!(byte, 0b000_0000_0001);
+            let byte = reader.read();
+            assert_eq!(byte, 0b000_0000_0001);
+            let byte = reader.read();
+            assert_eq!(byte, 0b000_0000_0001);
+            let byte = reader.read();
+            assert_eq!(byte, 0b000_0000_0001);
+            let byte = reader.read();
+            assert_eq!(byte, 0b100_0000_0001);
+            let byte = reader.read();
+            assert_eq!(byte, 0b100_0000_0001);
+            let byte = reader.read();
+            assert_eq!(byte, 0b100_0000_0001);
+            let byte = reader.read();
+            assert_eq!(byte, 0b100_0000_0001);
+            let byte = reader.read();
+            assert_eq!(byte, 0b100_0000_0001);
+            let byte = reader.read();
+            assert_eq!(byte, 0b100_0000_0001);
+            let byte = reader.read();
+            assert_eq!(byte, 0b100_0000_0001);
+            let byte = reader.read();
+            assert_eq!(byte, 0b100_0000_0001);
+        }
+    }
+}


### PR DESCRIPTION
this PR makes the bip39 implementation slightly more reliable as it adds the original test vectors to retrieve both entropy and seed.

Also remove dependencies upon `bit_vec` and `bitreader` making `wallet-crypto` a bit smaller once compiled.