### PR TITLE
Fix bad input selection in some rare cases

### DIFF
--- a/cardano/src/fee.rs
+++ b/cardano/src/fee.rs
@@ -3,7 +3,7 @@
 use std::{result, ops::{Add, Mul}};
 use coin;
 use coin::{Coin};
-use tx::{Tx, TxInWitness, TxAux, txaux_serialize};
+use tx::{Tx, TxInWitness, TxAux, txaux_serialize_size};
 use cbor_event;
 
 /// A fee value that represent either a fee to pay, or a fee paid.
@@ -119,9 +119,8 @@ impl FeeAlgorithm for LinearFee {
         self.estimate(txbytes.len())
     }
     fn calculate_for_txaux_component(&self, tx: &Tx, witnesses: &Vec<TxInWitness>) -> Result<Fee> {
-        let ser = cbor_event::se::Serializer::new_vec();
-        let txbytes = txaux_serialize(tx, witnesses, ser)?.finalize();
-        self.estimate(txbytes.len())
+        let size_bytes = txaux_serialize_size(tx, witnesses);
+        self.estimate(size_bytes)
     }
 }
 

--- a/cardano/src/input_selection.rs
+++ b/cardano/src/input_selection.rs
@@ -95,7 +95,12 @@ impl SelectionAlgorithm for LinearFee {
             , O : 'b + Iterator<Item = &'b TxOut> + Clone
             , Addressing: 'a
     {
-        debug_assert!(policy == SelectionPolicy::FirstMatchFirst);
+        // kind reminder to update the algorithm once we start to implement
+        // better kind of selection policy
+        debug_assert!(
+            policy == SelectionPolicy::FirstMatchFirst,
+            "Only supported selection policy here is FirstMatchFirst"
+        );
 
         // note: we cannot use `is_empty()` because it is an `ExactSizeIterator`
         //       and it does not expose this function directly.

--- a/cardano/src/txbuild.rs
+++ b/cardano/src/txbuild.rs
@@ -337,14 +337,13 @@ mod tests {
 
     #[test]
     fn txbuild_auto() {
-        let id1 = Blake2b256::new(&[1,2]);
         let inputs = vec![ fake_txopointer_val(300000u32.into()) ];
         let alg = LinearFee::default();
         let out_policy = OutputPolicy::One(decode_addr(RADDRS[2]));
         for out_value in [8000u32.into(), 12004u32.into(), 51235u32.into()].iter() {
             let outputs = vec![ TxOut::new(decode_addr(RADDRS[1]), *out_value) ];
             let mut builder = build_input_outputs(&inputs[..], &outputs[..]);
-            builder.add_output_policy(&alg, &out_policy);
+            builder.add_output_policy(&alg, &out_policy).unwrap();
 
             fee_is_minimal(builder.balance(&alg).unwrap());
             assert!(build_finalize(builder).is_ok())


### PR DESCRIPTION
Fix the input selection algorithm, make use of the `TxBuilder` to abstract the different sub computations of the different cbor encoding to prevent mis-computation of the fee.