### PR TITLE
fix authors in Cargo.toml

### DIFF
--- a/cardano-c/Cargo.toml
+++ b/cardano-c/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cardano-c"
 version = "0.1.0"
-authors = ["Vincent Hanquez <vincent.hanquez@iohk.io>", "Nicolas Di Prima <nicolas.diprima@iohk.io>", "The Rust-Crypto Project Developers"]
+authors = ["Vincent Hanquez <vincent.hanquez@iohk.io>", "Nicolas Di Prima <nicolas.diprima@iohk.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/input-output-hk/rust-cardano"

--- a/cardano/Cargo.toml
+++ b/cardano/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cardano"
 version = "0.1.0"
-authors = ["Vincent Hanquez <vincent.hanquez@iohk.io>", "Nicolas Di Prima <nicolas.diprima@iohk.io>", "The Rust-Crypto Project Developers"]
+authors = ["Vincent Hanquez <vincent.hanquez@iohk.io>", "Nicolas Di Prima <nicolas.diprima@iohk.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/input-output-hk/rust-cardano"

--- a/cbor_event/Cargo.toml
+++ b/cbor_event/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cbor_event"
 version = "0.1.0"
-authors = ["Vincent Hanquez <vincent.hanquez@iohk.io>", "Nicolas Di Prima <nicolas.diprima@iohk.io>", "The Rust-Crypto Project Developers"]
+authors = ["Vincent Hanquez <vincent.hanquez@iohk.io>", "Nicolas Di Prima <nicolas.diprima@iohk.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 categories = ["binary", "cbor", "serialisation", "deserialisation", "cardano", "wasm"]

--- a/exe-common/Cargo.toml
+++ b/exe-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "exe-common"
 version = "0.1.0"
-authors = ["Vincent Hanquez <vincent.hanquez@iohk.io>", "Nicolas Di Prima <nicolas.diprima@iohk.io>", "The Rust-Crypto Project Developers"]
+authors = ["Vincent Hanquez <vincent.hanquez@iohk.io>", "Nicolas Di Prima <nicolas.diprima@iohk.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/input-output-hk/rust-cardano"

--- a/hermes/Cargo.toml
+++ b/hermes/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hermes"
 version = "0.1.0"
-authors = ["Vincent Hanquez <vincent.hanquez@iohk.io>", "Nicolas Di Prima <nicolas.diprima@iohk.io>", "The Rust-Crypto Project Developers"]
+authors = ["Vincent Hanquez <vincent.hanquez@iohk.io>", "Nicolas Di Prima <nicolas.diprima@iohk.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/input-output-hk/rust-cardano"

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "protocol"
 version = "0.1.0"
-authors = ["Vincent Hanquez <vincent.hanquez@iohk.io>", "Nicolas Di Prima <nicolas.diprima@iohk.io>", "The Rust-Crypto Project Developers"]
+authors = ["Vincent Hanquez <vincent.hanquez@iohk.io>", "Nicolas Di Prima <nicolas.diprima@iohk.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/input-output-hk/rust-cardano"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cardano-storage"
 version = "0.1.0"
-authors = ["Vincent Hanquez <vincent.hanquez@iohk.io>", "Nicolas Di Prima <nicolas.diprima@iohk.io>", "The Rust-Crypto Project Developers"]
+authors = ["Vincent Hanquez <vincent.hanquez@iohk.io>", "Nicolas Di Prima <nicolas.diprima@iohk.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/input-output-hk/rust-cardano"


### PR DESCRIPTION
fix authors in the Cargo.toml files. _The Rust-Crypto Project Developers_ is only for the cryptoxide crate.