### PR TITLE
net_sync() improvements

### DIFF
--- a/cardano/src/block/types.rs
+++ b/cardano/src/block/types.rs
@@ -125,7 +125,7 @@ impl fmt::Display for ChainDifficulty {
 
 pub type EpochId = u32;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SlotId {
     pub epoch: EpochId,
     pub slotid: u32,

--- a/exe-common/src/config.rs
+++ b/exe-common/src/config.rs
@@ -192,7 +192,7 @@ pub mod net {
     pub struct Config {
         pub genesis: HeaderHash,
         pub genesis_prev: HeaderHash,
-        pub k: u32,
+        pub epoch_stability_depth: u32,
         pub protocol_magic: ProtocolMagic,
         pub epoch_start: EpochId,
         pub peers: Peers
@@ -205,7 +205,7 @@ pub mod net {
             Config {
                 genesis: HeaderHash::from_hex(&"89D9B5A5B8DDC8D7E5A6795E9774D97FAF1EFEA59B2CAF7EAF9F8C5B32059DF4").unwrap(),
                 genesis_prev: HeaderHash::from_hex(&"5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb").unwrap(),
-                k: 2160,
+                epoch_stability_depth: 2160,
                 protocol_magic: ProtocolMagic::default(),
                 epoch_start: 0,
                 peers: peers
@@ -219,7 +219,7 @@ pub mod net {
             Config {
                 genesis: HeaderHash::from_hex(&"B365F1BE6863B453F12B93E1810909B10C79A95EE44BF53414888513FE172C90").unwrap(),
                 genesis_prev: HeaderHash::from_hex(&"c6a004d3d178f600cd8caa10abbebe1549bef878f0665aea2903472d5abf7323").unwrap(),
-                k: 2160,
+                epoch_stability_depth: 2160,
                 protocol_magic: ProtocolMagic::new(633343913),
                 epoch_start: 0,
                 peers: peers

--- a/exe-common/src/config.rs
+++ b/exe-common/src/config.rs
@@ -192,6 +192,7 @@ pub mod net {
     pub struct Config {
         pub genesis: HeaderHash,
         pub genesis_prev: HeaderHash,
+        pub k: u32,
         pub protocol_magic: ProtocolMagic,
         pub epoch_start: EpochId,
         pub peers: Peers
@@ -204,6 +205,7 @@ pub mod net {
             Config {
                 genesis: HeaderHash::from_hex(&"89D9B5A5B8DDC8D7E5A6795E9774D97FAF1EFEA59B2CAF7EAF9F8C5B32059DF4").unwrap(),
                 genesis_prev: HeaderHash::from_hex(&"5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb").unwrap(),
+                k: 2160,
                 protocol_magic: ProtocolMagic::default(),
                 epoch_start: 0,
                 peers: peers
@@ -217,6 +219,7 @@ pub mod net {
             Config {
                 genesis: HeaderHash::from_hex(&"B365F1BE6863B453F12B93E1810909B10C79A95EE44BF53414888513FE172C90").unwrap(),
                 genesis_prev: HeaderHash::from_hex(&"c6a004d3d178f600cd8caa10abbebe1549bef878f0665aea2903472d5abf7323").unwrap(),
+                k: 2160,
                 protocol_magic: ProtocolMagic::new(633343913),
                 epoch_start: 0,
                 peers: peers

--- a/exe-common/src/config.rs
+++ b/exe-common/src/config.rs
@@ -6,7 +6,7 @@ pub mod net {
     use serde_yaml;
     use serde;
 
-    const DEFAULT_EPOCH_STABILITY_DEPTH : u32 = 2160;
+    const DEFAULT_EPOCH_STABILITY_DEPTH : usize = 2160;
 
 
     /// A blockchain may have multiple Peer of different kind. Here we define the list
@@ -194,7 +194,7 @@ pub mod net {
     pub struct Config {
         pub genesis: HeaderHash,
         pub genesis_prev: HeaderHash,
-        pub epoch_stability_depth: u32,
+        pub epoch_stability_depth: usize,
         pub protocol_magic: ProtocolMagic,
         pub epoch_start: EpochId,
         pub peers: Peers

--- a/exe-common/src/config.rs
+++ b/exe-common/src/config.rs
@@ -6,6 +6,8 @@ pub mod net {
     use serde_yaml;
     use serde;
 
+    const DEFAULT_EPOCH_STABILITY_DEPTH : u32 = 2160;
+
 
     /// A blockchain may have multiple Peer of different kind. Here we define the list
     /// of possible kind of peer we may connect to.
@@ -205,7 +207,7 @@ pub mod net {
             Config {
                 genesis: HeaderHash::from_hex(&"89D9B5A5B8DDC8D7E5A6795E9774D97FAF1EFEA59B2CAF7EAF9F8C5B32059DF4").unwrap(),
                 genesis_prev: HeaderHash::from_hex(&"5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb").unwrap(),
-                epoch_stability_depth: 2160,
+                epoch_stability_depth: DEFAULT_EPOCH_STABILITY_DEPTH,
                 protocol_magic: ProtocolMagic::default(),
                 epoch_start: 0,
                 peers: peers
@@ -219,7 +221,7 @@ pub mod net {
             Config {
                 genesis: HeaderHash::from_hex(&"B365F1BE6863B453F12B93E1810909B10C79A95EE44BF53414888513FE172C90").unwrap(),
                 genesis_prev: HeaderHash::from_hex(&"c6a004d3d178f600cd8caa10abbebe1549bef878f0665aea2903472d5abf7323").unwrap(),
-                epoch_stability_depth: 2160,
+                epoch_stability_depth: DEFAULT_EPOCH_STABILITY_DEPTH,
                 protocol_magic: ProtocolMagic::new(633343913),
                 epoch_start: 0,
                 peers: peers

--- a/exe-common/src/network/api.rs
+++ b/exe-common/src/network/api.rs
@@ -1,8 +1,7 @@
 use cardano::block::{BlockHeader, RawBlock, HeaderHash, EpochId};
-use storage::{Storage, types::{PackHash}};
-
-use network::{Result};
 use config::{net};
+use network::{Result};
+use storage::{Storage, types::{PackHash}};
 
 /// Api to abstract the network interaction and do the
 /// necessary operations
@@ -14,6 +13,9 @@ pub trait Api {
     /// Get one specific block (represented by its unique hash) from the
     /// network
     fn get_block(&mut self, hash: HeaderHash) -> Result<RawBlock>;
+
+    /// Get the blocks in the half-open interval (from, to].
+    fn get_blocks(&mut self, from: HeaderHash, to: HeaderHash) -> Result<Vec<(HeaderHash, RawBlock)>>;
 
     /// Fetch a finished epoch
     ///

--- a/exe-common/src/network/api.rs
+++ b/exe-common/src/network/api.rs
@@ -1,4 +1,4 @@
-use cardano::block::{BlockHeader, Block, HeaderHash, EpochId};
+use cardano::block::{BlockHeader, RawBlock, HeaderHash, EpochId};
 use storage::{Storage, types::{PackHash}};
 
 use network::{Result};
@@ -13,7 +13,7 @@ pub trait Api {
 
     /// Get one specific block (represented by its unique hash) from the
     /// network
-    fn get_block(&mut self, hash: HeaderHash) -> Result<Block>;
+    fn get_block(&mut self, hash: HeaderHash) -> Result<RawBlock>;
 
     /// Fetch a finished epoch
     ///

--- a/exe-common/src/network/api.rs
+++ b/exe-common/src/network/api.rs
@@ -1,7 +1,5 @@
-use cardano::block::{BlockHeader, RawBlock, HeaderHash, EpochId};
-use config::{net};
+use cardano::block::{Block, BlockHeader, RawBlock, HeaderHash, BlockDate};
 use network::{Result};
-use storage::{Storage, types::{PackHash}};
 
 /// Api to abstract the network interaction and do the
 /// necessary operations
@@ -14,61 +12,16 @@ pub trait Api {
     /// network
     fn get_block(&mut self, hash: HeaderHash) -> Result<RawBlock>;
 
-    /// Get the blocks in the half-open interval (from, to].
-    fn get_blocks(&mut self, from: HeaderHash, to: HeaderHash) -> Result<Vec<(HeaderHash, RawBlock)>>;
-
-    /// Fetch a finished epoch
-    ///
-    /// Note that calling this api too close to the windows of block instability will either likely
-    /// result in failure to get the pack, or unexpected result.
-    ///
-    /// In the case of hermes, an epoch is pack only after the latest block of the epoch
-    /// is considered immutable in the chain by being old enough; latest known block's date
-    /// is tip.date() - k where k is typically around 2200 blocks. TODO this is a configurable
-    /// parameter, so expect to be able to find the constant somewhere in the net::Config in the future.
-    fn fetch_epoch(&mut self, config: &net::Config, storage: &mut Storage, fep: FetchEpochParams) -> Result<FetchEpochResult>;
+    /// Get the blocks in the half-open interval (from, to] (if
+    /// inclusive = false) or [from, to] (if inclusive = true). FIXME:
+    /// the inclusive = true case is only needed because the native
+    /// protocol doesn't support fetching from the genesis_prev hash.
+    fn get_blocks(&mut self, from: &BlockRef, inclusive: bool, to: &BlockRef,
+                   got_block: &mut FnMut(&HeaderHash, &Block, &RawBlock) -> ());
 }
 
-/// Parameter for fetching a full epoch
-///
-/// the epoch_id refer to which full epoch we want to fetch,
-/// which is either used to make sure we're getting the
-/// right blocks in the native API, or directly as a way
-/// to get the right epoch in the http API.
-///
-/// The upper bound hash is used for the native API to have
-/// a way to query the blocks in a range. we always know
-/// the genesis hash (coming from the configuration) and
-/// the get_tip API (coming from querying a network node.
-///
-/// The previous_header_hash is the hash we used to make
-/// sure that the chain is actually valid; this hash
-/// which represent the latest known block in the previous epoch,
-/// should be equal to the genesis block of the new epoch
-/// that is going to be fetch
-///
-/// start_header_hash is only used in the native protocol
-/// when downloading the first block of the chain,
-/// since we can't start downloading at previous_header_hash
-/// which point to a non valid block
-#[derive(Debug)]
-pub struct FetchEpochParams {
-    pub epoch_id: EpochId,
-    pub start_header_hash: HeaderHash,
-    pub previous_header_hash: HeaderHash,
-    pub upper_bound_hash: HeaderHash
-}
-
-/// Result values of an epoch fetch.
-//
-/// it will return:
-///
-/// * the hash of the pack where the data have been stored,
-/// * the hash of the last header fetched
-/// * optionally if known, the hash of the next epoch first block
-#[derive(Debug)]
-pub struct FetchEpochResult {
-    pub next_epoch_hash: Option<HeaderHash>,
-    pub last_header_hash: HeaderHash,
-    pub packhash: PackHash
+#[derive(Debug, Clone)]
+pub struct BlockRef {
+    pub hash: HeaderHash,
+    pub date: BlockDate
 }

--- a/exe-common/src/network/api.rs
+++ b/exe-common/src/network/api.rs
@@ -10,7 +10,7 @@ pub trait Api {
 
     /// Get one specific block (represented by its unique hash) from the
     /// network
-    fn get_block(&mut self, hash: HeaderHash) -> Result<RawBlock>;
+    fn get_block(&mut self, hash: &HeaderHash) -> Result<RawBlock>;
 
     /// Get the blocks in the half-open interval (from, to] (if
     /// inclusive = false) or [from, to] (if inclusive = true). FIXME:
@@ -23,5 +23,6 @@ pub trait Api {
 #[derive(Debug, Clone, PartialEq)]
 pub struct BlockRef {
     pub hash: HeaderHash,
-    pub date: BlockDate
+    pub date: BlockDate,
+    pub parent: HeaderHash, // FIXME: remove
 }

--- a/exe-common/src/network/api.rs
+++ b/exe-common/src/network/api.rs
@@ -20,7 +20,7 @@ pub trait Api {
                    got_block: &mut FnMut(&HeaderHash, &Block, &RawBlock) -> ());
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct BlockRef {
     pub hash: HeaderHash,
     pub date: BlockDate

--- a/exe-common/src/network/hermes.rs
+++ b/exe-common/src/network/hermes.rs
@@ -65,6 +65,10 @@ impl Api for HermesEndPoint {
         unimplemented!()
     }
 
+    fn get_blocks(&mut self, _from: HeaderHash, _to: HeaderHash) -> Result<Vec<(HeaderHash, RawBlock)>> {
+        unimplemented!()
+    }
+
     fn fetch_epoch(&mut self, _config: &net::Config, storage: &mut Storage, fep: FetchEpochParams) -> Result<FetchEpochResult> {
         let path = format!("epoch/{}", fep.epoch_id);
 

--- a/exe-common/src/network/hermes.rs
+++ b/exe-common/src/network/hermes.rs
@@ -1,4 +1,4 @@
-use cardano::block::{block, BlockHeader, RawBlock, HeaderHash};
+use cardano::block::{block, Block, BlockHeader, RawBlock, HeaderHash};
 use storage::{self, Storage, tmpfile::{TmpFile}};
 use std::io::{Write, Seek, SeekFrom};
 use std::time::{SystemTime};
@@ -10,7 +10,7 @@ use hyper::Client;
 use tokio_core::reactor::Core;
 
 use network::{Result, Error};
-use network::api::{Api, FetchEpochParams, FetchEpochResult};
+use network::api::{Api, BlockRef};
 
 
 /// hermes end point
@@ -65,10 +65,13 @@ impl Api for HermesEndPoint {
         unimplemented!()
     }
 
-    fn get_blocks(&mut self, _from: HeaderHash, _to: HeaderHash) -> Result<Vec<(HeaderHash, RawBlock)>> {
+    fn get_blocks(&mut self, from: &BlockRef, inclusive: bool, to: &BlockRef,
+                   got_block: &mut FnMut(&HeaderHash, &Block, &RawBlock) -> ())
+    {
         unimplemented!()
     }
 
+    /*
     fn fetch_epoch(&mut self, _config: &net::Config, storage: &mut Storage, fep: FetchEpochParams) -> Result<FetchEpochResult> {
         let path = format!("epoch/{}", fep.epoch_id);
 
@@ -117,4 +120,5 @@ impl Api for HermesEndPoint {
             packhash: packhash
         })
     }
+    */
 }

--- a/exe-common/src/network/hermes.rs
+++ b/exe-common/src/network/hermes.rs
@@ -1,4 +1,4 @@
-use cardano::block::{block, BlockHeader, Block, HeaderHash};
+use cardano::block::{block, BlockHeader, RawBlock, HeaderHash};
 use storage::{self, Storage, tmpfile::{TmpFile}};
 use std::io::{Write, Seek, SeekFrom};
 use std::time::{SystemTime};
@@ -61,7 +61,7 @@ impl Api for HermesEndPoint {
         Ok(bh_raw.decode()?)
     }
 
-    fn get_block(&mut self, _hash: HeaderHash) -> Result<Block> {
+    fn get_block(&mut self, _hash: HeaderHash) -> Result<RawBlock> {
         unimplemented!()
     }
 

--- a/exe-common/src/network/hermes.rs
+++ b/exe-common/src/network/hermes.rs
@@ -99,7 +99,6 @@ impl Api for HermesEndPoint {
         let (packhash, index) = packwriter.finalize();
         let (_, tmpfile) = storage::pack::create_index(storage, &index);
         tmpfile.render_permanent(&storage.config.get_index_filepath(&packhash))?;
-        storage::epoch::epoch_create(&storage.config, &packhash, fep.epoch_id);
 
         let last_hdr = match last {
             None => { panic!("no last block found, error.") },

--- a/exe-common/src/network/native.rs
+++ b/exe-common/src/network/native.rs
@@ -1,16 +1,13 @@
 use protocol;
 use mstream::{MStream, MetricStart, MetricStats};
-use cardano::{config::{ProtocolMagic}, util::{hex}};
+use cardano::{config::{ProtocolMagic}};
 use rand;
 use std::{net::{SocketAddr, ToSocketAddrs}, ops::{Deref, DerefMut}};
-use cardano::block::{self, Block, BlockHeader, RawBlock, HeaderHash, EpochId, SlotId, BlockDate};
-use storage::{self, Storage, types::{PackHash}};
+use cardano::block::{Block, BlockHeader, RawBlock, HeaderHash};
 use protocol::command::*;
-use std::time::{SystemTime, Duration};
 
-use config::net;
 use network::{Error, Result};
-use network::api::{Api, FetchEpochParams, FetchEpochResult};
+use network::api::{Api, BlockRef};
 
 /// native peer
 pub struct PeerPool {
@@ -63,17 +60,12 @@ impl Api for PeerPool {
         }
     }
 
-    fn get_blocks(&mut self, from: HeaderHash, to: HeaderHash) -> Result<Vec<(HeaderHash, RawBlock)>> {
+    fn get_blocks(&mut self, from: &BlockRef, inclusive: bool, to: &BlockRef,
+                   got_block: &mut FnMut(&HeaderHash, &Block, &RawBlock) -> ())
+    {
         match self.connections.get_mut(0) {
             None => panic!("We expect at lease one connection on any native peer"),
-            Some(conn) => conn.get_blocks(from, to)
-        }
-    }
-
-    fn fetch_epoch(&mut self, config: &net::Config, storage: &mut Storage, fep: FetchEpochParams) -> Result<FetchEpochResult> {
-        match self.connections.get_mut(0) {
-            None => panic!("We expect at lease one connection on any native peer"),
-            Some(conn) => conn.fetch_epoch(config, storage, fep)
+            Some(conn) => conn.get_blocks(from, inclusive, to, got_block)
         }
     }
 }
@@ -136,297 +128,75 @@ impl Api for OpenPeer {
         Ok(RawBlock::from_dat(b[0].as_ref().to_vec()))
     }
 
-    fn get_blocks(&mut self, from: HeaderHash, to: HeaderHash) -> Result<Vec<(HeaderHash, RawBlock)>> {
-        let mut blocks = vec!();
-        fetch_range(self, &from, &to, false, |blockhash, _block, block_raw| {
-            blocks.push((blockhash.clone(), block_raw.clone()));
-        });
-        Ok(blocks)
-    }
+    fn get_blocks(&mut self, from: &BlockRef, inclusive: bool, to: &BlockRef,
+                   got_block: &mut FnMut(&HeaderHash, &Block, &RawBlock) -> ())
+    {
+        let mut inclusive = inclusive;
+        let mut from = from.clone();
 
-    fn fetch_epoch(&mut self, _config: &net::Config, storage: &mut Storage, fep: FetchEpochParams) -> Result<FetchEpochResult> {
-        let result = download_epoch(storage, self, fep.epoch_id, &fep.start_header_hash, &fep.previous_header_hash, &fep.upper_bound_hash);
-        Ok(FetchEpochResult {
-            last_header_hash: result.0,
-            next_epoch_hash: Some(result.1),
-            packhash: result.2
-        })
-    }
-}
-
-/// Fetch the blocks in the half-open interval (from, to] in batches
-/// of around 2000 blocks at a time. The closure 'got_block' is called
-/// with each block in the order (from, to]. We check that there is no
-/// gap in the chain, i.e. each block has the previous block as its
-/// parent. If 'one_epoch' is set, we return when we encounter a block
-/// in a different epoch than the previous one.
-fn fetch_range<F>(
-    net: &mut OpenPeer,
-    from: &HeaderHash,
-    to: &HeaderHash,
-    one_epoch: bool,
-    mut got_block: F)
-    -> (HeaderHash, Option<HeaderHash>)
-where F: FnMut(&HeaderHash, &Block, &RawBlock) -> ()
-{
-    assert!(from != to);
-
-    let mut from = from.clone();
-    let mut epoch = None;
-    let mut next_hash = None;
-
-    while &from != to && (!one_epoch || next_hash.is_none()) {
-        info!("  ### from={} to={}", from, to);
-        let metrics = net.read_start();
-        let block_headers_raw = GetBlockHeader::range(
-            &vec![from.clone()], to.clone()).execute(&mut net.0).expect("to get one header at least");
-        let hdr_metrics = net.read_elapsed(&metrics);
-        let block_headers = block_headers_raw.decode().unwrap();
-        info!("  got {} headers  ( {} )", block_headers.len(), hdr_metrics);
-
-        assert!(!block_headers.is_empty());
-
-        let mut start = 0;
-        let end = block_headers.len() - 1;
-
-        info!("  asked {} to {}", from, to);
-        info!("  start {} {} <- {}", block_headers[start].compute_hash(), block_headers[start].get_blockdate(), block_headers[start].get_previous_header());
-        info!("  end   {} {} <- {}", block_headers[end].compute_hash(), block_headers[end].get_blockdate(), block_headers[end].get_previous_header());
-
-        // The server will return the oldest ~2000 blocks starting at
-        // 'from'. However, they're in reverse order. Thus the last
-        // element of 'block_headers' should have 'from' as its
-        // parent.
-        assert!(block_headers[end].get_previous_header() == from);
-
-        if one_epoch {
-
-            if epoch.is_none() {
-                epoch = Some(block_headers[end].get_blockdate().get_epochid());
+        loop {
+            if inclusive {
+                if from.date > to.date { break }
+                info!("  ### get headers [{}..{}]", from.hash, to.hash);
+            } else {
+                if from.date >= to.date { break }
+                info!("  ### get headers ({}..{}]", from.hash, to.hash);
             }
+            let metrics = self.read_start();
+            let block_headers_raw = GetBlockHeader::range(
+                &vec![from.hash.clone()], to.hash.clone())
+                .execute(&mut self.0).expect("to get one header at least");
+            let hdr_metrics = self.read_elapsed(&metrics);
+            let block_headers = block_headers_raw.decode().unwrap();
+            info!("  got {} headers  ( {} )", block_headers.len(), hdr_metrics);
 
-            // Skip blocks beyond the current epoch.
-            while end >= start && block_headers[start].get_blockdate().get_epochid() > epoch.unwrap() {
-                start += 1
+            assert!(!block_headers.is_empty());
+
+            let start = 0;
+            let end = block_headers.len() - 1;
+
+            info!("  start {} {} <- {}", block_headers[start].compute_hash(), block_headers[start].get_blockdate(), block_headers[start].get_previous_header());
+            info!("  end   {} {} <- {}", block_headers[end].compute_hash(), block_headers[end].get_blockdate(), block_headers[end].get_previous_header());
+
+            // The server will return the oldest ~2000 blocks starting at
+            // 'from'. However, they're in reverse order. Thus the last
+            // element of 'block_headers' should have 'from' as its
+            // parent.
+            assert!(block_headers[end].get_previous_header() == from.hash);
+
+            let start_hash = if inclusive { block_headers[end].get_previous_header() } else { block_headers[end].compute_hash() };
+            let end_hash = block_headers[start].compute_hash();
+
+            info!("  get blocks [{}..{}]", start_hash, end_hash);
+
+            let metrics = self.read_start();
+            let blocks_raw = GetBlock::from(&start_hash, &end_hash)
+                .execute(&mut self.0)
+                .expect("to get one block at least");
+            let blocks_metrics = self.read_elapsed(&metrics);
+            info!("  got {} blocks  ( {} )", blocks_raw.len(), blocks_metrics);
+
+            assert!(!blocks_raw.is_empty());
+
+            for block_raw in blocks_raw.iter() {
+                let block = block_raw.decode().unwrap();
+                let hdr = block.get_header();
+                let date = hdr.get_blockdate();
+                let blockhash = hdr.compute_hash();
+
+                //info!("  got block {} {} prev {}", blockhash, date, hdr.get_previous_header());
+
+                if !inclusive && hdr.get_previous_header() != from.hash {
+                    panic!("previous header doesn't match: hash {} date {} got {} expected {}",
+                           blockhash, date, hdr.get_previous_header(), from.hash)
+                }
+
+                got_block(&hdr.compute_hash(), &block, &block_raw);
+
+                from.hash = blockhash;
+                from.date = date;
+                inclusive = false;
             }
-
-            if start > 0 {
-                info!("  found next epoch");
-                next_hash = Some(block_headers[start-1].compute_hash());
-            }
-        }
-
-        let latest_block = &block_headers[start];
-        let first_block = &block_headers[end];
-
-        info!("  hdr latest {} {}", latest_block.compute_hash(), latest_block.get_blockdate());
-        info!("  hdr first  {} {}", first_block.compute_hash(), first_block.get_blockdate());
-
-        let download_start_hash = first_block.compute_hash();
-
-        let metrics = net.read_start();
-        let blocks_raw = GetBlock::from(&download_start_hash, &latest_block.compute_hash())
-                                .execute(&mut net.0)
-                                .expect("to get one block at least");
-        let blocks_metrics = net.read_elapsed(&metrics);
-        info!("  got {} blocks  ( {} )", blocks_raw.len(), blocks_metrics);
-
-        assert!(!blocks_raw.is_empty());
-
-        for block_raw in blocks_raw.iter() {
-            let block = block_raw.decode().unwrap();
-            let hdr = block.get_header();
-            let date = hdr.get_blockdate();
-            let blockhash = hdr.compute_hash();
-
-            info!("got block {} {} prev {}", blockhash, date, hdr.get_previous_header());
-
-            if hdr.get_previous_header() != from {
-                panic!("previous header doesn't match: hash {} date {} got {} expected {}",
-                       blockhash, date, hdr.get_previous_header(), from)
-            }
-
-            if one_epoch && date.get_epochid() != epoch.unwrap() {
-                panic!("received block from wrong epoch: hash {} date {} expected {}",
-                       blockhash, date, epoch.unwrap())
-            }
-
-            got_block(&hdr.compute_hash(), &block, &block_raw);
-
-            from = blockhash;
         }
     }
-
-    (from, next_hash)
-}
-
-fn download_epoch(storage: &Storage, net: &mut OpenPeer,
-                  epoch_id: EpochId,
-                  x_start_hash: &HeaderHash,
-                  x_previous_headerhash: &HeaderHash,
-                  tip_hash: &HeaderHash) -> (HeaderHash, HeaderHash, PackHash)
-{
-    let mut writer = storage::pack::PackWriter::init(&storage.config);
-    let epoch_time_start = SystemTime::now();
-    let mut expected_slotid = block::BlockDate::Genesis(epoch_id);
-
-    let (last_hash, next_hash) = fetch_range(net, x_previous_headerhash, tip_hash, true, |blockhash, block, block_raw| {
-        let hdr = block.get_header();
-        let date = hdr.get_blockdate();
-
-        if date.get_epochid() != epoch_id {
-            panic!("trying to append a block of different epoch id {}", date.get_epochid())
-        }
-
-        if &date != &expected_slotid {
-            println!("  WARNING: not contiguous. addr {} found, expected {}", date, expected_slotid);
-        }
-
-        match date {
-            BlockDate::Genesis(epoch) => {
-                expected_slotid = BlockDate::Normal(SlotId { epoch: epoch, slotid: 0 });
-            },
-            BlockDate::Normal(slotid) => {
-                expected_slotid = BlockDate::Normal(slotid.next());
-            },
-        }
-
-        writer.append(&storage::types::header_to_blockhash(&blockhash), block_raw.as_ref());
-    });
-
-    // write packfile
-    let (packhash, index) = writer.finalize();
-    let (_, tmpfile) = storage::pack::create_index(storage, &index);
-    tmpfile.render_permanent(&storage.config.get_index_filepath(&packhash)).unwrap();
-    let epoch_time_elapsed = epoch_time_start.elapsed().unwrap();
-    info!("=> pack {} written for epoch {} in {}", hex::encode(&packhash[..]), epoch_id, duration_print(epoch_time_elapsed));
-    (last_hash, next_hash.unwrap(), packhash)
-}
-
-/*
-fn download_epoch(storage: &Storage, net: &mut OpenPeer,
-                  epoch_id: EpochId,
-                  x_start_hash: &HeaderHash,
-                  x_previous_headerhash: &HeaderHash,
-                  tip_hash: &HeaderHash) -> (HeaderHash, HeaderHash, PackHash) {
-    let mut start_hash = x_start_hash.clone();
-    let mut found_epoch_boundary = None;
-    let mut previous_headerhash = x_previous_headerhash.clone();
-    let mut expected_slotid = block::BlockDate::Genesis(epoch_id);
-
-    loop {
-        info!("  ### slotid={} from={}", expected_slotid, start_hash);
-        let metrics = net.read_start();
-        let block_headers_raw = network_get_blocks_headers(net, &start_hash, tip_hash);
-        let hdr_metrics = net.read_elapsed(&metrics);
-        let block_headers = block_headers_raw.decode().unwrap();
-        info!("  got {} headers  ( {} )", block_headers.len(), hdr_metrics);
-
-        let mut start = 0;
-        let mut end = block_headers.len() - 1;
-
-        debug!("  asked {} to {}", start_hash, tip_hash);
-        debug!("  start {} {} <- {}", block_headers[start].compute_hash(),  block_headers[start].get_blockdate(), block_headers[start].get_previous_header());
-        debug!("  end   {} {} <- {}", block_headers[end].compute_hash(), block_headers[end].get_blockdate(), block_headers[end].get_previous_header());
-
-        // if the earliest block headers we receive has an epoch
-        // less than the expected epoch, we just fast skip
-        // this set of headers and restart the loop with the
-        // latest known hash
-        if block_headers[start].get_blockdate().get_epochid() < epoch_id {
-            start_hash = block_headers[start].compute_hash();
-            info!("headers are of previous epochs, fast skip to {}", start_hash);
-            continue;
-        }
-
-        while end >= start && block_headers[start].get_blockdate().get_epochid() > epoch_id {
-            start += 1
-        }
-        while end > start && block_headers[end].get_blockdate().get_epochid() < epoch_id {
-            end -= 1
-        }
-
-        if start > 0 {
-            info!("  found next epoch");
-            found_epoch_boundary = Some(block_headers[start-1].compute_hash());
-        }
-        let latest_block = &block_headers[start];
-        let first_block = &block_headers[end];
-
-        debug!("  hdr latest {} {}", latest_block.compute_hash(), latest_block.get_blockdate());
-        debug!("  hdr first  {} {}", first_block.compute_hash(), first_block.get_blockdate());
-
-        let download_start_hash = if first_block.get_blockdate() == expected_slotid {
-            first_block.compute_hash()
-        } else if first_block.get_blockdate() == expected_slotid.next() {
-            first_block.get_previous_header()
-        } else {
-            panic!("not matching. gap")
-        };
-
-        let metrics = net.read_start();
-        let blocks_raw = GetBlock::from(&download_start_hash, &latest_block.compute_hash())
-                                .execute(&mut net.0)
-                                .expect("to get one block at least");
-        let blocks_metrics = net.read_elapsed(&metrics);
-        info!("  got {} blocks  ( {} )", blocks_raw.len(), blocks_metrics);
-
-        let first_block = blocks_raw[0].decode().unwrap();
-        let first_block_hdr = first_block.get_header();
-        debug!("first block {} {} prev {}", first_block_hdr.compute_hash(), first_block_hdr.get_blockdate(), first_block_hdr.get_previous_header());
-
-        for block_raw in blocks_raw.iter() {
-            let block = block_raw.decode().unwrap();
-            let hdr = block.get_header();
-            let date = hdr.get_blockdate();
-            let blockhash = hdr.compute_hash();
-            let block_previous_header = hdr.get_previous_header();
-
-            if date.get_epochid() != epoch_id {
-                panic!("trying to append a block of different epoch id {}", date.get_epochid())
-            }
-
-            if previous_headerhash != block_previous_header {
-                panic!("previous header doesn't match: hash {} date {} got {} expected {}",
-                       blockhash, date, block_previous_header, previous_headerhash)
-            }
-
-            if &date != &expected_slotid {
-                println!("  WARNING: not contiguous. addr {} found, expected {} {}", date, expected_slotid, block_previous_header);
-            }
-
-            match date {
-                BlockDate::Genesis(epoch) => {
-                    expected_slotid = BlockDate::Normal(SlotId { epoch: epoch, slotid: 0 });
-                },
-                BlockDate::Normal(slotid) => {
-                    expected_slotid = BlockDate::Normal(slotid.next());
-                },
-            }
-
-            writer.append(&storage::types::header_to_blockhash(&blockhash), block_raw.as_ref());
-            previous_headerhash = blockhash.clone();
-        }
-        // println!("packing {}", slot);
-        start_hash = previous_headerhash.clone();
-
-        match found_epoch_boundary {
-            None    => {},
-            Some(b) => {
-                info!("=> packing finished {} slotids", expected_slotid);
-                // write packfile
-                let (packhash, index) = writer.finalize();
-                let (_, tmpfile) = storage::pack::create_index(storage, &index);
-                tmpfile.render_permanent(&storage.config.get_index_filepath(&packhash)).unwrap();
-                let epoch_time_elapsed = epoch_time_start.elapsed().unwrap();
-                info!("=> pack {} written for epoch {} in {}", hex::encode(&packhash[..]), epoch_id, duration_print(epoch_time_elapsed));
-                return (previous_headerhash, b, packhash)
-            },
-        }
-    }
-}
-*/
-
-fn duration_print(d: Duration) -> String {
-    format!("{}.{:03} seconds", d.as_secs(), d.subsec_millis())
 }

--- a/exe-common/src/network/native.rs
+++ b/exe-common/src/network/native.rs
@@ -263,7 +263,6 @@ fn download_epoch(storage: &Storage, net: &mut OpenPeer,
                 tmpfile.render_permanent(&storage.config.get_index_filepath(&packhash)).unwrap();
                 let epoch_time_elapsed = epoch_time_start.elapsed().unwrap();
                 info!("=> pack {} written for epoch {} in {}", hex::encode(&packhash[..]), epoch_id, duration_print(epoch_time_elapsed));
-                storage::tag::write(storage, &storage::tag::get_epoch_tag(epoch_id), &packhash[..]);
                 return (previous_headerhash, b, packhash)
             },
         }

--- a/exe-common/src/network/peer.rs
+++ b/exe-common/src/network/peer.rs
@@ -1,9 +1,8 @@
 use config;
 use network::{native, Result, hermes};
-use network::api::{*};
+use network::api::{*, BlockRef};
 use cardano::config::{ProtocolMagic};
-use cardano::block::{BlockHeader, RawBlock, HeaderHash};
-use storage::{Storage};
+use cardano::block::{Block, BlockHeader, RawBlock, HeaderHash};
 
 /// network object to handle a peer connection and redirect to constructing
 /// the appropriate network protocol object (native, http...)
@@ -38,17 +37,12 @@ impl Api for Peer {
         }
     }
 
-    fn get_blocks(&mut self, from: HeaderHash, to: HeaderHash) -> Result<Vec<(HeaderHash, RawBlock)>> {
+    fn get_blocks(&mut self, from: &BlockRef, inclusive: bool, to: &BlockRef,
+                   got_block: &mut FnMut(&HeaderHash, &Block, &RawBlock) -> ())
+    {
         match self {
-            Peer::Native(peer)   => peer.get_blocks(from, to),
-            Peer::Http(endpoint) => endpoint.get_blocks(from, to),
-        }
-    }
-
-    fn fetch_epoch(&mut self, config: &config::net::Config, storage: &mut Storage, fep: FetchEpochParams) -> Result<FetchEpochResult> {
-        match self {
-            Peer::Native(peer)   => peer.fetch_epoch(config, storage, fep),
-            Peer::Http(endpoint) => endpoint.fetch_epoch(config, storage, fep),
+            Peer::Native(peer)   => peer.get_blocks(from, inclusive, to, got_block),
+            Peer::Http(endpoint) => endpoint.get_blocks(from, inclusive, to, got_block),
         }
     }
 }

--- a/exe-common/src/network/peer.rs
+++ b/exe-common/src/network/peer.rs
@@ -2,7 +2,7 @@ use config;
 use network::{native, Result, hermes};
 use network::api::{*};
 use cardano::config::{ProtocolMagic};
-use cardano::block::{BlockHeader, Block, HeaderHash};
+use cardano::block::{BlockHeader, RawBlock, HeaderHash};
 use storage::{Storage};
 
 /// network object to handle a peer connection and redirect to constructing
@@ -31,7 +31,7 @@ impl Api for Peer {
         }
     }
 
-    fn get_block(&mut self, hash: HeaderHash) -> Result<Block> {
+    fn get_block(&mut self, hash: HeaderHash) -> Result<RawBlock> {
         match self {
             Peer::Native(peer)   => peer.get_block(hash),
             Peer::Http(endpoint) => endpoint.get_block(hash),

--- a/exe-common/src/network/peer.rs
+++ b/exe-common/src/network/peer.rs
@@ -30,7 +30,7 @@ impl Api for Peer {
         }
     }
 
-    fn get_block(&mut self, hash: HeaderHash) -> Result<RawBlock> {
+    fn get_block(&mut self, hash: &HeaderHash) -> Result<RawBlock> {
         match self {
             Peer::Native(peer)   => peer.get_block(hash),
             Peer::Http(endpoint) => endpoint.get_block(hash),

--- a/exe-common/src/network/peer.rs
+++ b/exe-common/src/network/peer.rs
@@ -38,6 +38,13 @@ impl Api for Peer {
         }
     }
 
+    fn get_blocks(&mut self, from: HeaderHash, to: HeaderHash) -> Result<Vec<(HeaderHash, RawBlock)>> {
+        match self {
+            Peer::Native(peer)   => peer.get_blocks(from, to),
+            Peer::Http(endpoint) => endpoint.get_blocks(from, to),
+        }
+    }
+
     fn fetch_epoch(&mut self, config: &config::net::Config, storage: &mut Storage, fep: FetchEpochParams) -> Result<FetchEpochResult> {
         match self {
             Peer::Native(peer)   => peer.fetch_epoch(config, storage, fep),

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -67,8 +67,8 @@ pub fn net_sync(net: &mut Api, net_cfg: &net::Config, storage: storage::Storage)
     // If our tip is in an epoch that has become stable, we now need
     // to pack it. So read the previously fetched blocks in this epoch
     // and prepend them to the incoming blocks.
-    if our_tip.0.date.get_epochid() < first_unstable_epoch {
-
+    if our_tip.0.date.get_epochid() < first_unstable_epoch && our_tip != genesis_ref
+    {
         let epoch_id = our_tip.0.date.get_epochid();
         let mut writer = storage::pack::PackWriter::init(&storage.config);
         let epoch_time_start = SystemTime::now();

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -63,6 +63,10 @@ pub fn net_sync(net: &mut Api, net_cfg: &net::Config, storage: storage::Storage)
     net.get_blocks(&our_tip.0, our_tip.1, &tip, &mut |block_hash, block, block_raw| {
         let date = block.get_header().get_blockdate();
 
+        // TODO: if we're finishing an epoch that was previously
+        // partially fetched (as separate blocks), we now need to load
+        // the previous blocks and pack the epoch.
+
         // Flush the previous epoch (if any).
         if date.is_genesis() {
             if let Some((epoch_id, writer, epoch_time_start)) = cur_epoch_state.as_mut() {

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -56,7 +56,7 @@ pub fn net_sync(net: &mut Api, net_cfg: &net::Config, storage: storage::Storage)
     let first_unstable_epoch = tip.date.get_epochid() -
         match tip.date {
             BlockDate::Genesis(_) => 1,
-            BlockDate::Normal(d) => if d.slotid <= net_cfg.epoch_stability_depth { 1 } else { 0 }
+            BlockDate::Normal(d) => if d.slotid as usize <= net_cfg.epoch_stability_depth { 1 } else { 0 }
         };
     info!("First unstable epoch : {}", first_unstable_epoch);
 

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -64,6 +64,11 @@ pub fn net_sync_fast(network: String, mut storage: storage::Storage) {
             upper_bound_hash: network_tip.clone(),
         };
         let result = net.fetch_epoch(&net_cfg, &mut storage, fep).unwrap();
+
+        storage::epoch::epoch_create(&storage.config, &result.packhash, download_epoch_id);
+
+        storage::refpack_epoch_pack(&storage, &format!("EPOCH_{}", download_epoch_id)).unwrap();
+
         download_prev_hash = result.last_header_hash.clone();
         download_start_hash = result.next_epoch_hash.unwrap_or(result.last_header_hash);
         download_epoch_id += 1;

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -70,8 +70,6 @@ pub fn net_sync(net: &mut Api, net_cfg: &net::Config, storage: storage::Storage)
 
                 storage::epoch::epoch_create(&storage.config, &packhash, *epoch_id);
 
-                storage::refpack_epoch_pack(&storage, &format!("EPOCH_{}", epoch_id)).unwrap();
-
                 // Checkpoint the tip so we don't have to refetch
                 // everything if we get interrupted.
                 storage::tag::write(&storage, &tag::HEAD, &last_block.as_ref().unwrap().bytes()[..]);

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -73,26 +73,16 @@ pub fn net_sync(net: &mut Api, net_cfg: &net::Config, storage: storage::Storage)
         let mut writer = storage::pack::PackWriter::init(&storage.config);
         let epoch_time_start = SystemTime::now();
 
-        let mut cur_hash = our_tip.0.hash.clone();
-        let mut blocks = vec![];
-        loop {
-            let block_raw = block_read(&storage, cur_hash.bytes()).unwrap();
-            let block = block_raw.decode().unwrap();
-            let hdr = block.get_header();
-            assert!(hdr.get_blockdate().get_epochid() == epoch_id);
-            blocks.push((storage::types::header_to_blockhash(&cur_hash), block_raw));
-            if hdr.get_blockdate().is_genesis() { break }
-            cur_hash = hdr.get_previous_header();
-        }
-
-        while let Some((hash, block_raw)) = blocks.pop() {
-            writer.append(&hash, block_raw.as_ref());
-        }
+        let prev_block = append_blocks_to_epoch_reverse(
+            &storage, epoch_id, &mut writer, &our_tip.0.hash);
 
         cur_epoch_state = Some((epoch_id, writer, epoch_time_start));
 
-        // FIXME: in fact we may need to pack the previous epoch as
-        // well. (If tip.slotid < w, it won't have been packed yet).
+        // If tip.slotid < w, the previous epoch won't have been
+        // created yet either, so do that now.
+        if epoch_id > net_cfg.epoch_start {
+            maybe_create_epoch(&storage, epoch_id - 1, &prev_block);
+        }
     }
 
     net.get_blocks(&our_tip.0, our_tip.1, &tip, &mut |block_hash, block, block_raw| {
@@ -101,21 +91,11 @@ pub fn net_sync(net: &mut Api, net_cfg: &net::Config, storage: storage::Storage)
         // Flush the previous epoch (if any).
         if date.is_genesis() {
             if let Some((epoch_id, writer, epoch_time_start)) = cur_epoch_state.as_mut() {
-                let (packhash, index) = writer.finalize();
-                let (_, tmpfile) = storage::pack::create_index(&storage, &index);
-                tmpfile.render_permanent(&storage.config.get_index_filepath(&packhash)).unwrap();
-                let epoch_time_elapsed = epoch_time_start.elapsed().unwrap();
-
-                storage::tag::write(&storage, &storage::tag::get_epoch_tag(*epoch_id), &packhash[..]);
-
-                storage::epoch::epoch_create(&storage.config, &packhash, *epoch_id);
+                finish_epoch(&storage, *epoch_id, writer, epoch_time_start);
 
                 // Checkpoint the tip so we don't have to refetch
                 // everything if we get interrupted.
                 storage::tag::write(&storage, &tag::HEAD, &last_block.as_ref().unwrap().bytes()[..]);
-
-                info!("=> pack {} written for epoch {} in {}", hex::encode(&packhash[..]),
-                      epoch_id, duration_print(epoch_time_elapsed));
             }
         }
 
@@ -145,6 +125,69 @@ pub fn net_sync(net: &mut Api, net_cfg: &net::Config, storage: storage::Storage)
         storage::tag::write(&storage, &tag::HEAD,
                             &storage::types::header_to_blockhash(&block_hash));
     }
+}
+
+// Create an epoch from a complete set of previously fetched blocks on
+// disk.
+fn maybe_create_epoch(storage: &storage::Storage, epoch_id: EpochId, last_block: &HeaderHash)
+{
+    // FIXME: epoch_read() is a bit inefficient here; we really only
+    // want to know if it exists.
+    if storage::epoch::epoch_read(&storage.config, epoch_id).is_ok() { return }
+
+    info!("Packing epoch {}", epoch_id);
+
+    let mut writer = storage::pack::PackWriter::init(&storage.config);
+    let epoch_time_start = SystemTime::now();
+
+    append_blocks_to_epoch_reverse(&storage, epoch_id, &mut writer, last_block);
+
+    finish_epoch(storage, epoch_id, &mut writer, &epoch_time_start);
+
+    // TODO: delete the blocks from disk?
+}
+
+fn append_blocks_to_epoch_reverse(
+    storage: &storage::Storage,
+    epoch_id : EpochId,
+    writer : &mut storage::pack::PackWriter,
+    last_block: &HeaderHash)
+    -> HeaderHash
+{
+    let mut cur_hash = last_block.clone();
+    let mut blocks = vec![];
+    loop {
+        let block_raw = block_read(&storage, cur_hash.bytes()).unwrap();
+        let block = block_raw.decode().unwrap();
+        let hdr = block.get_header();
+        assert!(hdr.get_blockdate().get_epochid() == epoch_id);
+        blocks.push((storage::types::header_to_blockhash(&cur_hash), block_raw));
+        cur_hash = hdr.get_previous_header();
+        if hdr.get_blockdate().is_genesis() { break }
+    }
+
+    while let Some((hash, block_raw)) = blocks.pop() {
+        writer.append(&hash, block_raw.as_ref());
+    }
+
+    cur_hash
+}
+
+fn finish_epoch(storage: &storage::Storage, epoch_id : EpochId, writer : &mut storage::pack::PackWriter, epoch_time_start : &SystemTime)
+{
+    let (packhash, index) = writer.finalize();
+    let (_, tmpfile) = storage::pack::create_index(&storage, &index);
+    tmpfile.render_permanent(&storage.config.get_index_filepath(&packhash)).unwrap();
+    let epoch_time_elapsed = epoch_time_start.elapsed().unwrap();
+
+    // TODO: should test that epoch <epoch_id - 1> exists.
+
+    storage::tag::write(&storage, &storage::tag::get_epoch_tag(epoch_id), &packhash[..]);
+
+    storage::epoch::epoch_create(&storage.config, &packhash, epoch_id);
+
+    info!("=> pack {} written for epoch {} in {}", hex::encode(&packhash[..]),
+          epoch_id, duration_print(epoch_time_elapsed));
 }
 
 pub fn get_peer(blockchain: &str, cfg: &net::Config, native: bool) -> Peer {

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -107,25 +107,11 @@ pub fn net_sync(net: &mut Api, net_cfg: &net::Config, storage: storage::Storage)
     }
 }
 
-pub fn net_sync_http(network: String, storage: storage::Storage) {
-    let netcfg_file = storage.config.get_config_file();
-    let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
-    let mut net = get_http_peer(network, &net_cfg);
-    net_sync(&mut net, &net_cfg, storage)
-}
-
-pub fn net_sync_native(network: String, storage: storage::Storage) {
-    let netcfg_file = storage.config.get_config_file();
-    let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
-    let mut net = get_native_peer(network, &net_cfg);
-    net_sync(&mut net, &net_cfg, storage)
-}
-
-pub fn get_http_peer(blockchain: String, cfg: &net::Config) -> Peer {
+pub fn get_peer(blockchain: &str, cfg: &net::Config, native: bool) -> Peer {
     for peer in cfg.peers.iter() {
-        if peer.is_http() {
+        if (native && peer.is_native()) || (!native && peer.is_http()) {
             return Peer::new(
-                blockchain,
+                String::from(blockchain),
                 peer.name().to_owned(),
                 peer.peer().clone(),
                 cfg.protocol_magic,
@@ -133,20 +119,5 @@ pub fn get_http_peer(blockchain: String, cfg: &net::Config) -> Peer {
         }
     }
 
-    panic!("no http peer to connect to")
-}
-
-pub fn get_native_peer(blockchain: String, cfg: &net::Config) -> Peer {
-    for peer in cfg.peers.iter() {
-        if peer.is_native() {
-            return Peer::new(
-                blockchain,
-                peer.name().to_owned(),
-                peer.peer().clone(),
-                cfg.protocol_magic,
-            ).unwrap();
-        }
-    }
-
-    panic!("no native peer to connect to")
+    panic!("no peer to connect to")
 }

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -4,11 +4,7 @@ use network::{api, Peer, api::Api};
 use storage;
 use utils::*;
 
-pub fn net_sync_fast(network: String, mut storage: storage::Storage) {
-    let netcfg_file = storage.config.get_config_file();
-    let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
-    let mut net = get_native_peer(network, &net_cfg);
-
+pub fn net_sync(net: &mut Api, net_cfg: &net::Config, mut storage: storage::Storage) {
     //let mut our_tip = tag::read_hash(&storage, &"TIP".to_string()).unwrap_or(genesis.clone());
 
     // recover and print the TIP of the network
@@ -20,14 +16,6 @@ pub fn net_sync_fast(network: String, mut storage: storage::Storage) {
     info!("Configured genesis-1 : {}", net_cfg.genesis_prev);
     info!("Network TIP is       : {}", network_tip);
     info!("Network TIP slotid   : {}", network_slotid);
-
-    // start from our tip towards network tip
-    /*
-    if &network_tip == &our_tip {
-        info!("Qapla ! already synchronised");
-        return ();
-    }
-    */
 
     // find the earliest epoch we know about starting from network_slotid
     let (latest_known_epoch_id, mstart_hash, prev_hash) =
@@ -65,6 +53,8 @@ pub fn net_sync_fast(network: String, mut storage: storage::Storage) {
         };
         let result = net.fetch_epoch(&net_cfg, &mut storage, fep).unwrap();
 
+        storage::tag::write(&storage, &storage::tag::get_epoch_tag(download_epoch_id), &result.packhash[..]);
+
         storage::epoch::epoch_create(&storage.config, &result.packhash, download_epoch_id);
 
         storage::refpack_epoch_pack(&storage, &format!("EPOCH_{}", download_epoch_id)).unwrap();
@@ -75,60 +65,18 @@ pub fn net_sync_fast(network: String, mut storage: storage::Storage) {
     }
 }
 
-pub fn net_sync_faster(network: String, mut storage: storage::Storage) {
+pub fn net_sync_http(network: String, storage: storage::Storage) {
     let netcfg_file = storage.config.get_config_file();
     let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
     let mut net = get_http_peer(network, &net_cfg);
+    net_sync(&mut net, &net_cfg, storage)
+}
 
-    //let mut our_tip = tag::read_hash(&storage, &"TIP".to_string()).unwrap_or(genesis.clone());
-
-    // recover TIP of the network
-    let mbh = net.get_tip().unwrap();
-    let network_slotid = mbh.get_blockdate();
-
-    info!("Configured genesis   : {}", net_cfg.genesis);
-    info!("Configured genesis-1 : {}", net_cfg.genesis_prev);
-
-    // find the earliest epoch we know about starting from network_slotid
-    let (latest_known_epoch_id, mstart_hash, prev_hash) =
-        match find_earliest_epoch(&storage, net_cfg.epoch_start, 100) {
-            // TODO
-            None => (
-                net_cfg.epoch_start,
-                Some(net_cfg.genesis.clone()),
-                net_cfg.genesis_prev.clone(),
-            ),
-            Some((found_epoch_id, packhash)) => (
-                found_epoch_id + 1,
-                None,
-                get_last_blockid(&storage.config, &packhash).unwrap(),
-            ),
-        };
-    info!(
-        "latest known epoch {} hash={:?}",
-        latest_known_epoch_id, mstart_hash
-    );
-
-    let mut download_epoch_id = latest_known_epoch_id;
-    let mut download_prev_hash = prev_hash.clone();
-    let mut download_start_hash = mstart_hash.or(Some(prev_hash)).unwrap();
-
-    while block::BlockDate::Genesis(download_epoch_id) <= network_slotid {
-        info!(
-            "downloading epoch {} {}",
-            download_epoch_id, download_start_hash
-        );
-        let fep = api::FetchEpochParams {
-            epoch_id: download_epoch_id,
-            start_header_hash: download_start_hash,
-            previous_header_hash: download_prev_hash,
-            upper_bound_hash: net_cfg.genesis_prev.clone(),
-        };
-        let result = net.fetch_epoch(&net_cfg, &mut storage, fep).unwrap();
-        download_prev_hash = result.last_header_hash.clone();
-        download_start_hash = result.next_epoch_hash.unwrap_or(result.last_header_hash);
-        download_epoch_id += 1;
-    }
+pub fn net_sync_native(network: String, storage: storage::Storage) {
+    let netcfg_file = storage.config.get_config_file();
+    let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
+    let mut net = get_native_peer(network, &net_cfg);
+    net_sync(&mut net, &net_cfg, storage)
 }
 
 pub fn get_http_peer(blockchain: String, cfg: &net::Config) -> Peer {

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -44,6 +44,10 @@ pub fn net_sync(net: &mut Api, net_cfg: &net::Config, storage: storage::Storage)
         }
     };
 
+    // TODO: we need to handle the case where our_tip is not an
+    // ancestor of tip. In that case we should start from the last
+    // stable epoch before our_tip.
+
     info!("Fetching from        : {} ({})", our_tip.0.hash, our_tip.0.date);
 
     // Determine whether the previous epoch is stable yet. Note: This

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -77,6 +77,7 @@ pub fn net_sync(net: &mut Api, net_cfg: &net::Config, storage: storage::Storage)
             &storage, epoch_id, &mut writer, &our_tip.0.hash);
 
         cur_epoch_state = Some((epoch_id, writer, epoch_time_start));
+        last_block = Some(our_tip.0.hash.clone());
 
         // If tip.slotid < w, the previous epoch won't have been
         // created yet either, so do that now.

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -56,7 +56,7 @@ pub fn net_sync(net: &mut Api, net_cfg: &net::Config, storage: storage::Storage)
     let first_unstable_epoch = tip.date.get_epochid() -
         match tip.date {
             BlockDate::Genesis(_) => 1,
-            BlockDate::Normal(d) => if d.slotid <= net_cfg.k { 1 } else { 0 }
+            BlockDate::Normal(d) => if d.slotid <= net_cfg.epoch_stability_depth { 1 } else { 0 }
         };
     info!("First unstable epoch : {}", first_unstable_epoch);
 

--- a/hermes/src/config.rs
+++ b/hermes/src/config.rs
@@ -39,7 +39,8 @@ type Result<T> = result::Result<T, Error>;
 pub struct Config {
     pub root_dir: PathBuf,
     pub port: u16,
-    pub network_names: HashSet<String>
+    pub network_names: HashSet<String>,
+    pub sync: bool,
 }
 
 impl Default for Config {
@@ -54,7 +55,8 @@ impl Config {
         Config {
             root_dir: root_dir,
             port: port,
-            network_names: HashSet::new()
+            network_names: HashSet::new(),
+            sync: true,
         }
     }
 

--- a/hermes/src/main.rs
+++ b/hermes/src/main.rs
@@ -63,6 +63,10 @@ fn main() {
                     .default_value("mainnet")
                     .possible_values(&["mainnet", "testnet"])
                 )
+                .arg(Arg::with_name("no-sync")
+                    .long("no-sync")
+                    .help("disable synchronizing with the upstream network")
+                )
         )
         .get_matches();
 
@@ -94,6 +98,8 @@ fn main() {
 
                 cfg.add_network(template, &net_cfg).unwrap();
             }
+
+            cfg.sync = !args.is_present("no-sync");
 
             info!("Starting {}-{}", crate_name!(), crate_version!());
             service::start(cfg);

--- a/hermes/src/service.rs
+++ b/hermes/src/service.rs
@@ -56,7 +56,7 @@ fn refresh_networks(networks: Networks) {
                 "Refresh for network {} failed: Unable to access storage",
                 label
             ),
-            Ok(storage) => sync::net_sync_fast(label, storage),
+            Ok(storage) => sync::net_sync_native(label, storage),
         }
     }
 }

--- a/hermes/src/service.rs
+++ b/hermes/src/service.rs
@@ -6,6 +6,7 @@ use router::Router;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
+use net;
 
 static NETWORK_REFRESH_FREQUENCY: Duration = Duration::from_secs(60 * 10);
 
@@ -56,7 +57,11 @@ fn refresh_networks(networks: Networks) {
                 "Refresh for network {} failed: Unable to access storage",
                 label
             ),
-            Ok(storage) => sync::net_sync_native(label, storage),
+            Ok(storage) => {
+                let netcfg_file = storage.config.get_config_file();
+                let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
+                sync::net_sync(&mut sync::get_peer(&label, &net_cfg, true), &net_cfg, storage)
+            }
         }
     }
 }

--- a/hermes/src/service.rs
+++ b/hermes/src/service.rs
@@ -11,7 +11,7 @@ use net;
 static NETWORK_REFRESH_FREQUENCY: Duration = Duration::from_secs(60 * 10);
 
 pub fn start(cfg: Config) {
-    let _refresher = start_networks_refresher(cfg.clone());
+    let _refresher = if cfg.sync { Some(start_networks_refresher(cfg.clone())) } else { None };
     let _server = start_http_server(&cfg, Arc::new(cfg.get_networks().unwrap()));
 
     // XXX: consider installing a signal handler to initiate a graceful shutdown here

--- a/protocol/src/packet.rs
+++ b/protocol/src/packet.rs
@@ -179,25 +179,15 @@ pub fn send_handshake(hs: &Handshake) -> Vec<u8> { cbor!(hs).unwrap() }
 type Message = (u8, Vec<u8>);
 
 pub enum MsgType {
-    MsgSubscribe,
-    MsgGetHeaders,
-    MsgGetBlocks,
-}
-
-impl MsgType {
-    pub fn to_u8(self) -> u8 {
-        match self {
-            MsgType::MsgSubscribe => 0xe,
-            MsgType::MsgGetHeaders => 0x4,
-            MsgType::MsgGetBlocks => 0x6,
-        }
-    }
+    MsgSubscribe = 0xe,
+    MsgGetHeaders = 0x4,
+    MsgGetBlocks = 0x6,
 }
 
 pub fn send_msg_subscribe(keep_alive: bool) -> Message {
     let value = if keep_alive { 43 } else { 42 };
     let dat = se::Serializer::new_vec().write_unsigned_integer(value).unwrap().finalize();
-    (0xe, dat)
+    (MsgType::MsgSubscribe as u8, dat)
 }
 
 pub fn send_msg_getheaders(froms: &[block::HeaderHash], to: &Option<block::HeaderHash>) -> Message {
@@ -211,7 +201,7 @@ pub fn send_msg_getheaders(froms: &[block::HeaderHash], to: &Option<block::Heade
         }
     };
     let dat = serializer.finalize();
-    (0x4, dat)
+    (MsgType::MsgGetHeaders as u8, dat)
 }
 
 pub fn send_msg_getblocks(from: &HeaderHash, to: &HeaderHash) -> Message {
@@ -219,7 +209,7 @@ pub fn send_msg_getblocks(from: &HeaderHash, to: &HeaderHash) -> Message {
         .serialize(from).unwrap()
         .serialize(to).unwrap()
         .finalize();
-    (0x6, dat)
+    (MsgType::MsgGetBlocks as u8, dat)
 }
 
 #[derive(Debug)]

--- a/wallet-cli/src/command/blockchain/mod.rs
+++ b/wallet-cli/src/command/blockchain/mod.rs
@@ -155,7 +155,7 @@ impl HasCommand for Blockchain {
                 let netcfg_file = config.get_storage_config().get_config_file();
                 let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
                 let b = sync::get_peer(&config.network, &net_cfg, opts.is_present("native"))
-                    .get_block(hh.clone()).unwrap().decode().unwrap();
+                    .get_block(&hh).unwrap().decode().unwrap();
                 let storage = config.get_storage().unwrap();
                 println!("got block: {}", b);
                 blob::write(&storage, hh.bytes(), &cbor!(&b).unwrap()).unwrap();

--- a/wallet-cli/src/command/blockchain/mod.rs
+++ b/wallet-cli/src/command/blockchain/mod.rs
@@ -145,7 +145,7 @@ impl HasCommand for Blockchain {
                 let netcfg_file = config.get_storage_config().get_config_file();
                 let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
                 let mbh = sync::get_peer(&config.network, &net_cfg, opts.is_present("native")).get_tip().unwrap();
-                println!("tip: {} {}", mbh, mbh.get_blockdate());
+                println!("tip: {} {} {}", mbh.compute_hash(), mbh.get_blockdate(), mbh);
             },
             ("get-block", Some(opts)) => {
                 let config = resolv_network_by_name(&opts);
@@ -156,8 +156,8 @@ impl HasCommand for Blockchain {
                 let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
                 let b = sync::get_peer(&config.network, &net_cfg, opts.is_present("native"))
                     .get_block(&hh).unwrap().decode().unwrap();
+                println!("got block: {} {}", b.get_header().get_blockdate(), b);
                 let storage = config.get_storage().unwrap();
-                println!("got block: {}", b);
                 blob::write(&storage, hh.bytes(), &cbor!(&b).unwrap()).unwrap();
             },
             ("sync", Some(opts)) => {

--- a/wallet-cli/src/command/blockchain/mod.rs
+++ b/wallet-cli/src/command/blockchain/mod.rs
@@ -154,7 +154,7 @@ impl HasCommand for Blockchain {
                 let netcfg_file = config.get_storage_config().get_config_file();
                 let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
                 let mut net = sync::get_native_peer(config.network.clone(), &net_cfg);
-                let b = net.get_block(hh.clone()).unwrap();
+                let b = net.get_block(hh.clone()).unwrap().decode().unwrap();
                 let storage = config.get_storage().unwrap();
                 blob::write(&storage, hh.bytes(), &cbor!(&b).unwrap()).unwrap();
             },

--- a/wallet-cli/src/command/blockchain/mod.rs
+++ b/wallet-cli/src/command/blockchain/mod.rs
@@ -345,19 +345,20 @@ impl HasCommand for Blockchain {
 
                 let netcfg_file = config.get_storage_config().get_config_file();
                 let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
-                let mut prev = net_cfg.genesis_prev;
+                let mut prev = None;
 
-                let mut iter = storage.iterate_from_epoch(0).unwrap();
-                //let mut iter = storage.reverse_iter().unwrap();
+                let mut iter = storage.reverse_iter().unwrap();
 
                 while let Some(blk) = iter.next() {
                     let hdr = blk.get_header();
                     let date = hdr.get_blockdate();
                     let hash = hdr.compute_hash();
                     println!("block {} {:?}", hash, date);
-                    assert!(prev == hdr.get_previous_header());
-                    prev = hash;
+                    if let Some(h) = prev { assert!(hash == h) }
+                    prev = Some(hdr.get_previous_header());
                 }
+
+                if let Some(h) = prev { assert!(net_cfg.genesis_prev == h) }
             },
 
             (find_address::FindAddress::COMMAND, Some(opts)) => find_address::FindAddress::run((), opts),

--- a/wallet-cli/src/command/blockchain/mod.rs
+++ b/wallet-cli/src/command/blockchain/mod.rs
@@ -50,6 +50,7 @@ impl HasCommand for Blockchain {
             .subcommand(SubCommand::with_name("sync")
                 .about("get the next block repeatedly (deprecated will be replaced soon).")
                 .arg(blockchain_name_arg(1))
+                .arg(Arg::with_name("native").long("native").help("use native protocol rather than HTTP"))
             )
             .subcommand(SubCommand::with_name("cat")
                 .about("show content of a block")
@@ -159,7 +160,10 @@ impl HasCommand for Blockchain {
             },
             ("sync", Some(opts)) => {
                 let config = resolv_network_by_name(&opts);
-                sync::net_sync_faster(config.network.clone(), config.get_storage().unwrap())
+                match opts.is_present("native") {
+                    true => sync::net_sync_native(config.network.clone(), config.get_storage().unwrap()),
+                    false => sync::net_sync_http(config.network.clone(), config.get_storage().unwrap())
+                }
             },
             ("debug-index", Some(opts)) => {
                 let config = resolv_network_by_name(&opts);


### PR DESCRIPTION
This adds the following improvements:

* It can synchronize up to the current tip, rather than just fetching entire epochs. Thus it will fetch individual blocks from the current epoch and store them as separate blobs on disk. When on a subsequent sync we have an entire epoch of blocks, they'll be packed into an epoch on disk.

* It respects the blockchain parameter 'k'. Thus it won't pack blocks into an epoch until we're at least k blocks into the next epoch.

* It maintains the `HEAD` tag to point to the most recently fetched tip. So it no longer relies on epochs to figure out from where to restart synchronization. In the future, we'll want a tip per peer (and probably a tag to point to the latest "stable" block).

* `ariadne blockchain sync` now has a flag `--native` to force it to sync using a native peer rather than a Hermes peer. This is useful for testing the native protocol.

* Unrelated, added for testing: a command `ariadne ls-blocks` to list the blocks in the blockchain.

Note that I changed `network::Api`: it no longer has a `fetch_epoch()` function. Instead, it has a `get_blocks()` function that fetches an arbitrary range of blocks. In the case of Hermes, this is optimized by fetching blocks in epochs, but that's an implementation detail that the caller doesn't need to know about. The reason for this change is that it simplifies `net_sync()` and `network::Api`, and it prevents the network layer from having a dependency on the storage layer.

Some limitations:

* It doesn't handle divergence yet: if the local tip is not an ancestor of the remote tip, it will barf. Obviously we'll need to handle this in the future (probably by restarting the sync from the latest stable block).

* Fetching the individual blocks in the current epoch from Hermes could be slow on a high-latency connection.