### PR TITLE
 Add magic + version number to all binary files

### DIFF
--- a/cardano-cli/src/blockchain/iter/epoch.rs
+++ b/cardano-cli/src/blockchain/iter/epoch.rs
@@ -58,7 +58,7 @@ impl<'a> Iterator for Epochs<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let r = epoch_open_pack_reader(&self.storage_config, self.epoch_id);
         match r {
-            Err(e) => { Some(Err(Error::IoError(e))) },
+            Err(e) => { Some(Err(Error::StorageError(e))) },
             Ok(None) => { None },
             Ok(Some(r)) => {
                 let iter = Iter(r);

--- a/cardano-cli/src/blockchain/iter/error.rs
+++ b/cardano-cli/src/blockchain/iter/error.rs
@@ -1,13 +1,17 @@
 #[derive(Debug)]
 pub enum Error {
     IoError(::std::io::Error),
-    CborError(::cbor_event::Error)
+    CborError(::cbor_event::Error),
+    StorageError(::storage::Error),
 }
 impl From<::std::io::Error> for Error {
     fn from(e: ::std::io::Error) -> Self { Error::IoError(e) }
 }
 impl From<::cbor_event::Error> for Error {
     fn from(e: ::cbor_event::Error) -> Self { Error::CborError(e) }
+}
+impl From<::storage::Error> for Error {
+    fn from(e: ::storage::Error) -> Self { Error::StorageError(e) }
 }
 
 pub type Result<T> = ::std::result::Result<T, Error>;

--- a/cardano-cli/src/blockchain/peer.rs
+++ b/cardano-cli/src/blockchain/peer.rs
@@ -107,7 +107,7 @@ impl<'a> ConnectedPeer<'a> {
             && !internal::epoch_exists(&peer.blockchain.storage, best_tip.0.date.get_epochid())
         {
             let epoch_id = best_tip.0.date.get_epochid();
-            let mut writer = storage::pack::packwriter_init(&peer.blockchain.storage.config);
+            let mut writer = storage::pack::packwriter_init(&peer.blockchain.storage.config).unwrap();
             let epoch_time_start = SystemTime::now();
 
             let prev_block = internal::append_blocks_to_epoch_reverse(
@@ -174,7 +174,11 @@ impl<'a> ConnectedPeer<'a> {
 
                 // If this is the epoch genesis block, start writing a new epoch pack.
                 if date.is_genesis() {
-                    cur_epoch_state = Some((date.get_epochid(), storage::pack::packwriter_init(&peer.blockchain.storage.config), SystemTime::now()));
+                    cur_epoch_state = Some((
+                        date.get_epochid(),
+                        storage::pack::packwriter_init(&peer.blockchain.storage.config).unwrap(),
+                        SystemTime::now()
+                    ));
                 }
 
                 // And append the block to the epoch pack.
@@ -309,7 +313,7 @@ mod internal {
 
         info!("Packing epoch {}", epoch_id);
 
-        let mut writer = storage::pack::packwriter_init(&storage.config);
+        let mut writer = storage::pack::packwriter_init(&storage.config).unwrap();
         let epoch_time_start = SystemTime::now();
 
         append_blocks_to_epoch_reverse(&storage, epoch_id, &mut writer, last_block);

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -85,7 +85,7 @@ fn net_sync_to<A: Api>(
 
         epoch_writer_state = Some(EpochWriterState {
             epoch_id,
-            writer: storage::pack::packwriter_init(&storage.config),
+            writer: storage::pack::packwriter_init(&storage.config).unwrap(),
             write_start_time: SystemTime::now(),
             blobs_to_delete: vec![]
         });
@@ -151,7 +151,7 @@ fn net_sync_to<A: Api>(
             if date.is_genesis() {
                 epoch_writer_state = Some(EpochWriterState {
                     epoch_id: date.get_epochid(),
-                    writer: storage::pack::packwriter_init(&storage.config),
+                    writer: storage::pack::packwriter_init(&storage.config).unwrap(),
                     write_start_time: SystemTime::now(),
                     blobs_to_delete: vec![]
                 });
@@ -221,7 +221,7 @@ fn maybe_create_epoch(storage: &storage::Storage, epoch_id: EpochId, last_block:
 
     let mut epoch_writer_state = EpochWriterState {
         epoch_id,
-        writer: storage::pack::packwriter_init(&storage.config),
+        writer: storage::pack::packwriter_init(&storage.config).unwrap(),
         write_start_time: SystemTime::now(),
         blobs_to_delete: vec![]
     };

--- a/storage/src/containers/indexfile.rs
+++ b/storage/src/containers/indexfile.rs
@@ -38,14 +38,14 @@ const VERSION: magic::Version = 1;
 const FANOUT_ELEMENTS : usize = 256;
 const FANOUT_SIZE : usize = FANOUT_ELEMENTS*SIZE_SIZE;
 
-const HEADER_SIZE : usize = BLOOM_OFFSET as usize - magic::HEADER_SIZE;
+const HEADER_SIZE : usize = BLOOM_OFFSET - magic::HEADER_SIZE;
 
-const FANOUT_OFFSET : usize = magic::HEADER_SIZE;
+const FANOUT_OFFSET : usize = magic::HEADER_SIZE + 8;
 const BLOOM_OFFSET : usize = FANOUT_OFFSET + FANOUT_SIZE;
 
 // calculate the file offset from where the hashes are stored
 fn offset_hashes(bloom_size: u32) -> u64 {
-    8 + 8 + FANOUT_SIZE as u64 + bloom_size as u64
+    magic::HEADER_SIZE as u64 + 8 + FANOUT_SIZE as u64 + bloom_size as u64
 }
 
 // calculate the file offset from where the offsets are stored
@@ -161,7 +161,7 @@ impl Index {
             }
 
             for i in 0..FANOUT_ELEMENTS {
-                let ofs = FANOUT_OFFSET + i * SIZE_SIZE - magic::HEADER_SIZE; /* start at 16, because 0..8 is the magic, followed by size, and padding */
+                let ofs = FANOUT_OFFSET + i * SIZE_SIZE - magic::HEADER_SIZE;
                 write_size(&mut hdr_buf[ofs..ofs+SIZE_SIZE], fanout_incr[i]);
             }
             Fanout(fanout_incr)

--- a/storage/src/containers/packfile.rs
+++ b/storage/src/containers/packfile.rs
@@ -73,6 +73,8 @@ pub fn read_next_block<R: Read>(mut file: R) -> io::Result<Vec<u8>> {
     let mut sz_buf = [0u8;SIZE_SIZE];
     file.read_exact(&mut sz_buf)?;
     let sz = read_size(&sz_buf);
+    // don't potentially consume all memory when reading a corrupt file
+    assert!(sz < 20000000);
     let mut v : Vec<u8> = repeat(0).take(sz as usize).collect();
     file.read_exact(v.as_mut_slice())?;
     if (v.len() % 4) != 0 {
@@ -149,7 +151,7 @@ impl Writer {
         Ok(Writer {
             tmpfile: tmpfile,
             index: idx,
-            pos: 0,
+            pos: magic::HEADER_SIZE as u64,
             nb_blobs: 0,
             hash_context: ctxt,
         })

--- a/storage/src/epoch.rs
+++ b/storage/src/epoch.rs
@@ -68,7 +68,6 @@ pub fn epoch_read_pack(config: &StorageConfig, epochid: cardano::block::EpochId)
 
     let pack_filepath = config.get_epoch_pack_filepath(epochid);
     let mut file = fs::File::open(&pack_filepath)?;
-    magic::check_header(&mut file, FILE_TYPE, VERSION, VERSION)?;
     let _read = file.read_to_end(&mut content).unwrap();
 
     let p = String::from_utf8(content.clone()).ok().and_then(|r| hex::decode(&r).ok()).unwrap();

--- a/storage/src/epoch.rs
+++ b/storage/src/epoch.rs
@@ -1,14 +1,16 @@
 use std::fs;
-use std::io;
 use std::io::{Read};
 use cardano::util::{hex};
-
 use cardano;
 
-use super::{StorageConfig, PackHash, packreader_init, packreader_block_next, header_to_blockhash};
+use super::{Result, Error, StorageConfig, PackHash, packreader_init, packreader_block_next, header_to_blockhash};
 use super::utils::tmpfile;
 use super::utils::tmpfile::{TmpFile};
 use super::containers::{packfile, reffile};
+use magic;
+
+const FILE_TYPE: magic::FileType = 0x45504f43; // = EPOC
+const VERSION: magic::Version = 1;
 
 pub fn epoch_create_with_refpack(config: &StorageConfig, packref: &PackHash, refpack: &reffile::Lookup, epochid: cardano::block::EpochId) {
     let dir = config.get_epoch_dir(epochid);
@@ -18,6 +20,7 @@ pub fn epoch_create_with_refpack(config: &StorageConfig, packref: &PackHash, ref
     tmpfile::atomic_write_simple(&pack_filepath, hex::encode(packref).as_bytes()).unwrap();
 
     let mut tmpfile = TmpFile::create(config.get_epoch_dir(epochid)).unwrap();
+    magic::write_header(&mut tmpfile, FILE_TYPE, VERSION).unwrap();
     refpack.write(&mut tmpfile).unwrap();
     tmpfile.render_permanent(&config.get_epoch_refpack_filepath(epochid)).unwrap();
 }
@@ -51,6 +54,7 @@ pub fn epoch_create(config: &StorageConfig, packref: &PackHash, epochid: cardano
 
     // write the refpack
     let mut tmpfile = TmpFile::create(config.get_epoch_dir(epochid)).unwrap();
+    magic::write_header(&mut tmpfile, FILE_TYPE, VERSION).unwrap();
     rp.write(&mut tmpfile).unwrap();
     tmpfile.render_permanent(&config.get_epoch_refpack_filepath(epochid)).unwrap();
 
@@ -59,11 +63,12 @@ pub fn epoch_create(config: &StorageConfig, packref: &PackHash, epochid: cardano
     tmpfile::atomic_write_simple(&pack_filepath, hex::encode(packref).as_bytes()).unwrap();
 }
 
-pub fn epoch_read_pack(config: &StorageConfig, epochid: cardano::block::EpochId) -> io::Result<PackHash> {
+pub fn epoch_read_pack(config: &StorageConfig, epochid: cardano::block::EpochId) -> Result<PackHash> {
     let mut content = Vec::new();
 
     let pack_filepath = config.get_epoch_pack_filepath(epochid);
     let mut file = fs::File::open(&pack_filepath)?;
+    magic::check_header(&mut file, FILE_TYPE, VERSION, VERSION)?;
     let _read = file.read_to_end(&mut content).unwrap();
 
     let p = String::from_utf8(content.clone()).ok().and_then(|r| hex::decode(&r).ok()).unwrap();
@@ -73,7 +78,7 @@ pub fn epoch_read_pack(config: &StorageConfig, epochid: cardano::block::EpochId)
     Ok(ph)
 }
 
-pub fn epoch_open_packref(config: &StorageConfig, epochid: cardano::block::EpochId) -> io::Result<reffile::Reader> {
+pub fn epoch_open_packref(config: &StorageConfig, epochid: cardano::block::EpochId) -> Result<reffile::Reader> {
     let path = config.get_epoch_refpack_filepath(epochid);
     reffile::Reader::open(path)
 }
@@ -81,15 +86,10 @@ pub fn epoch_open_packref(config: &StorageConfig, epochid: cardano::block::Epoch
 /// Try to open a packfile Reader on a specific epoch
 ///
 /// if there's no pack at this address, then nothing is return
-pub fn epoch_open_pack_reader(config: &StorageConfig, epochid: cardano::block::EpochId) -> io::Result<Option<packfile::Reader<fs::File>>> {
+pub fn epoch_open_pack_reader(config: &StorageConfig, epochid: cardano::block::EpochId) -> Result<Option<packfile::Reader<fs::File>>> {
     match epoch_read_pack(config, epochid) {
-        Err(err) => {
-            if err.kind() == ::std::io::ErrorKind::NotFound {
-                Ok(None)
-            } else {
-                Err(err)
-            }
-        },
+        Err(Error::IoError(ref err)) if err.kind() == ::std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err),
         Ok(epoch_ref) => {
             let reader = packreader_init(config, &epoch_ref);
             Ok(Some(reader))
@@ -102,16 +102,12 @@ pub fn epoch_open_pack_seeker() -> io::Result<Option<packfile::Seeker>> {
 }
 */
 
-pub fn epoch_read_packref(config: &StorageConfig, epochid: cardano::block::EpochId) -> io::Result<reffile::Reader> {
+pub fn epoch_read_packref(config: &StorageConfig, epochid: cardano::block::EpochId) -> Result<reffile::Reader> {
     reffile::Reader::open(config.get_epoch_refpack_filepath(epochid))
 }
 
-pub fn epoch_read(config: &StorageConfig, epochid: cardano::block::EpochId) -> io::Result<(PackHash, reffile::Reader)> {
-    match epoch_read_pack(config, epochid) {
-        Err(e) => Err(e),
-        Ok(ph) => {
-            let rp = epoch_read_packref(config, epochid)?;
-            Ok((ph, rp))
-        }
-    }
+pub fn epoch_read(config: &StorageConfig, epochid: cardano::block::EpochId) -> Result<(PackHash, reffile::Reader)> {
+    let ph = epoch_read_pack(config, epochid)?;
+    let rp = epoch_read_packref(config, epochid)?;
+    Ok((ph, rp))
 }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -154,13 +154,7 @@ pub mod blob {
     }
 
     pub fn read(storage: &super::Storage, hash: &super::BlockHash) -> Result<RawBlock> {
-        let mut content = Vec::new();
-        let path = storage.config.get_blob_filepath(&hash);
-
-        let mut file = fs::File::open(path)?;
-        file.read_to_end(&mut content)?;
-
-        Ok(RawBlock::from_dat(content))
+        Ok(RawBlock::from_dat(self::read_raw(storage, hash)?))
     }
 
     pub fn exist(storage: &super::Storage, hash: &super::BlockHash) -> bool {

--- a/storage/src/magic.rs
+++ b/storage/src/magic.rs
@@ -1,0 +1,64 @@
+use std::io::{Write, Read};
+use super::{Result, Error};
+use utils::serialize::{read_size, write_size};
+
+const MAGIC: &[u8;8] = b"\xfeCARDANO";
+const MAGIC_SIZE: usize = 8;
+const TYPE_SIZE: usize = 4;
+const VERSION_SIZE: usize = 4;
+pub const HEADER_SIZE: usize = MAGIC_SIZE + TYPE_SIZE + VERSION_SIZE;
+
+pub type FileType = u32;
+pub type Version = u32;
+
+/// Write a 16-byte header consisting of a magic value, a file type,
+/// and a file schema version number.
+pub fn write_header<File>(
+    file: &mut File,
+    file_type: FileType,
+    version: Version)
+    -> Result<()>
+    where File: Write
+{
+    let mut hdr_buf = [0u8;HEADER_SIZE];
+    hdr_buf[0..8].clone_from_slice(&MAGIC[..]);
+    write_size(&mut hdr_buf[8..12], file_type);
+    write_size(&mut hdr_buf[12..16], version);
+    file.write_all(&hdr_buf)?;
+    Ok(())
+}
+
+/// Check that a file has a header denoting the expected file type and
+/// has a version in the specified range. Return the version.
+pub fn check_header(
+    file: &mut Read,
+    expected_file_type: FileType,
+    min_version: Version,
+    max_version: Version)
+    -> Result<Version>
+{
+    let mut hdr_buf = [0u8;HEADER_SIZE];
+    file.read_exact(&mut hdr_buf)?;
+
+    if &hdr_buf[0..MAGIC_SIZE] != MAGIC {
+        return Err(Error::MissingMagic);
+    }
+
+    let file_type = read_size(&hdr_buf[8..12]);
+    let version = read_size(&hdr_buf[12..16]);
+
+    if file_type != expected_file_type {
+        return Err(Error::WrongFileType(expected_file_type, file_type));
+    }
+
+    if version < min_version {
+        return Err(Error::VersionTooOld(min_version, version));
+    }
+
+    if version > max_version {
+        return Err(Error::VersionTooNew(max_version, version));
+    }
+
+    Ok(version)
+}
+

--- a/storage/src/pack.rs
+++ b/storage/src/pack.rs
@@ -1,8 +1,7 @@
-
-use std::io;
 use std::fs;
 use utils::tmpfile::{TmpFile};
 use cardano;
+use super::Result;
 
 use containers::packfile;
 use containers::indexfile;
@@ -17,22 +16,22 @@ pub fn open_index(storage_config: &super::StorageConfig, pack: &super::PackHash)
     fs::File::open(storage_config.get_index_filepath(pack)).unwrap()
 }
 
-pub fn dump_index(storage_config: &super::StorageConfig, pack: &super::PackHash) -> io::Result<(indexfile::Lookup, Vec<super::BlockHash>)> {
+pub fn dump_index(storage_config: &super::StorageConfig, pack: &super::PackHash) -> Result<(indexfile::Lookup, Vec<super::BlockHash>)> {
     let mut file = open_index(storage_config, pack);
     indexfile::dump_file(&mut file)
 }
 
-pub fn read_index_fanout(storage_config: &super::StorageConfig, pack: &super::PackHash) -> io::Result<indexfile::Lookup> {
+pub fn read_index_fanout(storage_config: &super::StorageConfig, pack: &super::PackHash) -> Result<indexfile::Lookup> {
     let mut file = open_index(storage_config, pack);
     indexfile::Lookup::read_from_file(&mut file)
 }
 
-pub fn index_get_header(file: &fs::File) -> io::Result<indexfile::Lookup> {
+pub fn index_get_header(file: &mut fs::File) -> Result<indexfile::Lookup> {
     indexfile::Lookup::read_from_file(file)
 }
 
-pub fn packwriter_init(cfg: &super::StorageConfig) -> packfile::Writer {
-    let tmpfile = TmpFile::create(cfg.get_filetype_dir(super::StorageFileType::Pack)).unwrap();
+pub fn packwriter_init(cfg: &super::StorageConfig) -> Result<packfile::Writer> {
+    let tmpfile = TmpFile::create(cfg.get_filetype_dir(super::StorageFileType::Pack))?;
     packfile::Writer::init(tmpfile)
 }
 

--- a/storage/src/refpack.rs
+++ b/storage/src/refpack.rs
@@ -1,27 +1,10 @@
 //! pack of references, in a certain order
 
-use std::{io, result, fmt};
 use config::{StorageConfig};
 use containers::reffile;
+use super::Result;
 
 pub use std::collections::vec_deque::{Iter};
-
-#[derive(Debug)]
-pub enum Error {
-    IoError(io::Error),
-}
-impl From<io::Error> for Error {
-    fn from(e: io::Error) -> Self { Error::IoError(e) }
-}
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            &Error::IoError(ref err) => write!(f, "IO Error: {}", err)
-        }
-    }
-}
-
-pub type Result<T> = result::Result<T, Error>;
 
 pub fn read_refpack<P: AsRef<str>>(storage_config: &StorageConfig, name: P) -> Result<reffile::Lookup> {
     let r = reffile::Lookup::from_path(storage_config.get_refpack_filepath(name))?;

--- a/storage/src/utils/tmpfile.rs
+++ b/storage/src/utils/tmpfile.rs
@@ -34,7 +34,7 @@ impl TmpFile {
         // to error out correctly in every cases rename fail, however in a case of a hash, since the hash is suppose
         // to represent the same file, some error like EEXIST can be ignored, but some should be raised.
         // NOTE2: also we consider that the rename is atomic for the tmpfile abstraction to work correctly,
-        // but it mostly depends on the actual filesystem. for most case it should be atomic.
+        // but it mostly depends on the actual filesystem. POSIX requires it to be atomic.
         match fs::rename(&self.path, path) {
             _ => {},
         };


### PR DESCRIPTION
The header format is a 16-byte structure, consisting of the magic string `\xfeCARDANO`, a 4-byte file type identifier (e.g. `EPOC` for an epoch pack) and a 4-byte version number (currently 1 for all types).

Fixes  #230.

Warning: this breaks all current binary files.