### PR TITLE
exe-common::sync: Hot-fix a u32 underflow panic

### DIFF
--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -234,7 +234,14 @@ fn finish_epoch(storage: &storage::Storage, epoch_writer_state: &mut EpochWriter
     tmpfile.render_permanent(&storage.config.get_index_filepath(&packhash)).unwrap();
     let epoch_time_elapsed = epoch_writer_state.write_start_time.elapsed().unwrap();
 
-    assert!(epoch_id > 0 || epoch_exists(storage, epoch_id - 1));
+    if epoch_id > 0 {
+        assert!(
+            epoch_exists(storage, epoch_id - 1),
+            "Attempted finish_epoch() with non-existent previous epoch (ID {}, previous' ID {})",
+            epoch_id,
+            epoch_id - 1
+        );
+    }
 
     storage::epoch::epoch_create(&storage.config, &packhash, epoch_id);
 


### PR DESCRIPTION
This was originally found on a first run of Hermes which would catch the
underflow on the genesis epoch. The finish_epoch() function would use an
imprecise logical expression to determine that the specified epoch has a
predecessor.

This commit fixes the underflow which would happen for
epoch_id equal to 0 a.k.a. genesis.

I don't think this is the correct way to handle this, because I believe
the sync module is inconsistent. It assumes in finish_epoch() that
`previous_epoch_id(N) == N - 1` always holds true and therefore that the
genesis epoch ID is always 0, while at the same time other parts of the
code use different methods than checking the ID to check for genesis
(e.g. `is_genesis()` on block date).

**What do you think should be the definitive way to determine the epoch
that's allowed not to have a predecessor?**