### PR TITLE
Simplify Hermes command line interface

### DIFF
--- a/exe-common/src/network/native.rs
+++ b/exe-common/src/network/native.rs
@@ -33,7 +33,7 @@ impl PeerPool {
             match Connection::new(sockaddr, protocol_magic) {
                 Ok(connection) => connections.push(connection),
                 Err(Error::ConnectionTimedOut) => {
-                    warn!("connection peer `{}' address {} timedout, ignoring for now.", name, sockaddr)
+                    warn!("connection peer `{}' address {} timed out, ignoring for now.", name, sockaddr)
                 },
                 Err(err) => {
                     error!("connection peer `{}' address {} failed: {:?}", name, sockaddr, err);

--- a/hermes/src/main.rs
+++ b/hermes/src/main.rs
@@ -35,8 +35,8 @@ fn main() {
         .author(crate_authors!())
         .about(crate_description!())
         .subcommand(
-            SubCommand::with_name("init")
-                .about("init hermes environment")
+            SubCommand::with_name("start")
+                .about("start explorer server")
                 .arg(Arg::with_name("PORT NUMBER")
                     .long("port")
                     .takes_value(true)
@@ -52,16 +52,12 @@ fn main() {
                     .required(false)
                 )
         )
-        .subcommand(
-            SubCommand::with_name("start")
-                .about("start explorer server")
-        )
         .get_matches();
 
     let mut cfg = Config::open().unwrap_or(Config::default());
 
     match matches.subcommand() {
-        ("init", Some(args)) => {
+        ("start", Some(args)) => {
             cfg.port = value_t!(args.value_of("PORT NUMBER"), u16)
                 .or_else(|err| match err {
                     clap::Error{ kind:clap::ErrorKind::ArgumentNotFound, .. } => Ok(cfg.port),
@@ -75,12 +71,8 @@ fn main() {
                     err => Err(err),
                 })
                 .unwrap();
-            let loc = cfg.save().expect("save hermes config");
-            info!("Saved config to {:?}", loc);
             ::std::fs::create_dir_all(cfg.root_dir.clone()).expect("create networks directory");
             info!("Created networks directory {:?}", cfg.root_dir);
-        },
-        ("start", _) => {
             info!("Starting {}-{}", crate_name!(), crate_version!());
             service::start(cfg);
         },

--- a/hermes/src/main.rs
+++ b/hermes/src/main.rs
@@ -61,6 +61,7 @@ fn main() {
                     .required(false)
                     .multiple(true)
                     .default_value("mainnet")
+                    .possible_values(&["mainnet", "testnet"])
                 )
         )
         .get_matches();

--- a/hermes/src/service.rs
+++ b/hermes/src/service.rs
@@ -23,7 +23,7 @@ fn start_http_server(cfg: &Config, networks: Arc<Networks>) -> iron::Listening {
     handlers::pack::Handler::new(networks.clone()).route(&mut router);
     handlers::epoch::Handler::new(networks.clone()).route(&mut router);
     handlers::tip::Handler::new(networks.clone()).route(&mut router);
-    info!("listenting to port {}", cfg.port);
+    info!("listening to port {}", cfg.port);
     iron::Iron::new(router)
         .http(format!("0.0.0.0:{}", cfg.port))
         .expect("start http server")


### PR DESCRIPTION
This removes `hermes init` and allows all necessary configuration to be specified on the command line, e.g.
```
hermes start --port 4080 --networks-dir /var/lib/hermes/networks --template testnet
```

Fixes #146.

