### PR TITLE
Fix #246

### DIFF
--- a/storage/src/containers/reffile.rs
+++ b/storage/src/containers/reffile.rs
@@ -88,12 +88,12 @@ impl Lookup {
 
     pub fn to_path<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         let mut file = fs::File::create(path)?;
-        magic::write_header(&mut file, FILE_TYPE, VERSION)?;
         self.write(&mut file)?;
         Ok(())
     }
 
-    pub fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+    pub fn write<W: io::Write>(&self, writer: &mut W) -> Result<()> {
+        magic::write_header(writer, FILE_TYPE, VERSION)?;
         for bh in self.iter() { writer.write_all(&bh[..])?; }
         Ok(())
     }

--- a/storage/src/epoch.rs
+++ b/storage/src/epoch.rs
@@ -8,10 +8,6 @@ use super::utils::tmpfile;
 use super::utils::tmpfile::{TmpFile};
 use super::utils::error::StorageError;
 use super::containers::{packfile, reffile};
-use magic;
-
-const FILE_TYPE: magic::FileType = 0x45504f43; // = EPOC
-const VERSION: magic::Version = 1;
 
 pub fn epoch_create_with_refpack(config: &StorageConfig, packref: &PackHash, refpack: &reffile::Lookup, epochid: cardano::block::EpochId) {
     let dir = config.get_epoch_dir(epochid);
@@ -21,7 +17,6 @@ pub fn epoch_create_with_refpack(config: &StorageConfig, packref: &PackHash, ref
     tmpfile::atomic_write_simple(&pack_filepath, hex::encode(packref).as_bytes()).unwrap();
 
     let mut tmpfile = TmpFile::create(config.get_epoch_dir(epochid)).unwrap();
-    magic::write_header(&mut tmpfile, FILE_TYPE, VERSION).unwrap();
     refpack.write(&mut tmpfile).unwrap();
     tmpfile.render_permanent(&config.get_epoch_refpack_filepath(epochid)).unwrap();
 }
@@ -55,7 +50,6 @@ pub fn epoch_create(config: &StorageConfig, packref: &PackHash, epochid: cardano
 
     // write the refpack
     let mut tmpfile = TmpFile::create(config.get_epoch_dir(epochid)).unwrap();
-    magic::write_header(&mut tmpfile, FILE_TYPE, VERSION).unwrap();
     rp.write(&mut tmpfile).unwrap();
     tmpfile.render_permanent(&config.get_epoch_refpack_filepath(epochid)).unwrap();
 

--- a/storage/src/epoch.rs
+++ b/storage/src/epoch.rs
@@ -107,3 +107,12 @@ pub fn epoch_read(config: &StorageConfig, epochid: cardano::block::EpochId) -> R
     let rp = epoch_read_packref(config, epochid)?;
     Ok((ph, rp))
 }
+
+/// Check whether an epoch pack exists on disk.
+pub fn epoch_exists(config: &StorageConfig, epochid: cardano::block::EpochId) -> Result<bool> {
+    match epoch_read_pack(config, epochid) {
+        Ok(_) => Ok(true),
+        Err(Error::StorageError(StorageError::IoError(ref err))) if err.kind() == ::std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err)
+    }
+}


### PR DESCRIPTION
There was some confusion in the file type used for epoch refpacks: it was written with an `EPOC` type but read expecting a `REFS` type. This gets rid of the former.

Also, I moved `epoch_exists` into `storage` and made it more efficient (it just checks for the existence of `epoch/<N>/pack` now).