### PR TITLE
Add utxo verification

### DIFF
--- a/cardano/src/address.rs
+++ b/cardano/src/address.rs
@@ -234,7 +234,7 @@ impl cbor_event::de::Deserialize for Attributes {
         let len = raw.map()?;
         let mut len = match len {
             cbor_event::Len::Indefinite => {
-               return Err(cbor_event::Error::CustomError(format!("Invalid Attribytes: recieved map of {:?} elements", len)));
+               return Err(cbor_event::Error::CustomError(format!("Invalid Attributes: received map of {:?} elements", len)));
             },
             cbor_event::Len::Len(len) => len
         };

--- a/cardano/src/block/verify.rs
+++ b/cardano/src/block/verify.rs
@@ -37,6 +37,7 @@ pub enum Error {
     WrongMagic,
     WrongMerkleRoot,
     WrongMpcProof,
+    WrongRedeemTxId,
     WrongTxProof,
     WrongUpdateProof,
     ZeroCoin,
@@ -52,8 +53,8 @@ pub enum Error {
     OutputsTooBig,
     OutputsExceedInputs,
     FeeError(fee::Error),
-    WrongRedeemTxId,
     AddressMismatch,
+    DuplicateTxo,
 }
 
 impl fmt::Display for Error {
@@ -94,9 +95,10 @@ impl fmt::Display for Error {
             InputsTooBig => write!(f, "sum of inputs exceeds limit"),
             OutputsTooBig => write!(f, "sum of outputs exceeds limit"),
             OutputsExceedInputs => write!(f, "sum of outputs is larger than sum of inputs and fee"),
-            FeeError(err) => write!(f, "fee calculation failed: {}", err),
+            FeeError(_) => write!(f, "fee calculation failed"),
             WrongRedeemTxId => write!(f, "transaction input's ID does not match redeem public key"),
-            AddressMismatch => write!(f, "transaction input witness does not match utxo address")
+            AddressMismatch => write!(f, "transaction input witness does not match utxo address"),
+            DuplicateTxo => write!(f, "transaction has an output that already exists"),
         }
     }
 }
@@ -109,6 +111,7 @@ impl error::Error for Error {
     fn cause(&self) -> Option<& error::Error> {
         match self {
             Error::EncodingError(ref error) => Some(error),
+            Error::FeeError(ref error) => Some(error),
             _ => None
         }
     }

--- a/cardano/src/block/verify_chain.rs
+++ b/cardano/src/block/verify_chain.rs
@@ -201,7 +201,7 @@ impl ChainState {
                     match input_amount + txout.value {
                         Ok(x) => { input_amount = x; }
                         Err(coin::Error::OutOfBound(_)) => add_error(&mut res, Err(Error::InputsTooBig)),
-                        Err(_) => panic!()
+                        Err(err) => unreachable!("{}", err)
                     }
                 }
             }
@@ -213,7 +213,7 @@ impl ChainState {
             match output_amount + output.value {
                 Ok(x) => { output_amount = x; }
                 Err(coin::Error::OutOfBound(_)) => add_error(&mut res, Err(Error::OutputsTooBig)),
-                Err(_) => panic!()
+                Err(err) => unreachable!("{}", err)
             }
         }
 
@@ -237,7 +237,7 @@ impl ChainState {
                 add_error(&mut res, Err(Error::OutputsTooBig));
                 output_amount
             }
-            Err(_) => panic!()
+            Err(err) => unreachable!("{}", err)
         };
 
         // Check that total outputs + minimal fee <= total inputs.
@@ -248,7 +248,7 @@ impl ChainState {
         // Add the outputs to the utxo state.
         for (index, output) in tx.outputs.iter().enumerate() {
             if self.utxos.insert(TxoPointer { id, index: index as u32 }, output.clone()).is_some() {
-                panic!("utxo map already contains txo {}/{}", id, index);
+                add_error(&mut res, Err(Error::DuplicateTxo));
             }
         }
 

--- a/cardano/src/block/verify_chain.rs
+++ b/cardano/src/block/verify_chain.rs
@@ -17,6 +17,10 @@ pub struct ChainState {
     pub prev_date: Option<BlockDate>,
     pub slot_leaders: Vec<address::StakeholderId>,
     pub utxos: BTreeMap<TxoPointer, TxOut>,
+
+    // Some stats.
+    pub nr_transactions: u64,
+    pub spend_txos: u64,
 }
 
 impl ChainState {
@@ -43,6 +47,8 @@ impl ChainState {
             prev_date: None,
             slot_leaders: vec![],
             utxos,
+            nr_transactions: 0,
+            spend_txos: 0,
         }
     }
 
@@ -141,6 +147,8 @@ impl ChainState {
     /// outputs (utxos), and update the utxo state.
     fn verify_tx(&mut self, txaux: &TxAux) -> Result<(), Error> {
 
+        self.nr_transactions += 1;
+
         let mut res = Ok(());
         let tx = &txaux.tx;
         let id = tx.id();
@@ -160,6 +168,8 @@ impl ChainState {
                     add_error(&mut res, Err(Error::MissingUtxo));
                 }
                 Some(txout) => {
+
+                    self.spend_txos += 1;
 
                     let witness_address = match in_witness {
 

--- a/cardano/src/config.rs
+++ b/cardano/src/config.rs
@@ -92,6 +92,6 @@ pub struct GenesisData {
     pub epoch_stability_depth: usize, // a.k.a. 'k'
     pub protocol_magic: ProtocolMagic,
     pub fee_policy: fee::LinearFee,
-    pub avvm_distr: BTreeMap<redeem::PublicKey, coin::Coin>,
+    pub avvm_distr: BTreeMap<redeem::PublicKey, coin::Coin>, // AVVM = Ada Voucher Vending Machine
     pub non_avvm_balances: BTreeMap<String, coin::Coin>,
 }

--- a/cardano/src/config.rs
+++ b/cardano/src/config.rs
@@ -6,6 +6,11 @@
 
 use cbor_event::{self, de::RawCbor, se::{Serializer}};
 use std::fmt;
+use block;
+use fee;
+use coin;
+use redeem;
+use std::collections::BTreeMap;
 
 /// this is the protocol magic number
 ///
@@ -74,4 +79,19 @@ impl Default for Config {
     fn default() -> Self {
         Config::new(ProtocolMagic::default())
     }
+}
+
+/// A subset of the genesis data. The genesis data is a JSON file
+/// whose canonicalized form has the hash 'genesis_prev', which is the
+/// parent of the genesis block of epoch 0. (Note that "genesis data"
+/// is something completely different from a epoch genesis block. The
+/// genesis data is not stored in the chain as a block.)
+#[derive(Debug)]
+pub struct GenesisData {
+    pub genesis_prev: block::HeaderHash,
+    pub epoch_stability_depth: usize, // a.k.a. 'k'
+    pub protocol_magic: ProtocolMagic,
+    pub fee_policy: fee::LinearFee,
+    pub avvm_distr: BTreeMap<redeem::PublicKey, coin::Coin>,
+    pub non_avvm_balances: BTreeMap<String, coin::Coin>,
 }

--- a/cardano/src/tx.rs
+++ b/cardano/src/tx.rs
@@ -16,13 +16,21 @@ use redeem;
 use tags::{SigningTag};
 
 use hdwallet::{Signature, XPub, XPrv, XPUB_SIZE, SIGNATURE_SIZE};
-use address::{ExtendedAddr, SpendingData};
+use address::{ExtendedAddr, SpendingData, AddrType, Attributes};
 use coin::{self, Coin};
 
-// TODO: this seems to be the hash of the serialisation CBOR of a given Tx.
-// if this is confirmed, we need to make a proper type, wrapping it around
-// to hash a `Tx` by serializing it cbor first.
+// Transaction IDs are either a hash of the CBOR serialisation of a
+// given Tx, or a hash of a redeem address.
 pub type TxId = Blake2b256;
+
+pub fn redeem_pubkey_to_txid(pubkey: &redeem::PublicKey) -> (TxId, ExtendedAddr) {
+    let address = ExtendedAddr::new(
+        AddrType::ATRedeem,
+        SpendingData::RedeemASD(*pubkey),
+        Attributes::new_bootstrap_era(None));
+    let txid = Blake2b256::new(&cbor!(&address).unwrap());
+    (txid, address)
+}
 
 /// Tx Output composed of an address and a coin value
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/cardano/src/txbuild.rs
+++ b/cardano/src/txbuild.rs
@@ -266,7 +266,6 @@ impl TxFinalized {
 mod tests {
     use super::*;
     use address::ExtendedAddr;
-    use coin;
     use tx::{TxOut, TxId};
     use fee::LinearFee;
     use hash::Blake2b256;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -17,7 +17,7 @@ use std::{fs, io, result};
 pub use config::StorageConfig;
 
 use std::{collections::BTreeMap, fmt, error};
-use cardano::{block::{HeaderHash, BlockDate, RawBlock, Block, EpochId, SlotId}, util::hex};
+use cardano::{block::{HeaderHash, BlockDate, RawBlock, Block, EpochId, SlotId}};
 
 use types::*;
 use storage_units::utils::tmpfile::*;


### PR DESCRIPTION
This adds support for keeping track of utxos. It extends ChainState with a map from TxoPointers to TxOuts. `ChainState::verify_tx()` checks that all transaction inputs are in the map and removes them. It also does some other checks (e.g. that `inputs+fee <= outputs`).

Currently the utxo map is initialized in cardano-cli from the AVVM distribution in the genesis data and the chain can only be verified in its entirety, but in the future we can snapshot the utxo map to disk to allow verification to start from an arbitrary epoch.

Issue #89.