### PR TITLE
remote-ls: display some details regarding the remotes associated to a given wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,7 @@ dependencies = [
  "dirs 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "exe-common 0.1.0",
+ "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cardano-cli/Cargo.toml
+++ b/cardano-cli/Cargo.toml
@@ -17,6 +17,7 @@ serde_derive = "1.0"
 serde_yaml = "0.7"
 rpassword = "2.0"
 env_logger = "0.5.11"
+humantime = "1.1"
 cryptoxide = { path = "../cryptoxide" }
 cardano = { path = "../cardano" }
 exe-common = { path = "../exe-common" }

--- a/cardano-cli/src/blockchain/mod.rs
+++ b/cardano-cli/src/blockchain/mod.rs
@@ -12,6 +12,7 @@ use cardano::block;
 ///
 pub struct Blockchain {
     pub name: String,
+    pub dir: PathBuf,
     pub storage_config: StorageConfig,
     pub storage: Storage,
     pub config: Config,
@@ -35,6 +36,7 @@ impl Blockchain {
 
         Blockchain {
             name,
+            dir,
             storage_config,
             storage,
             config,
@@ -52,6 +54,7 @@ impl Blockchain {
 
         Blockchain {
             name,
+            dir,
             storage_config,
             storage,
             config

--- a/cardano-cli/src/blockchain/peer.rs
+++ b/cardano-cli/src/blockchain/peer.rs
@@ -17,7 +17,7 @@ impl<'a> Deref for ConnectedPeer<'a> {
 }
 impl<'a> ConnectedPeer<'a> {
     /// get the remote tip
-    fn query_tip(&mut self) -> BlockRef {
+    pub fn query_tip(&mut self) -> BlockRef {
         let tip_header = self.connection.get_tip().unwrap();
         BlockRef {
             hash: tip_header.compute_hash(),
@@ -135,16 +135,15 @@ impl<'a> ConnectedPeer<'a> {
 pub struct Peer<'a> {
     /// keep a reference to the upper blockchain, we will need to drop
     /// the peer before finalising the blockchain
-    blockchain: &'a super::Blockchain,
+    pub blockchain: &'a super::Blockchain,
 
     // we obviously need it in order to connect to a given configuration
-    config: exe_common::config::net::Peer,
+    pub config: exe_common::config::net::Peer,
 
     // the name of the peer
-    name: String,
+    pub name: String,
 
-    tag: String,
-
+    pub tag: String,
 }
 impl<'a> Peer<'a> {
     pub fn prepare(blockchain: &'a super::Blockchain, name: String) -> Self {
@@ -186,7 +185,7 @@ impl<'a> Peer<'a> {
     }
 
     /// load the peer current block
-    fn load_peer_local_tip(&self) -> HeaderHash {
+    pub fn load_peer_local_tip(&self) -> HeaderHash {
         match tag::read_hash(&self.blockchain.storage, &self.tag) {
             None => panic!("expecting any peer to have a tag"),
             Some(hh) => hh
@@ -203,7 +202,7 @@ impl<'a> Peer<'a> {
     }
 
     /// get the remote local tip. the bool is to note if the tip is the same as genesis
-    fn load_local_tip(&self) -> (BlockRef, bool) {
+    pub fn load_local_tip(&self) -> (BlockRef, bool) {
         let genesis_ref = (BlockRef {
             hash: self.blockchain.config.genesis.clone(),
             parent: self.blockchain.config.genesis_prev.clone(),

--- a/cardano-cli/src/lib.rs
+++ b/cardano-cli/src/lib.rs
@@ -9,6 +9,7 @@ extern crate serde_yaml;
 extern crate rand;
 #[macro_use]
 extern crate log;
+extern crate humantime;
 
 pub mod utils;
 pub mod blockchain;

--- a/cardano-cli/src/main.rs
+++ b/cardano-cli/src/main.rs
@@ -240,6 +240,20 @@ fn subcommand_blockchain<'a>(mut term: term::Term, root_dir: PathBuf, matches: &
 
             blockchain::commands::remote_fetch(term, root_dir, name, peers);
         },
+        ("remote-ls", Some(matches)) => {
+            let name = blockchain_argument_name_match(&matches);
+            let detailed = if matches.is_present("REMOTE_LS_DETAILED_SHORT") {
+                blockchain::commands::RemoteDetail::Short
+            } else if matches.is_present("REMOTE_LS_DETAILED_LOCAL") {
+                blockchain::commands::RemoteDetail::Local
+            } else if matches.is_present("REMOTE_LS_DETAILED_REMOTE") {
+                blockchain::commands::RemoteDetail::Remote
+            } else {
+                blockchain::commands::RemoteDetail::Short
+            };
+
+            blockchain::commands::remote_ls(term, root_dir, name, detailed);
+        },
         _ => {
             term.error(matches.usage()).unwrap();
             ::std::process::exit(1)
@@ -271,6 +285,28 @@ fn blockchain_commands_definition<'a, 'b>() -> App<'a, 'b> {
             .arg(blockchain_argument_remote_alias_definition()
                 .multiple(true) // we want to accept multiple aliases here too
                 .required(false) // we allow user not to set any values here
+            )
+        )
+        .subcommand(SubCommand::with_name("remote-ls")
+            .about("List all the remote nodes of the given blockchain")
+            .arg(blockchain_argument_name_definition())
+            .arg(Arg::with_name("REMOTE_LS_DETAILED_SHORT")
+                .long("--short")
+                .group("REMOTE_LS_DETAILED")
+                .required(false)
+                .help("print only the bare minimum information regarding the remotes (default)")
+            )
+            .arg(Arg::with_name("REMOTE_LS_DETAILED_LOCAL")
+                .long("--detailed")
+                .group("REMOTE_LS_DETAILED")
+                .required(false)
+                .help("print all local known information regarding the remotes")
+            )
+            .arg(Arg::with_name("REMOTE_LS_DETAILED_REMOTE")
+                .long("--complete")
+                .group("REMOTE_LS_DETAILED")
+                .required(false)
+                .help("print all local known information regarding the remotes as well as the details from the remote (needs a network connection)")
             )
         )
         .subcommand(SubCommand::with_name("forward")

--- a/cardano-cli/src/utils/term/mod.rs
+++ b/cardano-cli/src/utils/term/mod.rs
@@ -96,7 +96,7 @@ impl Term {
     }
     pub fn warn(&mut self, msg: &str) -> io::Result<()> {
         if self.config.quiet { return Ok(()); }
-        let mut out = self.stderr.lock();
+        let mut out = self.stdout.lock();
 
         out.set_color(ColorSpec::new().set_fg(Some(Color::Rgb(0xFF, 0xA5, 00))))?;
         write!(&mut out, "{}", msg)?;
@@ -104,7 +104,7 @@ impl Term {
     }
     pub fn error(&mut self, msg: &str) -> io::Result<()> {
         if self.config.quiet { return Ok(()); }
-        let mut out = self.stderr.lock();
+        let mut out = self.stdout.lock();
 
         out.set_color(ColorSpec::new().set_fg(Some(Color::Red)))?;
         write!(&mut out, "{}", msg)?;

--- a/protocol/src/ntt.rs
+++ b/protocol/src/ntt.rs
@@ -57,7 +57,7 @@ impl<W: Sized+Write+Read> Connection<W> {
             0xffffffff => Err(Error::UnsupportedVersion),
             0x00000001 => Err(Error::InvalidRequest),
             0x00000002 => Err(Error::CrossedRequest),
-            0x00000000 => { println!("HANDSHAKE OK"); Ok(conn) },
+            0x00000000 => { info!("HANDSHAKE OK"); Ok(conn) },
             v          => Err(Error::UnknownErrorCode(v)),
         }
     }
@@ -276,7 +276,7 @@ pub mod protocol {
         buf.push(v as u8);
     }
     */
-    
+
     fn append_u32(v: u32, buf: &mut Vec<u8>) {
         buf.push((v >> 24) as u8);
         buf.push((v >> 16) as u8);


### PR DESCRIPTION
3 level of details:

* short: only print the alias of the remote and the end point;
* detailed: short + details of the local tip (blockhash, last fetch, block date);
* complete: detailed + remote node details (need internet connection).

sneak pick:

<img width="463" alt="capture" src="https://user-images.githubusercontent.com/5445840/43596153-5fb676e0-9676-11e8-8e69-e53c16bfceaf.PNG">

This is an unplanned command, but it will be useful for user (short and detailed) and useful for debugging the blockchain/tooling (complete).