### PR TITLE
Fix Typo In cardano.h

### DIFF
--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -22,7 +22,7 @@ cardano_wallet *cardano_wallet_new_from_seed(const unsigned char * const seed_pt
 void cardano_wallet_delete(cardano_wallet *);
 
 cardano_account *cardano_account_create(cardano_wallet *wallet, const unsigned char *alias, unsigned int index);
-void cardano_accont_delete(cardano_account *account);
+void cardano_account_delete(cardano_account *account);
 
 unsigned long cardano_account_generate_addresses(cardano_account *account, int internal, unsigned int from_index, unsigned long num_indices, char *addresses_ptr[]);
 


### PR DESCRIPTION
Change `cardano_accont_delete` to `cardano_account_delete` to ensure that
header actually works when used to compile C programs. The previous typo was
preventing the header from being used as-is to build C programs.