### PR TITLE
Appveyor CI

### DIFF
--- a/.ci/before_deploy.ps1
+++ b/.ci/before_deploy.ps1
@@ -1,0 +1,27 @@
+# Based on the "trust" template v0.1.2
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://github.com/japaric/trust/tree/v0.1.2/LICENSE-MIT
+
+# This script takes care of packaging the build artifacts that will go in the
+# release zipfile
+
+$SRC_DIR = $PWD.Path
+$STAGE = [System.Guid]::NewGuid().ToString()
+
+Set-Location $ENV:Temp
+New-Item -Type Directory -Name $STAGE
+Set-Location $STAGE
+
+$ZIP = "$SRC_DIR\$($Env:CRATE_NAME)-$($Env:APPVEYOR_REPO_TAG_NAME)-$($Env:TARGET).zip"
+
+# TODO Update this to package the right artifacts
+Copy-Item "$SRC_DIR\target\$($Env:TARGET)\release\hello.exe" '.\'
+
+7z a "$ZIP" *
+
+Push-AppveyorArtifact "$ZIP"
+
+Remove-Item *.* -Force
+Set-Location ..
+Remove-Item $STAGE
+Set-Location $SRC_DIR

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/input-output-hk/rust-cardano.svg?branch=master)](https://travis-ci.org/input-output-hk/rust-cardano)
+[![Build status](https://ci.appveyor.com/api/projects/status/awho7gyd988djosg?svg=true)](https://ci.appveyor.com/project/zondax/rust-cardano)
 
 # rust implementation of cardano wallet and crypto
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,9 +88,9 @@ branches:
     - /^v\d+\.\d+\.\d+.*$/
     - master
 
-notifications:
-  - provider: Email
-    on_build_success: false
+#notifications:
+#  - provider: Email
+#    on_build_success: false
 
 # Building is done in the test phase, so we disable Appveyor's build phase.
 build: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,31 +8,30 @@ environment:
     CRATE_NAME: rust-cardano
 
   matrix:
-    # MinGW
-    - TARGET: i686-pc-windows-gnu
-    - TARGET: x86_64-pc-windows-gnu
+    # MinGW i686 - Enable?
+#    - TARGET: i686-pc-windows-gnu
+#    - TARGET: i686-pc-windows-gnu
+#      RUST_VERSION: beta
+#    - TARGET: i686-pc-windows-gnu
+#      RUST_VERSION: nightly
 
-    - TARGET: i686-pc-windows-gnu
-      RUST_VERSION: beta
-    - TARGET: x86_64-pc-windows-gnu
-      RUST_VERSION: beta
+    # MinGW x86_64 - Enable?
+#    - TARGET: x86_64-pc-windows-gnu
+#    - TARGET: x86_64-pc-windows-gnu
+#      RUST_VERSION: beta
+#    - TARGET: x86_64-pc-windows-gnu
+#      RUST_VERSION: nightly
 
-    - TARGET: i686-pc-windows-gnu
-      RUST_VERSION: nightly
-    - TARGET: x86_64-pc-windows-gnu
-      RUST_VERSION: nightly
+    # MSVC i686 - Enable?
+#    - TARGET: i686-pc-windows-msvc
+#    - TARGET: i686-pc-windows-msvc
+#      RUST_VERSION: beta
+#    - TARGET: i686-pc-windows-msvc
+#      RUST_VERSION: nightly
 
-    # MSVC
-    - TARGET: i686-pc-windows-msvc
     - TARGET: x86_64-pc-windows-msvc
-
-    - TARGET: i686-pc-windows-msvc
-      RUST_VERSION: beta
     - TARGET: x86_64-pc-windows-msvc
       RUST_VERSION: beta
-
-    - TARGET: i686-pc-windows-msvc
-      RUST_VERSION: nightly
     - TARGET: x86_64-pc-windows-msvc
       RUST_VERSION: nightly
 
@@ -52,12 +51,8 @@ install:
 test_script:
   # we don't run the "test phase" when doing deploys
   - if [%APPVEYOR_REPO_TAG%]==[false] (
-      cargo build --target %TARGET% &&
-      cargo build --target %TARGET% --release &&
-      cargo test --target %TARGET% &&
-      cargo test --target %TARGET% --release &&
-      cargo run --target %TARGET% &&
-      cargo run --target %TARGET% --release
+      cargo build --verbose --all &&
+      cargo test --verbose --all
     )
 
 #before_deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,7 +63,7 @@ test_script:
 #before_deploy:
 #  # TODO Update this to build the artifacts that matter to you
 #  - cargo rustc --target %TARGET% --release --bin hello -- -C lto
-#  - ps: ci\before_deploy.ps1
+#  - ps: .ci\before_deploy.ps1
 #
 # deploy:
 #   artifact: /.*\.zip/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,101 @@
+# Based on the "trust" template v0.1.2
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://github.com/japaric/trust/tree/v0.1.2/LICENSE-MIT
+
+environment:
+  global:
+    RUST_VERSION: stable
+    CRATE_NAME: rust-cardano
+
+  matrix:
+    # MinGW
+    - TARGET: i686-pc-windows-gnu
+    - TARGET: x86_64-pc-windows-gnu
+
+    - TARGET: i686-pc-windows-gnu
+      RUST_VERSION: beta
+    - TARGET: x86_64-pc-windows-gnu
+      RUST_VERSION: beta
+
+    - TARGET: i686-pc-windows-gnu
+      RUST_VERSION: nightly
+    - TARGET: x86_64-pc-windows-gnu
+      RUST_VERSION: nightly
+
+    # MSVC
+    - TARGET: i686-pc-windows-msvc
+    - TARGET: x86_64-pc-windows-msvc
+
+    - TARGET: i686-pc-windows-msvc
+      RUST_VERSION: beta
+    - TARGET: x86_64-pc-windows-msvc
+      RUST_VERSION: beta
+
+    - TARGET: i686-pc-windows-msvc
+      RUST_VERSION: nightly
+    - TARGET: x86_64-pc-windows-msvc
+      RUST_VERSION: nightly
+
+install:
+  - ps: >-
+      If ($Env:TARGET -eq 'x86_64-pc-windows-gnu') {
+        $Env:PATH += ';C:\msys64\mingw64\bin'
+      } ElseIf ($Env:TARGET -eq 'i686-pc-windows-gnu') {
+        $Env:PATH += ';C:\msys64\mingw32\bin'
+      }
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+  - rustup-init.exe -y --default-host %TARGET% --default-toolchain %RUST_VERSION%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -Vv
+  - cargo -V
+
+test_script:
+  # we don't run the "test phase" when doing deploys
+  - if [%APPVEYOR_REPO_TAG%]==[false] (
+      cargo build --target %TARGET% &&
+      cargo build --target %TARGET% --release &&
+      cargo test --target %TARGET% &&
+      cargo test --target %TARGET% --release &&
+      cargo run --target %TARGET% &&
+      cargo run --target %TARGET% --release
+    )
+
+#before_deploy:
+#  # TODO Update this to build the artifacts that matter to you
+#  - cargo rustc --target %TARGET% --release --bin hello -- -C lto
+#  - ps: ci\before_deploy.ps1
+#
+# deploy:
+#   artifact: /.*\.zip/
+#   # TODO update `auth_token.secure`
+#   # - Create a `public_repo` GitHub token. Go to: https://github.com/settings/tokens/new
+#   # - Encrypt it. Go to https://ci.appveyor.com/tools/encrypt
+#   # - Paste the output down here
+#   auth_token:
+#     secure: t3puM/2hOig26EHhAodcZBc61NywF7/PFEpimR6SwGaCiqS07KR5i7iAhSABmBp7
+#   description: ''
+#   on:
+#     # TODO Here you can pick which targets will generate binary releases
+#     # In this example, there are some targets that are tested using the stable
+#     # and nightly channels. This condition makes sure there is only one release
+#     # for such targets and that's generated using the stable channel
+#     RUST_VERSION: stable
+#     appveyor_repo_tag: true
+#   provider: GitHub
+
+cache:
+  - C:\Users\appveyor\.cargo\registry
+  - target
+
+branches:
+  only:
+    # Release tags
+    - /^v\d+\.\d+\.\d+.*$/
+    - master
+
+notifications:
+  - provider: Email
+    on_build_success: false
+
+# Building is done in the test phase, so we disable Appveyor's build phase.
+build: false


### PR DESCRIPTION
Appveyor CI - Issue https://github.com/input-output-hk/rust-cardano/issues/139

I was not sure what arch/compilers you wanted to test so the following are temporarily disabled:

- MinGW i686
- MinGW x86_64
- MSVC i686

At the moment, it will run `x86_64-pc-windows-msvc` in `{stable, beta, nightly}`

Once the PR is merged, it is necessary to update the key in the badge.

Here is an example of the CI in my fork: https://ci.appveyor.com/project/zondax/rust-cardano/history