### PR TITLE
make serde derivation optional in cardano crate

### DIFF
--- a/cardano/Cargo.toml
+++ b/cardano/Cargo.toml
@@ -9,10 +9,11 @@ keywords = [ "Cardano", "Wallet", "Crypto" ]
 [build-dependencies]
 
 [dependencies]
-serde = "1.0"
-serde_derive = "1.0"
 cryptoxide = { path = "../cryptoxide" }
 cbor_event = { path = "../cbor_event" }
+
+serde = { version = "1.0", optional = true }
+serde_derive = { version = "1.0", optional = true }
 
 [dev-dependencies]
 rand = "0.4"
@@ -20,4 +21,6 @@ serde_json = "*"
 unicode-normalization = "0.1.7"
 
 [features]
+default = []
 with-bench = []
+generic-serialization = ["serde", "serde_derive"]

--- a/cardano/src/address.rs
+++ b/cardano/src/address.rs
@@ -1,5 +1,6 @@
 //! Address creation and parsing
 use std::{fmt, str::{FromStr}, ops::{Deref}};
+#[cfg(feature = "generic-serialization")]
 use serde;
 
 use hash::{Blake2b224, Sha3_256};
@@ -11,7 +12,8 @@ use cbor_event::{self, de::RawCbor, se::{Serializer}};
 use hdwallet::{XPub};
 use hdpayload::{HDAddressPayload};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub enum AddrType {
     ATPubKey,
     ATScript,
@@ -60,7 +62,8 @@ impl cbor_event::de::Deserialize for AddrType {
 
 /// StakeholderId is the transaction
 ///
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct StakeholderId(Blake2b224);
 impl StakeholderId {
     pub fn new(pubk: &XPub) -> StakeholderId {
@@ -116,7 +119,8 @@ impl FromStr for StakeholderId {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub enum StakeDistribution {
     BootstrapEraDistr,
     SingleKeyDistr(StakeholderId),
@@ -173,7 +177,8 @@ impl cbor_event::de::Deserialize for StakeDistribution {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct Attributes {
     pub derivation_path: Option<HDAddressPayload>,
     pub stake_distribution: StakeDistribution
@@ -250,7 +255,8 @@ impl cbor_event::de::Deserialize for Attributes {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct Addr(Blake2b224);
 impl Addr {
     pub fn new(addr_type: AddrType, spending_data: &SpendingData, attrs: &Attributes) -> Self {
@@ -372,6 +378,7 @@ impl fmt::Display for ExtendedAddr {
         write!(f, "{}", base58::encode(&cbor!(self).unwrap()))
     }
 }
+#[cfg(feature = "generic-serialization")]
 impl serde::Serialize for ExtendedAddr
 {
     #[inline]
@@ -386,47 +393,47 @@ impl serde::Serialize for ExtendedAddr
         }
     }
 }
-struct XAddrVisitor();
-impl XAddrVisitor { fn new() -> Self { XAddrVisitor {} } }
-impl<'de> serde::de::Visitor<'de> for XAddrVisitor {
-    type Value = ExtendedAddr;
-
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "Expecting an Extended Address (`ExtendedAddr`)")
-    }
-
-    fn visit_str<'a, E>(self, v: &'a str) -> Result<Self::Value, E>
-        where E: serde::de::Error
-    {
-        let bytes = match base58::decode(v) {
-            Err(err) => { return Err(E::custom(format!("invalid base58:{}", err))); },
-            Ok(v) => v
-        };
-
-        match Self::Value::try_from_slice(&bytes) {
-            Err(err) => { Err(E::custom(format!("unable to parse ExtendedAddr: {:?}", err))) },
-            Ok(v) => Ok(v)
-        }
-    }
-
-    fn visit_bytes<'a, E>(self, v: &'a [u8]) -> Result<Self::Value, E>
-        where E: serde::de::Error
-    {
-        match Self::Value::try_from_slice(v) {
-            Err(err) => { Err(E::custom(format!("unable to parse ExtendedAddr: {:?}", err))) },
-            Ok(v) => Ok(v)
-        }
-    }
-}
+#[cfg(feature = "generic-serialization")]
 impl<'de> serde::Deserialize<'de> for ExtendedAddr
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where D: serde::Deserializer<'de>
     {
+        struct XAddrVisitor;
+        impl<'de> serde::de::Visitor<'de> for XAddrVisitor {
+            type Value = ExtendedAddr;
+
+            fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+                write!(fmt, "Expecting an Extended Address (`ExtendedAddr`)")
+            }
+
+            fn visit_str<'a, E>(self, v: &'a str) -> Result<Self::Value, E>
+                where E: serde::de::Error
+            {
+                let bytes = match base58::decode(v) {
+                    Err(err) => { return Err(E::custom(format!("invalid base58:{}", err))); },
+                    Ok(v) => v
+                };
+
+                match Self::Value::try_from_slice(&bytes) {
+                    Err(err) => { Err(E::custom(format!("unable to parse ExtendedAddr: {:?}", err))) },
+                    Ok(v) => Ok(v)
+                }
+            }
+
+            fn visit_bytes<'a, E>(self, v: &'a [u8]) -> Result<Self::Value, E>
+                where E: serde::de::Error
+            {
+                match Self::Value::try_from_slice(v) {
+                    Err(err) => { Err(E::custom(format!("unable to parse ExtendedAddr: {:?}", err))) },
+                    Ok(v) => Ok(v)
+                }
+            }
+        }
         if deserializer.is_human_readable() {
-            deserializer.deserialize_str(XAddrVisitor::new())
+            deserializer.deserialize_str(XAddrVisitor)
         } else {
-            deserializer.deserialize_bytes(XAddrVisitor::new())
+            deserializer.deserialize_bytes(XAddrVisitor)
         }
     }
 }
@@ -437,7 +444,8 @@ const SPENDING_DATA_TAG_PUBKEY : u64 = 0;
 const SPENDING_DATA_TAG_SCRIPT : u64 = 1; // TODO
 const SPENDING_DATA_TAG_REDEEM : u64 = 2;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub enum SpendingData {
     PubKeyASD (XPub),
     ScriptASD (Script),

--- a/cardano/src/bip/bip39.rs
+++ b/cardano/src/bip/bip39.rs
@@ -492,7 +492,8 @@ impl Drop for Seed {
 ///
 /// See the module documentation for more details about how to use it
 /// within the `cardano` library.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct MnemonicString(String);
 impl MnemonicString {
     /// create a `MnemonicString` from the given `String`. This function
@@ -546,7 +547,8 @@ impl fmt::Display for MnemonicString {
 /// | 21              | 224                 | 7                     |
 /// | 24              | 256                 | 8                     |
 ///
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub enum Type {
     Type12Words,
     Type15Words,
@@ -804,7 +806,8 @@ pub mod dictionary {
     use super::{MnemonicIndex};
 
     /// Errors associated to a given language/dictionary
-    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+    #[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
     pub enum Error {
         /// this means the given word is not in the Dictionary of the Language.
         MnemonicWordNotFoundInDictionary(String)

--- a/cardano/src/bip/bip44.rs
+++ b/cardano/src/bip/bip44.rs
@@ -18,6 +18,7 @@
 
 use hdpayload::{Path};
 use std::{fmt, result};
+#[cfg(feature = "generic-serialization")]
 use serde;
 
 /// the BIP44 derivation path has a specific length
@@ -31,7 +32,8 @@ pub const BIP44_COIN_TYPE : u32 = 0x80000717;
 pub const BIP44_SOFT_UPPER_BOUND : u32 = 0x80000000;
 
 /// Error relating to `bip44`'s `Addressing` operations
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub enum Error {
     /// this means the given `Path` has an incompatible length
     /// for bip44 derivation. See `BIP44_PATH_LENGTH` and `Addressing::from_path`.
@@ -105,6 +107,7 @@ impl fmt::Display for Account {
         write!(f, "{}", self.0)
     }
 }
+#[cfg(feature = "generic-serialization")]
 impl serde::Serialize for Account
 {
     #[inline]
@@ -114,45 +117,45 @@ impl serde::Serialize for Account
         serializer.serialize_u32(self.0)
     }
 }
-struct AccountVisitor();
-impl AccountVisitor { fn new() -> Self { AccountVisitor {} } }
-impl<'de> serde::de::Visitor<'de> for AccountVisitor {
-    type Value = Account;
-
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "Expecting a valid Account derivation index.")
-    }
-
-    fn visit_u16<E>(self, v: u16) -> result::Result<Self::Value, E>
-        where E: serde::de::Error
-    {
-        self.visit_u32(v as u32)
-    }
-    fn visit_u32<E>(self, v: u32) -> result::Result<Self::Value, E>
-        where E: serde::de::Error
-    {
-        match Account::new(v) {
-            Err(Error::AccountOutOfBound(_)) => Err(E::invalid_value(serde::de::Unexpected::Unsigned(v as u64), &"from 0 to 0x7fffffff")),
-            Err(err) => panic!("unexpected error: {}", err),
-            Ok(h) => Ok(h)
-        }
-    }
-
-    fn visit_u64<E>(self, v: u64) -> result::Result<Self::Value, E>
-        where E: serde::de::Error
-    {
-        if v > 0xFFFFFFFF {
-            return Err(E::invalid_value(serde::de::Unexpected::Unsigned(v), &"value should fit in 32bit integer"));
-        }
-        self.visit_u32(v as u32)
-    }
-}
+#[cfg(feature = "generic-serialization")]
 impl<'de> serde::Deserialize<'de> for Account
 {
     fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>
         where D: serde::Deserializer<'de>
     {
-        deserializer.deserialize_u32(AccountVisitor::new())
+        struct AccountVisitor;
+        impl<'de> serde::de::Visitor<'de> for AccountVisitor {
+            type Value = Account;
+
+            fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+                write!(fmt, "Expecting a valid Account derivation index.")
+            }
+
+            fn visit_u16<E>(self, v: u16) -> result::Result<Self::Value, E>
+                where E: serde::de::Error
+            {
+                self.visit_u32(v as u32)
+            }
+            fn visit_u32<E>(self, v: u32) -> result::Result<Self::Value, E>
+                where E: serde::de::Error
+            {
+                match Account::new(v) {
+                    Err(Error::AccountOutOfBound(_)) => Err(E::invalid_value(serde::de::Unexpected::Unsigned(v as u64), &"from 0 to 0x7fffffff")),
+                    Err(err) => panic!("unexpected error: {}", err),
+                    Ok(h) => Ok(h)
+                }
+            }
+
+            fn visit_u64<E>(self, v: u64) -> result::Result<Self::Value, E>
+                where E: serde::de::Error
+            {
+                if v > 0xFFFFFFFF {
+                    return Err(E::invalid_value(serde::de::Unexpected::Unsigned(v), &"value should fit in 32bit integer"));
+                }
+                self.visit_u32(v as u32)
+            }
+        }
+        deserializer.deserialize_u32(AccountVisitor)
     }
 }
 
@@ -178,6 +181,7 @@ impl Index {
     }
 }
 
+#[cfg(feature = "generic-serialization")]
 impl serde::Serialize for Index
 {
     #[inline]
@@ -187,45 +191,45 @@ impl serde::Serialize for Index
         serializer.serialize_u32(self.0)
     }
 }
-struct IndexVisitor();
-impl IndexVisitor { fn new() -> Self { IndexVisitor {} } }
-impl<'de> serde::de::Visitor<'de> for IndexVisitor {
-    type Value = Index;
-
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "Expecting a valid Index derivation index.")
-    }
-
-    fn visit_u16<E>(self, v: u16) -> result::Result<Self::Value, E>
-        where E: serde::de::Error
-    {
-        self.visit_u32(v as u32)
-    }
-    fn visit_u32<E>(self, v: u32) -> result::Result<Self::Value, E>
-        where E: serde::de::Error
-    {
-        match Index::new(v) {
-            Err(Error::IndexOutOfBound(_)) => Err(E::invalid_value(serde::de::Unexpected::Unsigned(v as u64), &"from 0 to 0x7fffffff")),
-            Err(err) => panic!("unexpected error: {}", err),
-            Ok(h) => Ok(h)
-        }
-    }
-
-    fn visit_u64<E>(self, v: u64) -> result::Result<Self::Value, E>
-        where E: serde::de::Error
-    {
-        if v > 0xFFFFFFFF {
-            return Err(E::invalid_value(serde::de::Unexpected::Unsigned(v), &"value should fit in 32bit integer"));
-        }
-        self.visit_u32(v as u32)
-    }
-}
+#[cfg(feature = "generic-serialization")]
 impl<'de> serde::Deserialize<'de> for Index
 {
     fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>
         where D: serde::Deserializer<'de>
     {
-        deserializer.deserialize_u32(IndexVisitor::new())
+        struct IndexVisitor;
+        impl<'de> serde::de::Visitor<'de> for IndexVisitor {
+            type Value = Index;
+
+            fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+                write!(fmt, "Expecting a valid Index derivation index.")
+            }
+
+            fn visit_u16<E>(self, v: u16) -> result::Result<Self::Value, E>
+                where E: serde::de::Error
+            {
+                self.visit_u32(v as u32)
+            }
+            fn visit_u32<E>(self, v: u32) -> result::Result<Self::Value, E>
+                where E: serde::de::Error
+            {
+                match Index::new(v) {
+                    Err(Error::IndexOutOfBound(_)) => Err(E::invalid_value(serde::de::Unexpected::Unsigned(v as u64), &"from 0 to 0x7fffffff")),
+                    Err(err) => panic!("unexpected error: {}", err),
+                    Ok(h) => Ok(h)
+                }
+            }
+
+            fn visit_u64<E>(self, v: u64) -> result::Result<Self::Value, E>
+                where E: serde::de::Error
+            {
+                if v > 0xFFFFFFFF {
+                    return Err(E::invalid_value(serde::de::Unexpected::Unsigned(v), &"value should fit in 32bit integer"));
+                }
+                self.visit_u32(v as u32)
+            }
+        }
+        deserializer.deserialize_u32(IndexVisitor)
     }
 }
 
@@ -248,7 +252,8 @@ impl Change {
 
 /// Bip44 address derivation
 ///
-#[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct Addressing {
     pub account: Account,
     pub change: u32,
@@ -260,7 +265,8 @@ impl fmt::Display for Addressing {
     }
 }
 
-#[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub enum AddrType {
     Internal,
     External,

--- a/cardano/src/block/block.rs
+++ b/cardano/src/block/block.rs
@@ -70,7 +70,8 @@ impl DerefMut for BlockHeaders {
 }
 
 /// Block Date which is either an epoch id for a genesis block or a slot id for a normal block
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub enum BlockDate {
     Genesis(EpochId),
     Normal(EpochSlotId),

--- a/cardano/src/block/types.rs
+++ b/cardano/src/block/types.rs
@@ -23,7 +23,8 @@ impl fmt::Display for Version {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct HeaderHash(Blake2b256);
 impl HeaderHash {
     pub fn new(bytes: &[u8]) -> Self { HeaderHash(Blake2b256::new(bytes))  }
@@ -156,7 +157,8 @@ impl fmt::Display for ChainDifficulty {
 pub type EpochId = u64; // == EpochIndex
 pub type SlotId = u16; // == LocalSlotIndex
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct EpochSlotId {
     pub epoch: EpochId,
     pub slotid: SlotId,

--- a/cardano/src/coin.rs
+++ b/cardano/src/coin.rs
@@ -13,7 +13,8 @@ pub const MAX_COIN: u64 = 45_000_000_000__000_000;
 
 /// error type relating to `Coin` operations
 ///
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub enum Error {
     /// means that the given value was out of bound
     ///
@@ -45,7 +46,8 @@ pub enum CoinDiff {
 
 // TODO: add custom implementation of `serde::de::Deserialize` so we can check the
 // upper bound of the `Coin`.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct Coin(u64);
 impl Coin {
     /// create a coin of value `0`.

--- a/cardano/src/config.rs
+++ b/cardano/src/config.rs
@@ -22,7 +22,8 @@ use std::fmt;
 /// assert_eq!(ProtocolMagic::default(), ProtocolMagic::new(0x2D964A09));
 /// ```
 ///
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct ProtocolMagic(u32);
 impl ProtocolMagic {
     #[deprecated]
@@ -56,7 +57,8 @@ impl cbor_event::Deserialize for ProtocolMagic {
 }
 
 /// Configuration for the wallet-crypto
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct Config {
     pub protocol_magic: ProtocolMagic
 }

--- a/cardano/src/fee.rs
+++ b/cardano/src/fee.rs
@@ -7,7 +7,8 @@ use tx::{Tx, TxInWitness, TxAux, txaux_serialize};
 use cbor_event;
 
 /// A fee value that represent either a fee to pay, or a fee paid.
-#[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct Fee(Coin);
 impl Fee {
     pub fn new(coin: Coin) -> Self { Fee(coin) }
@@ -29,7 +30,8 @@ impl From<cbor_event::Error> for Error {
     fn from(e: cbor_event::Error) -> Error { Error::CborError(e) }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, PartialOrd, Debug, Clone, Copy)]
+#[derive(PartialEq, PartialOrd, Debug, Clone, Copy)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct Milli (pub u64);
 impl Milli {
     pub fn new(i: u64, f: u64) -> Self { Milli(i * 1000 + f % 1000) }
@@ -66,7 +68,8 @@ impl Mul for Milli {
 }
 
 /// Linear fee using the basic affine formula `A * bytes(txaux) + CONSTANT`
-#[derive(Serialize, Deserialize, PartialEq, PartialOrd, Debug, Clone, Copy)]
+#[derive(PartialEq, PartialOrd, Debug, Clone, Copy)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct LinearFee {
     /// this is the minimal fee
     constant: Milli,

--- a/cardano/src/hash.rs
+++ b/cardano/src/hash.rs
@@ -10,9 +10,11 @@ use cryptoxide::sha3::Sha3;
 use util::{hex, try_from_slice::{TryFromSlice}};
 use cbor_event::{self, de::RawCbor};
 
+#[cfg(feature = "generic-serialization")]
 use serde;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub enum Error {
     InvalidHashSize(usize, usize),
     HexadecimalError(hex::Error),
@@ -106,6 +108,7 @@ macro_rules! define_hash_object {
             }
         }
 
+        #[cfg(feature = "generic-serialization")]
         impl serde::Serialize for $hash_ty
         {
             #[inline]
@@ -119,6 +122,7 @@ macro_rules! define_hash_object {
                 }
             }
         }
+        #[cfg(feature = "generic-serialization")]
         impl<'de> serde::Deserialize<'de> for $hash_ty
         {
             fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>

--- a/cardano/src/hdpayload.rs
+++ b/cardano/src/hdpayload.rs
@@ -38,7 +38,8 @@ impl From<cbor_event::Error> for Error {
 pub type Result<T> = ::std::result::Result<T, Error>;
 
 /// A derivation path of HD wallet derivation indices which uses a CBOR encoding
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct Path(Vec<u32>);
 impl Deref for Path {
     type Target = [u32];
@@ -72,7 +73,8 @@ impl cbor_event::Deserialize for Path {
 pub const HDKEY_SIZE : usize = 32;
 
 /// The key to encrypt and decrypt HD payload
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct HDKey([u8;HDKEY_SIZE]);
 impl AsRef<[u8]> for HDKey {
     fn as_ref(&self) -> &[u8] { self.0.as_ref() }
@@ -150,7 +152,8 @@ impl Drop for HDKey {
 ///
 /// It's however possible to store anything in this attributes, including
 /// non encrypted information.
-#[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct HDAddressPayload(Vec<u8>);
 impl AsRef<[u8]> for HDAddressPayload {
     fn as_ref(&self) -> &[u8] { self.0.as_ref() }

--- a/cardano/src/input_selection.rs
+++ b/cardano/src/input_selection.rs
@@ -136,7 +136,8 @@ impl SelectionAlgorithm for LinearFee {
 
 /// the input selection method.
 ///
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub enum SelectionPolicy {
     /// select the first inputs that matches, no optimisation
     FirstMatchFirst

--- a/cardano/src/lib.rs
+++ b/cardano/src/lib.rs
@@ -15,8 +15,10 @@
 //!
 #![cfg_attr(feature = "with-bench", feature(test))]
 
+#[cfg(feature = "generic-serialization")]
 #[macro_use]
 extern crate serde_derive;
+#[cfg(feature = "generic-serialization")]
 extern crate serde;
 #[cfg(test)]
 extern crate serde_json;

--- a/cardano/src/redeem.rs
+++ b/cardano/src/redeem.rs
@@ -10,11 +10,13 @@
 use cryptoxide::{ed25519};
 use util::{hex};
 use cbor_event::{self, de::RawCbor, se::{Serializer}};
+#[cfg(feature = "generic-serialization")]
 use serde;
 
 use std::{fmt, result, cmp};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub enum Error {
     InvalidPublicKeySize(usize),
     InvalidPrivateKeySize(usize),
@@ -239,6 +241,7 @@ impl cbor_event::de::Deserialize for Signature {
 //                                      Serde
 // ---------------------------------------------------------------------------
 
+#[cfg(feature = "generic-serialization")]
 impl serde::Serialize for PublicKey
 {
     #[inline]
@@ -252,8 +255,11 @@ impl serde::Serialize for PublicKey
         }
     }
 }
+#[cfg(feature = "generic-serialization")]
 struct PublicKeyVisitor();
+#[cfg(feature = "generic-serialization")]
 impl PublicKeyVisitor { fn new() -> Self { PublicKeyVisitor {} } }
+#[cfg(feature = "generic-serialization")]
 impl<'de> serde::de::Visitor<'de> for PublicKeyVisitor {
     type Value = PublicKey;
 
@@ -282,6 +288,7 @@ impl<'de> serde::de::Visitor<'de> for PublicKeyVisitor {
         }
     }
 }
+#[cfg(feature = "generic-serialization")]
 impl<'de> serde::Deserialize<'de> for PublicKey
 {
     fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>
@@ -295,6 +302,7 @@ impl<'de> serde::Deserialize<'de> for PublicKey
     }
 }
 
+#[cfg(feature = "generic-serialization")]
 impl serde::Serialize for PrivateKey
 {
     #[inline]
@@ -308,8 +316,11 @@ impl serde::Serialize for PrivateKey
         }
     }
 }
+#[cfg(feature = "generic-serialization")]
 struct PrivateKeyVisitor();
+#[cfg(feature = "generic-serialization")]
 impl PrivateKeyVisitor { fn new() -> Self { PrivateKeyVisitor {} } }
+#[cfg(feature = "generic-serialization")]
 impl<'de> serde::de::Visitor<'de> for PrivateKeyVisitor {
     type Value = PrivateKey;
 
@@ -338,6 +349,7 @@ impl<'de> serde::de::Visitor<'de> for PrivateKeyVisitor {
         }
     }
 }
+#[cfg(feature = "generic-serialization")]
 impl<'de> serde::Deserialize<'de> for PrivateKey
 {
     fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>
@@ -351,6 +363,7 @@ impl<'de> serde::Deserialize<'de> for PrivateKey
     }
 }
 
+#[cfg(feature = "generic-serialization")]
 impl serde::Serialize for Signature
 {
     #[inline]
@@ -364,8 +377,11 @@ impl serde::Serialize for Signature
         }
     }
 }
+#[cfg(feature = "generic-serialization")]
 struct SignatureVisitor();
+#[cfg(feature = "generic-serialization")]
 impl SignatureVisitor { fn new() -> Self { SignatureVisitor {} } }
+#[cfg(feature = "generic-serialization")]
 impl<'de> serde::de::Visitor<'de> for SignatureVisitor {
     type Value = Signature;
 
@@ -394,6 +410,7 @@ impl<'de> serde::de::Visitor<'de> for SignatureVisitor {
         }
     }
 }
+#[cfg(feature = "generic-serialization")]
 impl<'de> serde::Deserialize<'de> for Signature
 {
     fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>

--- a/cardano/src/tx.rs
+++ b/cardano/src/tx.rs
@@ -25,7 +25,8 @@ use coin::{self, Coin};
 pub type TxId = Blake2b256;
 
 /// Tx Output composed of an address and a coin value
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct TxOut {
     pub address: ExtendedAddr,
     pub value: Coin,
@@ -70,7 +71,8 @@ type RedeemerScript = TODO;
 /// * ScriptWitness: a witness for ScriptASD.
 /// * RedeemWitness: a witness for RedeemASD type, similar to PkWitness
 ///                  but for normal Public Key.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub enum TxInWitness {
     /// signature of the `Tx` with the associated `XPub`
     /// the `XPub` is the public key set in the AddrSpendingData
@@ -209,7 +211,8 @@ impl cbor_event::de::Deserialize for TxInWitness {
 /// Structure used for addressing a specific output of a transaction
 /// built from a TxId (hash of the tx) and the offset in the outputs of this
 /// transaction.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct TxoPointer {
     pub id: TxId,
     pub index: u32,
@@ -256,7 +259,8 @@ impl cbor_event::de::Deserialize for TxoPointer {
 }
 
 /// A Transaction containing tx inputs and tx outputs.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct Tx {
     pub inputs: Vec<TxoPointer>,
     pub outputs: Vec<TxOut>,
@@ -323,7 +327,8 @@ impl cbor_event::de::Deserialize for Tx {
 }
 
 /// A transaction witness is a vector of input witnesses
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct TxWitness(Vec<TxInWitness>);
 
 impl TxWitness {
@@ -368,7 +373,8 @@ pub fn txwitness_serialize<W>(in_witnesses: &Vec<TxInWitness>, serializer: Seria
 }
 
 /// A transaction witness is a vector of input witnesses
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct TxWitnesses {
     pub in_witnesses: Vec<TxWitness>
 }
@@ -392,7 +398,8 @@ impl cbor_event::se::Serialize for TxWitnesses
 }
 
 /// Tx with the vector of witnesses
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct TxAux {
     pub tx: Tx,
     pub witness: TxWitness,

--- a/cardano/src/txutils.rs
+++ b/cardano/src/txutils.rs
@@ -6,7 +6,8 @@ use address::{ExtendedAddr};
 ///
 /// * The number of coin associated for this utxo
 /// * Optionally, way to derive the address for this TxoPointer
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct TxoPointerInfo<Addressing> {
     pub txin: TxoPointer,
     pub value: Coin,
@@ -30,7 +31,8 @@ pub enum OutputPolicy {
 /// It also contains the `TxOut` the value present at the given
 /// `TxoPointer`'s `TxId` and _index_ in the block chain.
 ///
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct Input<Addressing> {
     pub ptr:   TxoPointer,
     pub value: TxOut,

--- a/cardano/src/util/base58.rs
+++ b/cardano/src/util/base58.rs
@@ -14,7 +14,8 @@
 
 pub const ALPHABET : &'static str = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub enum Error {
     /// error when a given character is not part of the supported
     /// base58 `ALPHABET`. Contains the index of the faulty byte.

--- a/cardano/src/util/hex.rs
+++ b/cardano/src/util/hex.rs
@@ -15,7 +15,8 @@ use std::{result, fmt};
 const ALPHABET : &'static [u8] = b"0123456789abcdef";
 
 /// hexadecimal encoding/decoding potential errors
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub enum Error {
     /// error when a given character is not part of the supported
     /// hexadecimal alphabet. Contains the index of the faulty byte

--- a/cardano/src/vss.rs
+++ b/cardano/src/vss.rs
@@ -5,7 +5,8 @@ use util::hex;
 const SIGNATURE_SIZE: usize = 64;
 
 // XXX Error and Result copied with slight modifications from redeem.rs
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub enum Error {
     InvalidSignatureSize(usize),
 }

--- a/cardano/src/wallet/rindex.rs
+++ b/cardano/src/wallet/rindex.rs
@@ -18,7 +18,8 @@ use input_selection;
 
 use super::scheme::{self};
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct Addressing(pub u32, pub u32);
 impl ::std::fmt::Display for Addressing {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {

--- a/exe-common/Cargo.toml
+++ b/exe-common/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Nicolas Di Prima <nicolas.diprima@iohk.io>"]
 
 [dependencies]
 cryptoxide = { path = "../cryptoxide" }
-cardano = { path = "../cardano" }
 storage = { path = "../storage" }
 protocol = { path = "../protocol" }
 cbor_event = { path = "../cbor_event" }
@@ -19,3 +18,6 @@ futures = "0.1"
 hyper = "0.11"
 tokio-core = "0.1"
 
+[dependencies.cardano]
+path = "../cardano"
+features = [ "generic-serialization" ]


### PR DESCRIPTION
closes #237 

replaces #248 

This makes serde serialization/deserialization optional, we only enable it if needed saving ~1MB in the total binary size at the end.