### PR TITLE
Ntt cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,22 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "num-derive"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "num_cpus"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +737,8 @@ dependencies = [
  "cardano 0.1.0",
  "cbor_event 0.1.0",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1441,6 +1459,8 @@ dependencies = [
 "checksum modifier 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41f5c9112cb662acd3b204077e0de5bc66305fa8df65c8019d5adb10e9ab6e58"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
+"checksum num-derive 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d2c31b75c36a993d30c7a13d70513cb93f02acafdd5b7ba250f9b0e18615de7"
+"checksum num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "630de1ef5cc79d0cdd78b7e33b81f083cbfe90de0f4b2b2f07f905867c70e9fe"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "901d6514273469bb17380c1ac3f51fb3ce54be1f960e51a6f04901eba313ab8d"

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -12,3 +12,5 @@ keywords = [ "Cardano", "Protocol" ]
 cbor_event = { path = "../cbor_event" }
 cardano = { path = "../cardano" }
 log = "0.4"
+num-traits = "0.2.5"
+num-derive = "0.2.2"

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -3,6 +3,9 @@ extern crate cardano;
 extern crate log;
 #[macro_use]
 extern crate cbor_event;
+#[macro_use]
+extern crate num_derive;
+extern crate num_traits;
 
 pub mod ntt;
 pub mod packet;

--- a/protocol/src/ntt.rs
+++ b/protocol/src/ntt.rs
@@ -244,16 +244,16 @@ pub mod protocol {
         // Given a ACK nodeid, get the equivalent SYN nodeid
         pub fn ack_to_syn(&self) -> Self {
             assert!(self.0[0] == NODEID_ACK);
-            let nodeid = self.clone();
-            nodeid.0[0] == NODEID_SYN;
+            let mut nodeid = self.clone();
+            nodeid.0[0] = NODEID_SYN;
             nodeid
         }
 
         // Given a SYN nodeid, get the equivalent ACK nodeid
         pub fn syn_to_ack(&self) -> Self {
             assert!(self.0[0] == NODEID_SYN);
-            let nodeid = self.clone();
-            nodeid.0[0] == NODEID_ACK;
+            let mut nodeid = self.clone();
+            nodeid.0[0] = NODEID_ACK;
             nodeid
         }
     }

--- a/protocol/src/protocol.rs
+++ b/protocol/src/protocol.rs
@@ -177,7 +177,7 @@ impl<T: Write+Read> Connection<T> {
 
         self.client_cons.insert(lcid, lc);
 
-        /* wait answer from server, which should a new light connection creation,
+        /* wait answer from server, which should be a new light connection creation,
          * followed by the handshake data and then the node id
          */
         let siv = match self.ntt.recv()? {


### PR DESCRIPTION
Some minor cleanups to the network code while I was working on the subscription code: 1) Fix `ack_to_syn` and `syn_to_ack`; and 2) turn `ControlHeader` into an explicitly numbered enum to remove the need for `control_header_{to,from}_u32`.