### PR TITLE
PeerPool: Create only one connection for now

### DIFF
--- a/exe-common/src/network/native.rs
+++ b/exe-common/src/network/native.rs
@@ -27,7 +27,10 @@ impl PeerPool {
         let mut connections = Vec::new();
         for sockaddr in address.to_socket_addrs()? {
             match Connection::new(sockaddr, protocol_magic) {
-                Ok(connection) => connections.push(connection),
+                Ok(connection) => {
+                    connections.push(connection);
+                    break
+                },
                 Err(Error::ConnectionTimedOut) => {
                     warn!("connection peer `{}' address {} timed out, ignoring for now.", name, sockaddr)
                 },


### PR DESCRIPTION
Since PeerPool currently only uses the first connection anyway, it
just slows down startup to create the other connections.

(This gets rid of the multiple `HANDSHAKE OK` messages at startup.)