### PR TITLE
Fix all warnings in cardano-cli

### DIFF
--- a/cardano-cli/src/blockchain/commands.rs
+++ b/cardano-cli/src/blockchain/commands.rs
@@ -1,8 +1,7 @@
 use std::path::PathBuf;
 use std::io::{Write};
 
-use exe_common::{config::net::{Config, Peer, Peers}, sync, network};
-use exe_common::network::api::BlockRef;
+use exe_common::config::net::Config;
 
 use utils::term::Term;
 
@@ -75,7 +74,7 @@ pub fn remote_fetch( mut term: Term
                    , peers: Vec<String>
                    )
 {
-    let mut blockchain = Blockchain::load(root_dir, name);
+    let blockchain = Blockchain::load(root_dir, name);
 
     for np in blockchain.peers() {
         if peers.is_empty() || peers.contains(&np.name().to_owned()) {
@@ -162,7 +161,7 @@ pub fn forward( mut term: Term
               , to: Option<String>
               )
 {
-    let mut blockchain = Blockchain::load(root_dir, name);
+    let blockchain = Blockchain::load(root_dir, name);
 
     let hash = if let Some(hash_hex) = to {
         let hash = super::config::parse_block_hash(&mut term, &hash_hex);

--- a/cardano-cli/src/blockchain/peer.rs
+++ b/cardano-cli/src/blockchain/peer.rs
@@ -3,9 +3,9 @@ use exe_common;
 use exe_common::network::{api::Api, api::BlockRef};
 use cardano::block::{BlockDate, EpochId, HeaderHash};
 use utils::term::Term;
-use storage::{self, tag, Storage, config::{StorageConfig}};
+use storage::{self, tag};
 use std::ops::Deref;
-use std::time::{SystemTime, Duration};
+use std::time::SystemTime;
 
 pub struct ConnectedPeer<'a> {
     peer: Peer<'a>,
@@ -288,13 +288,10 @@ impl<'a> Peer<'a> {
 }
 
 mod internal {
-    use storage::{self, tag, Error, block_read};
-    use cardano::block::{BlockDate, EpochId, HeaderHash};
+    use storage::{self, block_read};
+    use cardano::block::{EpochId, HeaderHash};
     use cardano::util::{hex};
     use std::time::{SystemTime, Duration};
-
-    use exe_common::config::net;
-    use exe_common::network::{Peer, api::Api, api::BlockRef};
 
     fn duration_print(d: Duration) -> String {
         format!("{}.{:03} seconds", d.as_secs(), d.subsec_millis())


### PR DESCRIPTION
This PR removes all warnings coming from cardano-cli. I didn't know what might
be your preference in terms of smashing particular warning kinds so I only did
this for the one crate.

**Note:** I made some arguable decisions like removing one unused method in
cardano-cli/src/blockchain/peer.rs or the unused stderr field from the Term
struct in cardano-cli/src/utils/term/mod.rs. I hope I connected the dots alright
on these two.