### PR TITLE
make Hermes serves EPOCH tip

### DIFF
--- a/exe-common/src/lib.rs
+++ b/exe-common/src/lib.rs
@@ -16,6 +16,7 @@ extern crate hyper;
 extern crate tokio_core;
 
 mod mstream;
+pub mod utils;
 pub mod network;
 pub mod config;
 pub mod sync;

--- a/exe-common/src/network/hermes.rs
+++ b/exe-common/src/network/hermes.rs
@@ -32,7 +32,25 @@ impl HermesEndPoint {
 
 impl Api for HermesEndPoint {
     fn get_tip(&mut self) -> Result<BlockHeader> {
-        unimplemented!()
+        let uri = self.uri("tip").as_str().parse().unwrap();
+        info!("querying uri: {}", uri);
+
+        let mut bh_bytes = Vec::with_capacity(4096);
+        {
+            let client = Client::new(&self.core.handle());
+            let work = client.get(uri).and_then(|res| {
+                res.body().for_each(|chunk| {
+                    bh_bytes.write_all(&chunk).map_err(From::from)
+                })
+            });
+            let now = SystemTime::now();
+            self.core.run(work)?;
+            let time_elapsed = now.elapsed().unwrap();
+            info!("Downloaded TIP in {}sec", time_elapsed.as_secs());
+        }
+
+        let bh_raw = block::RawBlockHeader::from_dat(bh_bytes);
+        Ok(bh_raw.decode()?)
     }
 
     fn get_block(&mut self, _hash: HeaderHash) -> Result<Block> {

--- a/exe-common/src/network/hermes.rs
+++ b/exe-common/src/network/hermes.rs
@@ -1,4 +1,4 @@
-use cardano::block::{BlockHeader, Block, HeaderHash};
+use cardano::block::{block, BlockHeader, Block, HeaderHash};
 use storage::{self, Storage, tmpfile::{TmpFile}};
 use std::io::{Write, Seek, SeekFrom};
 use std::time::{SystemTime};

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -16,15 +16,15 @@ pub fn net_sync_fast(network: String, mut storage: storage::Storage) {
     let network_tip = mbh.compute_hash();
     let network_slotid = mbh.get_blockdate();
 
-    println!("Configured genesis   : {}", net_cfg.genesis);
-    println!("Configured genesis-1 : {}", net_cfg.genesis_prev);
-    println!("Network TIP is       : {}", network_tip);
-    println!("Network TIP slotid   : {}", network_slotid);
+    info!("Configured genesis   : {}", net_cfg.genesis);
+    info!("Configured genesis-1 : {}", net_cfg.genesis_prev);
+    info!("Network TIP is       : {}", network_tip);
+    info!("Network TIP slotid   : {}", network_slotid);
 
     // start from our tip towards network tip
     /*
     if &network_tip == &our_tip {
-        println!("Qapla ! already synchronised");
+        info!("Qapla ! already synchronised");
         return ();
     }
     */
@@ -43,7 +43,7 @@ pub fn net_sync_fast(network: String, mut storage: storage::Storage) {
                 get_last_blockid(&storage.config, &packhash).unwrap(),
             ),
         };
-    println!(
+    info!(
         "latest known epoch {} hash={:?}",
         latest_known_epoch_id, mstart_hash
     );
@@ -53,7 +53,7 @@ pub fn net_sync_fast(network: String, mut storage: storage::Storage) {
     let mut download_start_hash = mstart_hash.or(Some(prev_hash)).unwrap();
 
     while download_epoch_id < network_slotid.get_epochid() {
-        println!(
+        info!(
             "downloading epoch {} {}",
             download_epoch_id, download_start_hash
         );
@@ -77,8 +77,8 @@ pub fn net_sync_faster(network: String, mut storage: storage::Storage) {
 
     //let mut our_tip = tag::read_hash(&storage, &"TIP".to_string()).unwrap_or(genesis.clone());
 
-    println!("Configured genesis   : {}", net_cfg.genesis);
-    println!("Configured genesis-1 : {}", net_cfg.genesis_prev);
+    info!("Configured genesis   : {}", net_cfg.genesis);
+    info!("Configured genesis-1 : {}", net_cfg.genesis_prev);
 
     // find the earliest epoch we know about starting from network_slotid
     let (latest_known_epoch_id, mstart_hash, prev_hash) =
@@ -95,7 +95,7 @@ pub fn net_sync_faster(network: String, mut storage: storage::Storage) {
                 get_last_blockid(&storage.config, &packhash).unwrap(),
             ),
         };
-    println!(
+    info!(
         "latest known epoch {} hash={:?}",
         latest_known_epoch_id, mstart_hash
     );
@@ -105,7 +105,7 @@ pub fn net_sync_faster(network: String, mut storage: storage::Storage) {
     let mut download_start_hash = mstart_hash.or(Some(prev_hash)).unwrap();
 
     while download_epoch_id < 46 {
-        println!(
+        info!(
             "downloading epoch {} {}",
             download_epoch_id, download_start_hash
         );

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -77,6 +77,10 @@ pub fn net_sync_faster(network: String, mut storage: storage::Storage) {
 
     //let mut our_tip = tag::read_hash(&storage, &"TIP".to_string()).unwrap_or(genesis.clone());
 
+    // recover TIP of the network
+    let mbh = net.get_tip().unwrap();
+    let network_slotid = mbh.get_blockdate();
+
     info!("Configured genesis   : {}", net_cfg.genesis);
     info!("Configured genesis-1 : {}", net_cfg.genesis_prev);
 
@@ -104,7 +108,7 @@ pub fn net_sync_faster(network: String, mut storage: storage::Storage) {
     let mut download_prev_hash = prev_hash.clone();
     let mut download_start_hash = mstart_hash.or(Some(prev_hash)).unwrap();
 
-    while download_epoch_id < 46 {
+    while block::BlockDate::Genesis(download_epoch_id) <= network_slotid {
         info!(
             "downloading epoch {} {}",
             download_epoch_id, download_start_hash

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -2,7 +2,7 @@ use cardano::block;
 use config::net;
 use network::{api, Peer, api::Api};
 use storage;
-use storage::types::PackHash;
+use utils::*;
 
 pub fn net_sync_fast(network: String, mut storage: storage::Storage) {
     let netcfg_file = storage.config.get_config_file();
@@ -150,55 +150,4 @@ pub fn get_native_peer(blockchain: String, cfg: &net::Config) -> Peer {
     }
 
     panic!("no native peer to connect to")
-}
-
-// Return the chain of block headers starting at from's next block
-// and terminating at to, unless this range represent a number
-// of blocks greater than the limit imposed by the node we're talking to.
-fn find_earliest_epoch(
-    storage: &storage::Storage,
-    minimum_epochid: block::EpochId,
-    start_epochid: block::EpochId,
-) -> Option<(block::EpochId, PackHash)> {
-    let mut epoch_id = start_epochid;
-    loop {
-        match storage::tag::read_hash(storage, &storage::tag::get_epoch_tag(epoch_id)) {
-            None => match storage::epoch::epoch_read_pack(&storage.config, epoch_id).ok() {
-                None => {}
-                Some(h) => {
-                    return Some((epoch_id, h));
-                }
-            },
-            Some(h) => {
-                println!("latest known epoch found is {}", epoch_id);
-                return Some((epoch_id, h.into_bytes()));
-            }
-        }
-
-        if epoch_id > minimum_epochid {
-            epoch_id -= 1
-        } else {
-            return None;
-        }
-    }
-}
-
-fn get_last_blockid(
-    storage_config: &storage::config::StorageConfig,
-    packref: &PackHash,
-) -> Option<block::HeaderHash> {
-    let mut reader = storage::pack::PackReader::init(&storage_config, packref);
-    let mut last_blk_raw = None;
-
-    while let Some(blk_raw) = reader.get_next() {
-        last_blk_raw = Some(blk_raw);
-    }
-    if let Some(blk_raw) = last_blk_raw {
-        let blk = blk_raw.decode().unwrap();
-        let hdr = blk.get_header();
-        println!("last_blockid: {} {}", hdr.compute_hash(), hdr.get_slotid());
-        Some(hdr.compute_hash())
-    } else {
-        None
-    }
 }

--- a/exe-common/src/utils.rs
+++ b/exe-common/src/utils.rs
@@ -1,0 +1,54 @@
+use cardano::block;
+use storage;
+use storage::types::PackHash;
+
+// Return the chain of block headers starting at from's next block
+// and terminating at to, unless this range represent a number
+// of blocks greater than the limit imposed by the node we're talking to.
+pub fn find_earliest_epoch(
+    storage: &storage::Storage,
+    minimum_epochid: block::EpochId,
+    start_epochid: block::EpochId,
+) -> Option<(block::EpochId, PackHash)> {
+    let mut epoch_id = start_epochid;
+    loop {
+        match storage::tag::read_hash(storage, &storage::tag::get_epoch_tag(epoch_id)) {
+            None => match storage::epoch::epoch_read_pack(&storage.config, epoch_id).ok() {
+                None => {}
+                Some(h) => {
+                    return Some((epoch_id, h));
+                }
+            },
+            Some(h) => {
+                info!("latest known epoch found is {}", epoch_id);
+                return Some((epoch_id, h.into_bytes()));
+            }
+        }
+
+        if epoch_id > minimum_epochid {
+            epoch_id -= 1
+        } else {
+            return None;
+        }
+    }
+}
+
+pub fn get_last_blockid(
+    storage_config: &storage::config::StorageConfig,
+    packref: &PackHash,
+) -> Option<block::HeaderHash> {
+    let mut reader = storage::pack::PackReader::init(&storage_config, packref);
+    let mut last_blk_raw = None;
+
+    while let Some(blk_raw) = reader.get_next() {
+        last_blk_raw = Some(blk_raw);
+    }
+    if let Some(blk_raw) = last_blk_raw {
+        let blk = blk_raw.decode().unwrap();
+        let hdr = blk.get_header();
+        info!("last_blockid: {} {}", hdr.compute_hash(), hdr.get_slotid());
+        Some(hdr.compute_hash())
+    } else {
+        None
+    }
+}

--- a/hermes/src/handlers/mod.rs
+++ b/hermes/src/handlers/mod.rs
@@ -2,3 +2,4 @@ pub mod common;
 pub mod block;
 pub mod pack;
 pub mod epoch;
+pub mod tip;

--- a/hermes/src/handlers/tip.rs
+++ b/hermes/src/handlers/tip.rs
@@ -1,0 +1,74 @@
+use config::{Networks};
+use storage::{block_location, block_read_location};
+use std::sync::{Arc};
+
+use iron;
+use iron::{Request, Response, IronResult};
+use iron::status;
+
+use router;
+use router::{Router};
+
+use handlers::common;
+use exe_common::utils::*;
+
+pub struct Handler {
+    networks: Arc<Networks>
+}
+impl Handler {
+    pub fn new(networks: Arc<Networks>) -> Self {
+        Handler {
+            networks: networks
+        }
+    }
+    pub fn route(self, router: &mut Router) -> &mut Router {
+        router.get(":network/tip", self, "block")
+    }
+}
+
+impl iron::Handler for Handler {
+    // XXX
+    //
+    // The current implementation of the TIP handler is to look for the latest epoch
+    // and to extract its latest block
+    fn handle(&self, req: &mut Request) -> IronResult<Response> {
+        let ref network_name = req.extensions.get::<router::Router>().unwrap().find("network").unwrap();
+
+        if ! common::validate_network_name (network_name) {
+            return Ok(Response::with(status::BadRequest));
+        }
+
+        let net = match self.networks.get(network_name.to_owned()) {
+            None => return Ok(Response::with(status::BadRequest)),
+            Some(net) => net
+        };
+        let net_cfg = &net.config;
+
+        let hh =
+            match find_earliest_epoch(&net.storage, net_cfg.epoch_start, 100) {
+                None => return Ok(Response::with((status::NotFound, "No Tip To Serve"))),
+                Some((_, packhash)) =>
+                    get_last_blockid(&net.storage.config, &packhash).unwrap(),
+            };
+
+        match block_location(&net.storage, hh.bytes()) {
+            None => {
+                warn!("block `{}' does not exist", hh);
+                Ok(Response::with((status::NotFound, "Not Found")))
+            },
+            Some(loc) => {
+                debug!("blk location: {:?}", loc);
+                match block_read_location(&net.storage, &loc, hh.bytes()) {
+                    None        => {
+                        error!("error while reading block at location: {:?}", loc);
+                        Ok(Response::with(status::InternalServerError))
+                    },
+                    Some(rblk) => {
+                        Ok(Response::with((status::Ok, rblk.to_header().as_ref())))
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/hermes/src/service.rs
+++ b/hermes/src/service.rs
@@ -22,6 +22,7 @@ fn start_http_server(cfg: &Config, networks: Arc<Networks>) -> iron::Listening {
     handlers::block::Handler::new(networks.clone()).route(&mut router);
     handlers::pack::Handler::new(networks.clone()).route(&mut router);
     handlers::epoch::Handler::new(networks.clone()).route(&mut router);
+    handlers::tip::Handler::new(networks.clone()).route(&mut router);
     info!("listenting to port {}", cfg.port);
     iron::Iron::new(router)
         .http(format!("0.0.0.0:{}", cfg.port))


### PR DESCRIPTION
Provide a simple implementation for Hermes' TIP. This allows us to remove the hardcoded epoch upper bound from the `faster_sync` function.

The implementation only use EPOCH though, the next step will be to fix this by providing:

- implement hermes' network sync;
- make hermes keep track of the TIP;
- make the `faster_sync` function fallback to block download when EPOCH download fails with not found (and still missing blocks).

see #80 and #82 for the missing tasks