### PR TITLE
C-bindings and address generator iterator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "storage",
     "hermes",
     "cbor_event",
+    "cardano-c",
 ]
 [dependencies]
 printer = { path = "rust-crypto-wasm" }

--- a/cardano-c/Cargo.toml
+++ b/cardano-c/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cardano-c"
+version = "0.1.0"
+authors = ["Nicolas Di Prima <nicolas.diprima@iohk.io>"]
+
+[dependencies]
+cardano = { path = "../cardano" }

--- a/cardano-c/Cargo.toml
+++ b/cardano-c/Cargo.toml
@@ -3,5 +3,8 @@ name = "cardano-c"
 version = "0.1.0"
 authors = ["Nicolas Di Prima <nicolas.diprima@iohk.io>"]
 
+[lib]
+crate-type = ["staticlib", "dylib"]
+
 [dependencies]
 cardano = { path = "../cardano" }

--- a/cardano-c/Cargo.toml
+++ b/cardano-c/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Nicolas Di Prima <nicolas.diprima@iohk.io>"]
 
 [lib]
-crate-type = ["staticlib", "dylib"]
+crate-type = ["staticlib" ]
 
 [dependencies]
 cardano = { path = "../cardano" }

--- a/cardano-c/README.md
+++ b/cardano-c/README.md
@@ -2,3 +2,50 @@
 
 exports simple API to use in C library or to write bindings in
 other languages.
+
+# Cross compiling for different targets
+
+To ease the process of cross-compiling to different plate-forms
+and architectures we provide a build script,
+
+```bash
+./build.sh <TARGETS>
+```
+
+To see the list of supported platforms, see `rustup target list`.
+Theoretically, all the targets are supported.
+
+# find linker for your targets
+
+rust does not provide the linker for the targets, it is you to
+provide it. For example, to cross compile for a given _`<target>`_:
+
+
+- in `.cargo/config
+  ```toml
+  [target.<target>]
+  linker = "/path/to/linker/for/<target>"
+  ```
+- then run build script:
+  ```bash
+  ./build.sh <target>
+  ```
+
+After successful completion of the script, you will find a directory `dist` at the root of this
+crate with directories containing the differently built targets. In our example, something like:
+
+```bash
+$ tree dist/
+dist/
+└── cardano-c
+    └── <target>
+        ├── debug
+        │   ├── libcardano_c.a
+        │   └── libcardano_c.d
+        └── release
+            ├── libcardano_c.a
+            └── libcardano_c.d
+```
+
+The `*.d` files are kept in case you want to integrate these in your build
+and track changes to the rust library as well.

--- a/cardano-c/README.md
+++ b/cardano-c/README.md
@@ -1,0 +1,4 @@
+# C binding for the cardano library
+
+exports simple API to use in C library or to write bindings in
+other languages.

--- a/cardano-c/build.sh
+++ b/cardano-c/build.sh
@@ -1,0 +1,55 @@
+#! /bin/bash
+
+set -e
+
+# see `rustup target list` for the list of supported targets
+TARGETS="${*}"
+
+RUSTUP=$(which rustup)
+CARGO="$(which cargo) --quiet"
+MKDIR=$(which mkdir)
+CP=$(which cp)
+
+install_lib() {
+    TARGET=${1}
+    BUILD=${2}
+
+    SOURCE_PATH=../target/${TARGET}/${BUILD}
+    TARGET_PATH=./dist/cardano-c/${TARGET}/${BUILD}
+
+    ${MKDIR} -p ${TARGET_PATH}
+
+    echo " * installing to \`${TARGET_PATH}'"
+    ${CP} ${SOURCE_PATH}/*.a ${TARGET_PATH}
+    ${CP} ${SOURCE_PATH}/*.d ${TARGET_PATH}
+}
+
+rustup_target_add() {
+    TARGET=${1}
+
+    set +e
+    ${RUSTUP} target list | grep ${TARGET} | grep --quiet "installed"
+    set -e
+    if [ ${?} -ne 0 ]; then
+        echo " * installing toolchain's target: \`${TARGET}'"
+        ${RUSTUP} target add ${TARGET}
+    else
+        echo " * toolchain's target \`${TARGET}' already installed"
+    fi
+
+}
+
+for TARGET in ${TARGETS}; do
+    echo "## compile library for target: \`${TARGET}'"
+    echo ""
+
+    rustup_target_add ${TARGET}
+    echo " * compiling with debug symbols"
+    ${CARGO} build           --target=${TARGET} --quiet
+    echo " * compiling for release"
+    ${CARGO} build --release --target=${TARGET} --quiet
+
+    install_lib ${TARGET} "debug"
+    install_lib ${TARGET} "release"
+    echo ""
+done

--- a/cardano-c/src/lib.rs
+++ b/cardano-c/src/lib.rs
@@ -1,0 +1,144 @@
+extern crate cardano;
+use cardano::wallet::scheme::{Wallet};
+
+use std::os::raw::{c_char};
+use std::{ffi, slice, ptr};
+
+/* ******************************************************************************* *
+ *                                  Wallet object                                  *
+ * ******************************************************************************* */
+
+/// handy type alias for pointer to a heap allocated wallet
+type WalletPtr  = *mut cardano::wallet::bip44::Wallet;
+/// handy type alias for pointer to a heap allocated account
+type AccountPtr = *mut cardano::wallet::bip44::Account<cardano::hdwallet::XPub>;
+
+// TODO: one of the major missing element is a proper clean error handling
+
+/// create a Wallet from the given seed (expecting a pointer to an array of 64 bytes)
+///
+/// the cardano mainnet protocol magic is `0x2D964A09`
+///
+/// use the function `wallet_delete` to free all the memory associated to the returned
+/// object. This function may fail if:
+///
+/// - panic: if there is no more memory to allocate the object to return
+/// - panic or return 0 (nullptr or NULL) if the given seed_ptr is of invalid length
+///
+#[no_mangle]
+pub extern "C"
+fn wallet_new_from_seed( seed_ptr: *const u8 /* expecting 64 bytes... */
+                       , protocol_magic: u32 /* the protocol magic to use */
+                       )
+    -> WalletPtr
+{
+    let seed_slice = unsafe {
+        slice::from_raw_parts(seed_ptr, cardano::bip::bip39::SEED_SIZE)
+    };
+
+    // TODO: we need to handle errors here
+    let seed = cardano::bip::bip39::Seed::from_slice(&seed_slice)
+                .expect("constructing a valid Seed form the given bytes");
+
+    let protocol_magic = cardano::config::ProtocolMagic::new(protocol_magic);
+    let config = cardano::config::Config::new(protocol_magic);
+
+    let wallet = Box::new(
+        cardano::wallet::bip44::Wallet::from_bip39_seed(
+            &seed,
+            Default::default(),
+            config
+        )
+    );
+
+    Box::into_raw(wallet)
+}
+
+/// take ownership of the given pointer and free the associated data
+///
+/// The data must be a valid Wallet created by `wallet_new_from_seed`.
+#[no_mangle]
+pub extern "C"
+fn wallet_delete(wallet_ptr: WalletPtr)
+{
+    unsafe {
+        Box::from_raw(wallet_ptr)
+    };
+}
+
+/* ******************************************************************************* *
+ *                                 Account object                                  *
+ * ******************************************************************************* */
+
+/// create a new account, the account is given an alias and an index,
+/// the index is the derivation index, we do not check if there is already
+/// an account with this given index. The alias here is only an handy tool
+/// to retrieve a created account from a wallet.
+///
+/// The returned object is not owned by any smart pointer or garbage collector.
+/// To avoid memory leak, use `account_delete`
+///
+#[no_mangle]
+pub extern "C"
+fn account_create( wallet_ptr: WalletPtr
+                 , account_alias: *mut c_char
+                 , account_index: u32
+                 )
+    -> AccountPtr
+{
+    let wallet = unsafe { wallet_ptr.as_mut() }.expect("Not a NULL PTR");
+    let account_alias = unsafe {
+        ffi::CStr::from_ptr(account_alias).to_string_lossy()
+    };
+
+    let account = wallet.create_account(&account_alias, account_index);
+    let account = Box::new(account.public());
+
+    Box::into_raw(account)
+}
+
+/// take ownership of the given pointer and free the memory associated
+#[no_mangle]
+pub extern "C"
+fn account_delete(account_ptr: AccountPtr)
+{
+    unsafe {
+        Box::from_raw(account_ptr)
+    };
+}
+
+#[no_mangle]
+pub extern "C"
+fn account_generate_addresses( account_ptr:  AccountPtr
+                             , internal:     bool
+                             , from_index: u32
+                             , num_indices: usize
+                             , addresses_ptr: *mut *mut c_char
+                             )
+    -> usize
+{
+    let account = unsafe { account_ptr.as_mut() }
+        .expect("Not a NULL PTR");
+
+    let addr_type = if internal {
+        cardano::wallet::bip44::AddrType::Internal
+    } else {
+        cardano::wallet::bip44::AddrType::External
+    };
+
+    account.address_generator(addr_type, from_index)
+        .expect("we expect the derivation to happen successfully")
+        .take(num_indices)
+        .enumerate()
+        .map(|(idx, xpub)| {
+            let address = cardano::address::ExtendedAddr::new_simple(*xpub.unwrap());
+            let address = format!("{}", cardano::util::base58::encode(&address.to_bytes()));
+            // generate a C String (null byte terminated string)
+            let c_address = ffi::CString::new(address)
+                .expect("base58 strings only contains ASCII chars");
+            // make sure the ptr is stored at the right place with alignments and all
+            unsafe {
+                ptr::write(addresses_ptr.wrapping_offset(idx as isize), c_address.into_raw())
+            };
+        }).count()
+}

--- a/cardano/src/wallet/bip44.rs
+++ b/cardano/src/wallet/bip44.rs
@@ -130,11 +130,11 @@ impl<K> Account<K> {
         Account { cached_root_key, derivation_scheme }
     }
 }
-impl<'a> From<&'a Account<XPrv>> for Account<XPub> {
-    fn from(prv: &'a Account<XPrv>) -> Self {
+impl Account<XPrv> {
+    pub fn public(&self) -> Account<XPub> {
         Account {
-            cached_root_key: prv.public(),
-            derivation_scheme: prv.derivation_scheme
+            cached_root_key: self.cached_root_key.public(),
+            derivation_scheme: self.derivation_scheme
         }
     }
 }

--- a/cardano/src/wallet/bip44.rs
+++ b/cardano/src/wallet/bip44.rs
@@ -137,6 +137,39 @@ impl Account<XPrv> {
             derivation_scheme: self.derivation_scheme
         }
     }
+
+    /// create an [`AddressGenerator`](./struct.AddressGenerator.html) iterator.
+    ///
+    /// an address iterator starts from the given index, and stop when
+    /// the last soft derivation is reached
+    /// ([`BIP44_SOFT_UPPER_BOUND`](../../bip/bip44/constant.BIP44_SOFT_UPPER_BOUND.html)).
+    ///
+    /// # Example:
+    ///
+    /// ```
+    /// # use cardano::wallet::{bip44::{self, AddrType}, scheme::{Wallet}};
+    /// # use cardano::bip::bip39::{MnemonicString, dictionary::ENGLISH};
+    /// # use cardano::address::ExtendedAddr;
+    /// # use cardano::util::base58;
+    ///
+    /// let mnemonics = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    /// let mnemonics = MnemonicString::new(&ENGLISH, mnemonics.to_owned()).unwrap();
+    ///
+    /// let mut wallet = bip44::Wallet::from_bip39_mnemonics(&mnemonics, b"password", Default::default(), Default::default());
+    /// let account = wallet.create_account("account 1", 0);
+    ///
+    /// // print only every two address (20 times)
+    /// for (idx, xprv) in account.address_generator(AddrType::External, 0)
+    ///                           .enumerate()
+    ///                           .filter(|(idx, _)| idx % 2 == 0)
+    ///                           .take(20)
+    /// {
+    ///   let address = ExtendedAddr::new_simple(*xprv.public());
+    ///   println!("address index {}: {}", idx, base58::encode(&address.to_bytes()));
+    /// }
+    ///
+    /// ```
+    ///
     pub fn address_generator(&self, addr_type: AddrType, from: u32) -> AddressGenerator<XPrv> {
         AddressGenerator {
             cached_root_key: self.cached_root_key.change(self.derivation_scheme, addr_type),
@@ -146,6 +179,37 @@ impl Account<XPrv> {
     }
 }
 impl Account<XPub> {
+    /// create an [`AddressGenerator`](./struct.AddressGenerator.html) iterator.
+    ///
+    /// an address iterator starts from the given index, and stop when
+    /// the last soft derivation is reached
+    /// ([`BIP44_SOFT_UPPER_BOUND`](../../bip/bip44/constant.BIP44_SOFT_UPPER_BOUND.html)).
+    ///
+    /// # Example:
+    ///
+    /// ```
+    /// # use cardano::wallet::{bip44::{self, AddrType}, scheme::{Wallet}};
+    /// # use cardano::bip::bip39::{MnemonicString, dictionary::ENGLISH};
+    /// # use cardano::address::ExtendedAddr;
+    /// # use cardano::util::base58;
+    ///
+    /// let mnemonics = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    /// let mnemonics = MnemonicString::new(&ENGLISH, mnemonics.to_owned()).unwrap();
+    ///
+    /// let mut wallet = bip44::Wallet::from_bip39_mnemonics(&mnemonics, b"password", Default::default(), Default::default());
+    /// let account = wallet.create_account("account 1", 0).public();
+    ///
+    /// // print first 10 addresses from index 10000
+    /// for (idx, xpub) in account.address_generator(AddrType::Internal, 10000).unwrap()
+    ///                           .take(10)
+    ///                           .enumerate()
+    /// {
+    ///   let address = ExtendedAddr::new_simple(*xpub.unwrap());
+    ///   println!("address index {}: {}", idx, base58::encode(&address.to_bytes()));
+    /// }
+    ///
+    /// ```
+    ///
     pub fn address_generator(&self, addr_type: AddrType, from: u32) -> Result<AddressGenerator<XPub>> {
         Ok(AddressGenerator {
             cached_root_key: self.cached_root_key.change(self.derivation_scheme, addr_type)?,
@@ -204,6 +268,16 @@ impl scheme::Account for Account<XPrv> {
     }
 }
 
+/// create an `AddressGenerator`
+///
+/// an address iterator starts from the given index, and stop when
+/// the last soft derivation is reached
+/// ([`BIP44_SOFT_UPPER_BOUND`](../../bip/bip44/constant.BIP44_SOFT_UPPER_BOUND.html)).
+///
+/// see [`Account<XPrv>::address_generator`](./struct.Account.html#method.address_generator)
+/// and [`Account<XPub>::address_generator`](./struct.Account.html#method.address_generator-1)
+/// for example of use.
+///
 pub struct AddressGenerator<K> {
     cached_root_key: ChangeLevel<K>,
     derivation_scheme: DerivationScheme,

--- a/wallet-cli/src/command/wallet/config.rs
+++ b/wallet-cli/src/command/wallet/config.rs
@@ -148,7 +148,7 @@ impl Accounts {
             let alias = format!("{}", account_index);
             wallet.create_account(&alias, account_index)
         };
-        let account = Account::from(&account);
+        let account = account.public();
         let account_cfg = account::Config::from_account(&account, alias);
         self.0.push(account_cfg);
         Ok(account)


### PR DESCRIPTION
# C-Binding `cardano-c`

this is a small example of c-binding for use in other languages. The aim of this library is to
demonstrate a simple use case of C library using the `rust-cardano` crates.

So far it provides:

1. create a new wallet from a bip39 seed (64 bytes expected);
2. create new bip44 accounts from a wallet;
3. generate bip44 addresses from a wallet.

# Address iterator

while writing the example above, I found it a bit tedious to generate a list of addresses, the iterator is meant to facilitate the address generations:

```rust
let wallet = /*  */ ;
let account = wallet.create_account("Main", 0);

let addresses = account.address_generator(AddrType::External, 0)
    .take(20) // if not used, we may iterate up to 0x7FFFFFFF, the limit for soft derivation
    .enumerate()
    .filter(|(x, _)| x % 2 == 0)
    .drop(2)
    .map(|(_, xprv) { ExtendedAddr::new_simple(xprv.public()) })
    .collect::<Vec<_>>();
```

This will return 8 addresses, indexed: 4, 6 8, 10, 12, 14, 16 and 18.