### PR TITLE
Real basic hermes refresher

### DIFF
--- a/exe-common/src/lib.rs
+++ b/exe-common/src/lib.rs
@@ -18,3 +18,4 @@ extern crate tokio_core;
 mod mstream;
 pub mod network;
 pub mod config;
+pub mod sync;

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -1,9 +1,10 @@
 use blockchain;
 use config::net;
 use network::{api, Peer, api::Api};
-use {storage, storage::{tag, Storage, types::PackHash}};
+use storage;
+use storage::types::PackHash;
 
-pub fn net_sync_faster(network: String, mut storage: Storage) {
+pub fn net_sync_faster(network: String, mut storage: storage::Storage) {
     let netcfg_file = storage.config.get_config_file();
     let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
     let mut net = get_http_peer(network, &net_cfg);
@@ -80,7 +81,7 @@ fn find_earliest_epoch(
 ) -> Option<(blockchain::EpochId, PackHash)> {
     let mut epoch_id = start_epochid;
     loop {
-        match tag::read_hash(storage, &tag::get_epoch_tag(epoch_id)) {
+        match storage::tag::read_hash(storage, &storage::tag::get_epoch_tag(epoch_id)) {
             None => match storage::epoch::epoch_read_pack(&storage.config, epoch_id).ok() {
                 None => {}
                 Some(h) => {

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -1,0 +1,122 @@
+use blockchain;
+use config::net;
+use network::{api, Peer, api::Api};
+use {storage, storage::{tag, Storage, types::PackHash}};
+
+pub fn net_sync_faster(network: String, mut storage: Storage) {
+    let netcfg_file = storage.config.get_config_file();
+    let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
+    let mut net = get_http_peer(network, &net_cfg);
+
+    //let mut our_tip = tag::read_hash(&storage, &"TIP".to_string()).unwrap_or(genesis.clone());
+
+    println!("Configured genesis   : {}", net_cfg.genesis);
+    println!("Configured genesis-1 : {}", net_cfg.genesis_prev);
+
+    // find the earliest epoch we know about starting from network_slotid
+    let (latest_known_epoch_id, mstart_hash, prev_hash) =
+        match find_earliest_epoch(&storage, net_cfg.epoch_start, 100) {
+            // TODO
+            None => (
+                net_cfg.epoch_start,
+                Some(net_cfg.genesis.clone()),
+                net_cfg.genesis_prev.clone(),
+            ),
+            Some((found_epoch_id, packhash)) => (
+                found_epoch_id + 1,
+                None,
+                get_last_blockid(&storage.config, &packhash).unwrap(),
+            ),
+        };
+    println!(
+        "latest known epoch {} hash={:?}",
+        latest_known_epoch_id, mstart_hash
+    );
+
+    let mut download_epoch_id = latest_known_epoch_id;
+    let mut download_prev_hash = prev_hash.clone();
+    let mut download_start_hash = mstart_hash.or(Some(prev_hash)).unwrap();
+
+    while download_epoch_id < 46 {
+        println!(
+            "downloading epoch {} {}",
+            download_epoch_id, download_start_hash
+        );
+        let fep = api::FetchEpochParams {
+            epoch_id: download_epoch_id,
+            start_header_hash: download_start_hash,
+            previous_header_hash: download_prev_hash,
+            upper_bound_hash: net_cfg.genesis_prev.clone(),
+        };
+        let result = net.fetch_epoch(&net_cfg, &mut storage, fep).unwrap();
+        download_prev_hash = result.last_header_hash.clone();
+        download_start_hash = result.next_epoch_hash.unwrap_or(result.last_header_hash);
+        download_epoch_id += 1;
+    }
+}
+
+pub fn get_http_peer(blockchain: String, cfg: &net::Config) -> Peer {
+    for peer in cfg.peers.iter() {
+        if peer.is_http() {
+            return Peer::new(
+                blockchain,
+                peer.name().to_owned(),
+                peer.peer().clone(),
+                cfg.protocol_magic,
+            ).unwrap();
+        }
+    }
+
+    panic!("no http peer to connect to")
+}
+
+// Return the chain of block headers starting at from's next block
+// and terminating at to, unless this range represent a number
+// of blocks greater than the limit imposed by the node we're talking to.
+fn find_earliest_epoch(
+    storage: &storage::Storage,
+    minimum_epochid: blockchain::EpochId,
+    start_epochid: blockchain::EpochId,
+) -> Option<(blockchain::EpochId, PackHash)> {
+    let mut epoch_id = start_epochid;
+    loop {
+        match tag::read_hash(storage, &tag::get_epoch_tag(epoch_id)) {
+            None => match storage::epoch::epoch_read_pack(&storage.config, epoch_id).ok() {
+                None => {}
+                Some(h) => {
+                    return Some((epoch_id, h));
+                }
+            },
+            Some(h) => {
+                println!("latest known epoch found is {}", epoch_id);
+                return Some((epoch_id, h.into_bytes()));
+            }
+        }
+
+        if epoch_id > minimum_epochid {
+            epoch_id -= 1
+        } else {
+            return None;
+        }
+    }
+}
+
+fn get_last_blockid(
+    storage_config: &storage::config::StorageConfig,
+    packref: &PackHash,
+) -> Option<blockchain::HeaderHash> {
+    let mut reader = storage::pack::PackReader::init(&storage_config, packref);
+    let mut last_blk_raw = None;
+
+    while let Some(blk_raw) = reader.get_next() {
+        last_blk_raw = Some(blk_raw);
+    }
+    if let Some(blk_raw) = last_blk_raw {
+        let blk = blk_raw.decode().unwrap();
+        let hdr = blk.get_header();
+        println!("last_blockid: {} {}", hdr.compute_hash(), hdr.get_slotid());
+        Some(hdr.compute_hash())
+    } else {
+        None
+    }
+}

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -4,6 +4,72 @@ use network::{api, Peer, api::Api};
 use storage;
 use storage::types::PackHash;
 
+pub fn net_sync_fast(network: String, mut storage: storage::Storage) {
+    let netcfg_file = storage.config.get_config_file();
+    let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
+    let mut net = get_native_peer(network, &net_cfg);
+
+    //let mut our_tip = tag::read_hash(&storage, &"TIP".to_string()).unwrap_or(genesis.clone());
+
+    // recover and print the TIP of the network
+    let mbh = net.get_tip().unwrap();
+    let network_tip = mbh.compute_hash();
+    let network_slotid = mbh.get_blockdate();
+
+    println!("Configured genesis   : {}", net_cfg.genesis);
+    println!("Configured genesis-1 : {}", net_cfg.genesis_prev);
+    println!("Network TIP is       : {}", network_tip);
+    println!("Network TIP slotid   : {}", network_slotid);
+
+    // start from our tip towards network tip
+    /*
+    if &network_tip == &our_tip {
+        println!("Qapla ! already synchronised");
+        return ();
+    }
+    */
+
+    // find the earliest epoch we know about starting from network_slotid
+    let (latest_known_epoch_id, mstart_hash, prev_hash) =
+        match find_earliest_epoch(&storage, net_cfg.epoch_start, network_slotid.get_epochid()) {
+            None => (
+                net_cfg.epoch_start,
+                Some(net_cfg.genesis.clone()),
+                net_cfg.genesis_prev.clone(),
+            ),
+            Some((found_epoch_id, packhash)) => (
+                found_epoch_id + 1,
+                None,
+                get_last_blockid(&storage.config, &packhash).unwrap(),
+            ),
+        };
+    println!(
+        "latest known epoch {} hash={:?}",
+        latest_known_epoch_id, mstart_hash
+    );
+
+    let mut download_epoch_id = latest_known_epoch_id;
+    let mut download_prev_hash = prev_hash.clone();
+    let mut download_start_hash = mstart_hash.or(Some(prev_hash)).unwrap();
+
+    while download_epoch_id < network_slotid.get_epochid() {
+        println!(
+            "downloading epoch {} {}",
+            download_epoch_id, download_start_hash
+        );
+        let fep = api::FetchEpochParams {
+            epoch_id: download_epoch_id,
+            start_header_hash: download_start_hash,
+            previous_header_hash: download_prev_hash,
+            upper_bound_hash: network_tip.clone(),
+        };
+        let result = net.fetch_epoch(&net_cfg, &mut storage, fep).unwrap();
+        download_prev_hash = result.last_header_hash.clone();
+        download_start_hash = result.next_epoch_hash.unwrap_or(result.last_header_hash);
+        download_epoch_id += 1;
+    }
+}
+
 pub fn net_sync_faster(network: String, mut storage: storage::Storage) {
     let netcfg_file = storage.config.get_config_file();
     let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
@@ -69,6 +135,21 @@ pub fn get_http_peer(blockchain: String, cfg: &net::Config) -> Peer {
     }
 
     panic!("no http peer to connect to")
+}
+
+pub fn get_native_peer(blockchain: String, cfg: &net::Config) -> Peer {
+    for peer in cfg.peers.iter() {
+        if peer.is_native() {
+            return Peer::new(
+                blockchain,
+                peer.name().to_owned(),
+                peer.peer().clone(),
+                cfg.protocol_magic,
+            ).unwrap();
+        }
+    }
+
+    panic!("no native peer to connect to")
 }
 
 // Return the chain of block headers starting at from's next block

--- a/hermes/src/config.rs
+++ b/hermes/src/config.rs
@@ -34,7 +34,7 @@ impl From<serde_yaml::Error> for Error {
 type Result<T> = result::Result<T, Error>;
 
 /// Configuration file for the Wallet CLI
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub root_dir: PathBuf,
     pub port: u16
@@ -71,7 +71,7 @@ impl Config {
         let dir = self.get_networks_dir();
         let mut networks = Networks::new();
 
-        for entry in fs::read_dir(dir.clone())? {
+        for entry in fs::read_dir(dir.clone()).expect("read the networks-dir") {
             let entry = entry?;
             if ! entry.file_type()?.is_dir() { continue; }
             let name = entry.file_name();

--- a/hermes/src/config.rs
+++ b/hermes/src/config.rs
@@ -60,7 +60,7 @@ impl Config {
         Self::from_file(p)
     }
 
-    pub fn save(&self) -> Result<()> {
+    pub fn save(&self) -> Result<PathBuf> {
         let p = hermes_path()?.join("config.yml");
         self.to_file(p)
     }
@@ -121,13 +121,13 @@ impl Config {
     /// write the config in the given file
     ///
     /// if the file already exists it will erase the original data.
-    pub fn to_file<P: AsRef<Path>>(&self, p: P) -> Result<()> {
+    pub fn to_file<P: AsRef<Path>>(&self, p: P) -> Result<P> {
         let dir = p.as_ref().parent().unwrap().to_path_buf();
         fs::DirBuilder::new().recursive(true).create(dir.clone())?;
         let mut file = TmpFile::create(dir)?;
         serde_yaml::to_writer(&mut file, &self)?;
         file.render_permanent(&p.as_ref().to_path_buf())?;
-        Ok(())
+        Ok(p)
     }
 }
 

--- a/hermes/src/handlers/block.rs
+++ b/hermes/src/handlers/block.rs
@@ -1,6 +1,5 @@
 use config::{Networks};
 use storage::{tag, block_location, block_read_location};
-use wallet_crypto::{cbor};
 use wallet_crypto::util::{hex};
 use blockchain;
 use std::sync::{Arc};
@@ -66,8 +65,6 @@ impl iron::Handler for Handler {
                         Ok(Response::with(status::InternalServerError))
                     },
                     Some(rblk) => {
-                        let blk = rblk.decode().unwrap();
-                        let hdr = blk.get_header();
                         Ok(Response::with((status::Ok, rblk.as_ref())))
                     }
                 }

--- a/hermes/src/handlers/common.rs
+++ b/hermes/src/handlers/common.rs
@@ -1,8 +1,5 @@
 
 use blockchain::EpochId;
-use std::sync::{Arc};
-use std::rc::{Rc};
-use config::{Networks, Network};
 
 pub fn validate_network_name(v: &&str) -> bool {
     v.chars().all(|c| c.is_ascii_alphanumeric())

--- a/hermes/src/main.rs
+++ b/hermes/src/main.rs
@@ -76,7 +76,10 @@ fn main() {
                     err => Err(err),
                 })
                 .unwrap();
-            info!("saving config, {:?}", cfg.save());
+            let loc = cfg.save().expect("save hermes config");
+            info!("Saved config to {:?}", loc);
+            ::std::fs::create_dir_all(cfg.root_dir.clone()).expect("create networks directory");
+            info!("Created networks directory {:?}", cfg.root_dir);
         },
         ("start", _) => {
             info!("Starting {}-{}", crate_name!(), crate_version!());

--- a/hermes/src/main.rs
+++ b/hermes/src/main.rs
@@ -69,7 +69,7 @@ fn main() {
             let dir  = value_t!(args.value_of("NETWORKS DIRECTORY"), String).unwrap();
             cfg.port = port;
             cfg.root_dir = PathBuf::from(&dir);
-            cfg.save().unwrap();
+            info!("saving config, result {:?}", cfg.save());
         },
         ("start", _) => {
             info!("Starting {}-{}", crate_name!(), crate_version!());

--- a/hermes/src/main.rs
+++ b/hermes/src/main.rs
@@ -15,14 +15,14 @@ extern crate wallet_crypto;
 extern crate blockchain;
 extern crate exe_common;
 
-use std::{sync::{Arc}, path::{PathBuf}};
+use std::path::{PathBuf};
 
-use iron::Iron;
 
 mod config;
 mod handlers;
+mod service;
 
-use config::{Config};
+use config::Config;
 
 fn main() {
     use clap::{App, Arg, SubCommand};
@@ -80,13 +80,7 @@ fn main() {
         },
         ("start", _) => {
             info!("Starting {}-{}", crate_name!(), crate_version!());
-            let mut router = router::Router::new();
-            let networks = Arc::new(cfg.get_networks().unwrap());
-            handlers::block::Handler::new(networks.clone()).route(&mut router);
-            handlers::pack::Handler::new(networks.clone()).route(&mut router);
-            handlers::epoch::Handler::new(networks.clone()).route(&mut router);
-            info!("listenting to port {}", cfg.port);
-            Iron::new(router).http(format!("0.0.0.0:{}", cfg.port)).unwrap();
+            service::start(cfg);
         },
         _ => {
             println!("{}", matches.usage());

--- a/hermes/src/service.rs
+++ b/hermes/src/service.rs
@@ -1,0 +1,17 @@
+use std::sync::Arc;
+use iron::Iron;
+use handlers;
+use router::Router;
+use config::Config;
+
+pub fn start(cfg: Config) {
+    let mut router = Router::new();
+    let networks = Arc::new(cfg.get_networks().unwrap());
+    handlers::block::Handler::new(networks.clone()).route(&mut router);
+    handlers::pack::Handler::new(networks.clone()).route(&mut router);
+    handlers::epoch::Handler::new(networks.clone()).route(&mut router);
+    info!("listenting to port {}", cfg.port);
+    Iron::new(router)
+        .http(format!("0.0.0.0:{}", cfg.port))
+        .unwrap();
+}

--- a/hermes/src/service.rs
+++ b/hermes/src/service.rs
@@ -4,11 +4,17 @@ use handlers;
 use iron;
 use router::Router;
 use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+static NETWORK_REFRESH_FREQUENCY: Duration = Duration::from_secs(60 * 10);
 
 pub fn start(cfg: Config) {
-    let networks = Arc::new(cfg.get_networks().unwrap());
-    // start background thread to refresh sync blocks
-    start_http_server(cfg, networks);
+    let _refresher = start_networks_refresher(cfg.clone());
+    let _server = start_http_server(&cfg, Arc::new(cfg.get_networks().unwrap()));
+
+    // XXX: consider installing a signal handler to initiate a graceful shutdown here
+    // XXX: after initiating shutdown, do `refresher.join()` and something similar for `server`.
 }
 
 fn start_http_server(cfg: &Config, networks: Arc<Networks>) -> iron::Listening {
@@ -21,4 +27,35 @@ fn start_http_server(cfg: &Config, networks: Arc<Networks>) -> iron::Listening {
         .http(format!("0.0.0.0:{}", cfg.port))
         .expect("start http server")
 }
+
+// TODO: make this a struct which receives a shutdown message on a channel and then wraps itself up
+fn start_networks_refresher(cfg: Config) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
+        info!("Refreshing every {:?}", NETWORK_REFRESH_FREQUENCY);
+        loop {
+            match cfg.get_networks() {
+                Err(err) => warn!("Refresh failed: {:?}", err),
+                Ok(networks) => {
+                    refresh_networks(networks);
+                    info!("Refresh completed")
+                }
+            }
+            thread::sleep(NETWORK_REFRESH_FREQUENCY);
+        }
+    })
+}
+
+// XXX: how do we want to report partial failures?
+fn refresh_networks(networks: Networks) {
+    for (label, net) in networks.into_iter() {
+        info!("Refreshing network {:?}", label);
+        match Arc::try_unwrap(net.storage) {
+            // Cannot just use `.unwrap()` because that requires a debug instance
+            Err(_) => warn!(
+                "Refresh for network {} failed: Unable to access storage",
+                label
+            ),
+            Ok(storage) => sync::net_sync_fast(label, storage),
+        }
+    }
 }

--- a/hermes/src/service.rs
+++ b/hermes/src/service.rs
@@ -1,4 +1,5 @@
 use config::{Config, Networks};
+use exe_common::sync;
 use handlers;
 use iron::Iron;
 use router::Router;

--- a/hermes/src/service.rs
+++ b/hermes/src/service.rs
@@ -1,12 +1,17 @@
-use std::sync::Arc;
-use iron::Iron;
+use config::{Config, Networks};
 use handlers;
+use iron::Iron;
 use router::Router;
-use config::Config;
+use std::sync::Arc;
 
 pub fn start(cfg: Config) {
-    let mut router = Router::new();
     let networks = Arc::new(cfg.get_networks().unwrap());
+    // start background thread to refresh sync blocks
+    start_http_server(cfg, networks);
+}
+
+fn start_http_server(cfg: Config, networks: Arc<Networks>) {
+    let mut router = Router::new();
     handlers::block::Handler::new(networks.clone()).route(&mut router);
     handlers::pack::Handler::new(networks.clone()).route(&mut router);
     handlers::epoch::Handler::new(networks.clone()).route(&mut router);

--- a/hermes/src/service.rs
+++ b/hermes/src/service.rs
@@ -1,7 +1,7 @@
 use config::{Config, Networks};
 use exe_common::sync;
 use handlers;
-use iron::Iron;
+use iron;
 use router::Router;
 use std::sync::Arc;
 
@@ -11,13 +11,14 @@ pub fn start(cfg: Config) {
     start_http_server(cfg, networks);
 }
 
-fn start_http_server(cfg: Config, networks: Arc<Networks>) {
+fn start_http_server(cfg: &Config, networks: Arc<Networks>) -> iron::Listening {
     let mut router = Router::new();
     handlers::block::Handler::new(networks.clone()).route(&mut router);
     handlers::pack::Handler::new(networks.clone()).route(&mut router);
     handlers::epoch::Handler::new(networks.clone()).route(&mut router);
     info!("listenting to port {}", cfg.port);
-    Iron::new(router)
+    iron::Iron::new(router)
         .http(format!("0.0.0.0:{}", cfg.port))
-        .unwrap();
+        .expect("start http server")
+}
 }

--- a/wallet-cli/src/command/blockchain/mod.rs
+++ b/wallet-cli/src/command/blockchain/mod.rs
@@ -10,7 +10,7 @@ use blockchain;
 use config::{Config};
 use std::io::{Write, stdout};
 
-use exe_common::{config::{net}, network::{api::{*}}};
+use exe_common::{config::{net}, network::{api::{*}}, sync};
 
 use command::pretty::Pretty;
 
@@ -18,123 +18,6 @@ mod util;
 mod find_address;
 
 use self::util::{*, range::RangeOption};
-
-// Return the chain of block headers starting at from's next block
-// and terminating at to, unless this range represent a number
-// of blocks greater than the limit imposed by the node we're talking to.
-fn find_earliest_epoch(storage: &storage::Storage, minimum_epochid: blockchain::EpochId, start_epochid: blockchain::EpochId)
-        -> Option<(blockchain::EpochId, PackHash)> {
-    let mut epoch_id = start_epochid;
-    loop {
-        match tag::read_hash(storage, &tag::get_epoch_tag(epoch_id)) {
-            None => {
-                match storage::epoch::epoch_read_pack(&storage.config, epoch_id).ok() {
-                    None => {}
-                    Some(h) => {
-                        return Some((epoch_id, h));
-                    }
-                }
-            },
-            Some(h) => {
-                println!("latest known epoch found is {}", epoch_id);
-                return Some((epoch_id, h.into_bytes()))
-            },
-        }
-
-        if epoch_id > minimum_epochid {
-            epoch_id -= 1
-        } else {
-            return None
-        }
-    }
-}
-
-fn net_sync_fast(network: String, mut storage: Storage) {
-    let netcfg_file = storage.config.get_config_file();
-    let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
-    let mut net = get_native_peer(network, &net_cfg);
-
-    //let mut our_tip = tag::read_hash(&storage, &"TIP".to_string()).unwrap_or(genesis.clone());
-
-    // recover and print the TIP of the network
-    let mbh = net.get_tip().unwrap();
-    let network_tip = mbh.compute_hash();
-    let network_slotid = mbh.get_blockdate();
-
-    println!("Configured genesis   : {}", net_cfg.genesis);
-    println!("Configured genesis-1 : {}", net_cfg.genesis_prev);
-    println!("Network TIP is       : {}", network_tip);
-    println!("Network TIP slotid   : {}", network_slotid);
-
-    // start from our tip towards network tip
-    /*
-    if &network_tip == &our_tip {
-        println!("Qapla ! already synchronised");
-        return ();
-    }
-    */
-
-    // find the earliest epoch we know about starting from network_slotid
-    let (latest_known_epoch_id, mstart_hash, prev_hash) = match find_earliest_epoch(&storage, net_cfg.epoch_start, network_slotid.get_epochid()) {
-        None => { (net_cfg.epoch_start, Some(net_cfg.genesis.clone()), net_cfg.genesis_prev.clone()) },
-        Some((found_epoch_id, packhash)) => { (found_epoch_id + 1, None, get_last_blockid(&storage.config, &packhash).unwrap()) }
-    };
-    println!("latest known epoch {} hash={:?}", latest_known_epoch_id, mstart_hash);
-
-    let mut download_epoch_id = latest_known_epoch_id;
-    let mut download_prev_hash = prev_hash.clone();
-    let mut download_start_hash = mstart_hash.or(Some(prev_hash)).unwrap();
-
-    while download_epoch_id < network_slotid.get_epochid() {
-        println!("downloading epoch {} {}", download_epoch_id, download_start_hash);
-        let fep = FetchEpochParams {
-            epoch_id: download_epoch_id,
-            start_header_hash: download_start_hash,
-            previous_header_hash: download_prev_hash,
-            upper_bound_hash: network_tip.clone()
-        };
-        let result = net.fetch_epoch(&net_cfg, &mut storage, fep).unwrap();
-        download_prev_hash = result.last_header_hash.clone();
-        download_start_hash = result.next_epoch_hash.unwrap_or(result.last_header_hash);
-        download_epoch_id += 1;
-    }
-}
-
-fn net_sync_faster(network: String, mut storage: Storage) {
-    let netcfg_file = storage.config.get_config_file();
-    let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
-    let mut net = get_http_peer(network, &net_cfg);
-
-    //let mut our_tip = tag::read_hash(&storage, &"TIP".to_string()).unwrap_or(genesis.clone());
-
-    println!("Configured genesis   : {}", net_cfg.genesis);
-    println!("Configured genesis-1 : {}", net_cfg.genesis_prev);
-
-    // find the earliest epoch we know about starting from network_slotid
-    let (latest_known_epoch_id, mstart_hash, prev_hash) = match find_earliest_epoch(&storage, net_cfg.epoch_start, 100) { // TODO
-        None => { (net_cfg.epoch_start, Some(net_cfg.genesis.clone()), net_cfg.genesis_prev.clone()) },
-        Some((found_epoch_id, packhash)) => { (found_epoch_id + 1, None, get_last_blockid(&storage.config, &packhash).unwrap()) }
-    };
-    println!("latest known epoch {} hash={:?}", latest_known_epoch_id, mstart_hash);
-
-    let mut download_epoch_id = latest_known_epoch_id;
-    let mut download_prev_hash = prev_hash.clone();
-    let mut download_start_hash = mstart_hash.or(Some(prev_hash)).unwrap();
-
-    while download_epoch_id < 46 {
-        println!("downloading epoch {} {}", download_epoch_id, download_start_hash);
-        let fep = FetchEpochParams {
-            epoch_id: download_epoch_id,
-            start_header_hash: download_start_hash,
-            previous_header_hash: download_prev_hash,
-            upper_bound_hash: net_cfg.genesis_prev.clone()
-        };
-        let result = net.fetch_epoch(&net_cfg, &mut storage, fep).unwrap();
-        download_prev_hash = result.last_header_hash.clone();
-        download_start_hash = result.next_epoch_hash.unwrap_or(result.last_header_hash);
-        download_epoch_id += 1;
-    }
-}
 
 pub struct Blockchain;
 
@@ -271,7 +154,7 @@ impl HasCommand for Blockchain {
             },
             ("sync", Some(opts)) => {
                 let config = resolv_network_by_name(&opts);
-                net_sync_faster(config.network.clone(), config.get_storage().unwrap())
+                sync::net_sync_faster(config.network.clone(), config.get_storage().unwrap())
             },
             ("debug-index", Some(opts)) => {
                 let config = resolv_network_by_name(&opts);
@@ -446,24 +329,6 @@ impl HasCommand for Blockchain {
                 ::std::process::exit(1);
             },
         }
-    }
-}
-
-
-fn get_last_blockid(storage_config: &storage::config::StorageConfig, packref: &PackHash) -> Option<blockchain::HeaderHash> {
-    let mut reader = storage::pack::PackReader::init(&storage_config, packref);
-    let mut last_blk_raw = None;
-
-    while let Some(blk_raw) = reader.get_next() {
-        last_blk_raw = Some(blk_raw);
-    }
-    if let Some(blk_raw) = last_blk_raw {
-        let blk = blk_raw.decode().unwrap();
-        let hdr = blk.get_header();
-        println!("last_blockid: {} {}", hdr.compute_hash(), hdr.get_slotid());
-        Some(hdr.compute_hash())
-    } else {
-        None
     }
 }
 

--- a/wallet-cli/src/command/blockchain/mod.rs
+++ b/wallet-cli/src/command/blockchain/mod.rs
@@ -136,7 +136,7 @@ impl HasCommand for Blockchain {
                 let config = resolv_network_by_name(&opts);
                 let netcfg_file = config.get_storage_config().get_config_file();
                 let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
-                let mut net = get_native_peer(config.network, &net_cfg);
+                let mut net = sync::get_native_peer(config.network, &net_cfg);
                 let mbh = net.get_tip().unwrap();
                 println!("prv block header: {}", mbh.get_previous_header());
             },
@@ -147,7 +147,7 @@ impl HasCommand for Blockchain {
                 let hh = blockchain::HeaderHash::from_slice(&hh_bytes).expect("blockid invalid");
                 let netcfg_file = config.get_storage_config().get_config_file();
                 let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
-                let mut net = get_native_peer(config.network.clone(), &net_cfg);
+                let mut net = sync::get_native_peer(config.network.clone(), &net_cfg);
                 let b = net.get_block(hh.clone()).unwrap();
                 let storage = config.get_storage().unwrap();
                 blob::write(&storage, hh.bytes(), &cbor::encode_to_cbor(&b).unwrap()).unwrap();

--- a/wallet-cli/src/command/blockchain/util.rs
+++ b/wallet-cli/src/command/blockchain/util.rs
@@ -60,13 +60,3 @@ pub fn get_native_peer(blockchain: String, cfg: &net::Config) -> Peer {
 
     panic!("no native peer to connect to")
 }
-
-pub fn get_http_peer(blockchain: String, cfg: &net::Config) -> Peer {
-    for peer in cfg.peers.iter() {
-        if peer.is_http() {
-            return Peer::new(blockchain, peer.name().to_owned(), peer.peer().clone(), cfg.protocol_magic).unwrap()
-        }
-    }
-
-    panic!("no http peer to connect to")
-}

--- a/wallet-cli/src/command/blockchain/util.rs
+++ b/wallet-cli/src/command/blockchain/util.rs
@@ -1,4 +1,3 @@
-use exe_common::{config::{net}, network::{Peer}};
 use clap::{ArgMatches, Arg};
 
 pub mod range {
@@ -49,14 +48,4 @@ pub fn resolv_network_by_name<'a>(opts: &ArgMatches<'a>) -> Config {
     let mut config = Config::default();
     config.network = name;
     config
-}
-
-pub fn get_native_peer(blockchain: String, cfg: &net::Config) -> Peer {
-    for peer in cfg.peers.iter() {
-        if peer.is_native() {
-            return Peer::new(blockchain, peer.name().to_owned(), peer.peer().clone(), cfg.protocol_magic).unwrap()
-        }
-    }
-
-    panic!("no native peer to connect to")
 }


### PR DESCRIPTION
In this pr:
- :heavy_check_mark: moving code around so that hermes can use the `net_sync_fast{er}` functions  (#134 included many of the same commits)
- :heavy_check_mark: background thread calls `net_sync_fast` every 10 mins for whatever networks are currently in hermes' configured networks-dir

Not in this pr:
- :x: communication between network-refresher thread & the server thread about packs on disks
- :x: partial downloading and serving of blobs for incomplete epochs
- :x: signal handling & graceful shutdown
- :x: monitoring