### PR TITLE
Checked address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cardano"
 version = "0.1.0"
 dependencies = [
- "cbor_event 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cbor_event 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cryptoxide 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -47,7 +47,7 @@ name = "cardano-storage"
 version = "0.1.0"
 dependencies = [
  "cardano 0.1.0",
- "cbor_event 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cbor_event 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-units 0.1.0",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "cbor_event"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -159,7 +159,7 @@ name = "protocol"
 version = "0.1.0"
 dependencies = [
  "cardano 0.1.0",
- "cbor_event 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cbor_event 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -388,7 +388,7 @@ dependencies = [
 "checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
-"checksum cbor_event 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29a95a1de12d1f5a3ff0c34cd2578f625a5feddb5d5672546ebbbecdb6287a0f"
+"checksum cbor_event 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd1877f29511f8bbca55667b55e29e8d4ed80729155c9c9236d99bc340282a6f"
 "checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cryptoxide 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc9be687df90da186ed5c6ada0b6b4d69f5ad914071870bc5d41277377d30427"

--- a/cardano/Cargo.toml
+++ b/cardano/Cargo.toml
@@ -15,7 +15,7 @@ keywords = [ "Cardano", "Wallet", "Crypto" ]
 
 [dependencies]
 cryptoxide = "0.1"
-cbor_event = "1.0"
+cbor_event = "^1.0.1"
 
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }

--- a/cardano/src/address.rs
+++ b/cardano/src/address.rs
@@ -364,7 +364,8 @@ impl fmt::Display for Addr {
 
 impl cbor_event::se::Serialize for Addr {
     fn serialize<W: ::std::io::Write>(&self, serializer: Serializer<W>) -> cbor_event::Result<Serializer<W>> {
-        serializer.write_bytes(self.as_ref())
+        let raw_cbor = RawCbor::from(&self.0);
+        serializer.append_raw_cbor(&raw_cbor)
     }
 }
 impl cbor_event::de::Deserialize for Addr {

--- a/cardano/src/address.rs
+++ b/cardano/src/address.rs
@@ -361,6 +361,18 @@ impl fmt::Display for Addr {
     }
 }
 
+impl cbor_event::se::Serialize for Addr {
+    fn serialize<W: ::std::io::Write>(&self, serializer: Serializer<W>) -> cbor_event::Result<Serializer<W>> {
+        serializer.write_bytes(self.as_ref())
+    }
+}
+impl cbor_event::de::Deserialize for Addr {
+    fn deserialize<'a>(raw: &mut RawCbor<'a>) -> cbor_event::Result<Self> {
+        let ea : ExtendedAddr = cbor_event::de::Deserialize::deserialize(raw)?;
+        Ok(ea.to_address())
+    }
+}
+
 /// A valid cardano address deconstructed
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub struct ExtendedAddr {

--- a/cardano/src/address.rs
+++ b/cardano/src/address.rs
@@ -400,7 +400,7 @@ impl<'de> serde::Deserialize<'de> for Addr
             type Value = Addr;
 
             fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-                write!(fmt, "Expecting an Extended Address (`ExtendedAddr`)")
+                write!(fmt, "Expecting an Address (`Addr`)")
             }
 
             fn visit_str<'a, E>(self, v: &'a str) -> Result<Self::Value, E>
@@ -412,7 +412,7 @@ impl<'de> serde::Deserialize<'de> for Addr
                 };
 
                 match Self::Value::try_from_slice(&bytes) {
-                    Err(err) => { Err(E::custom(format!("unable to parse ExtendedAddr: {:?}", err))) },
+                    Err(err) => { Err(E::custom(format!("unable to parse Addr: {:?}", err))) },
                     Ok(v) => Ok(v)
                 }
             }
@@ -421,7 +421,7 @@ impl<'de> serde::Deserialize<'de> for Addr
                 where E: serde::de::Error
             {
                 match Self::Value::try_from_slice(v) {
-                    Err(err) => { Err(E::custom(format!("unable to parse ExtendedAddr: {:?}", err))) },
+                    Err(err) => { Err(E::custom(format!("unable to parse Addr: {:?}", err))) },
                     Ok(v) => Ok(v)
                 }
             }

--- a/cardano/src/address.rs
+++ b/cardano/src/address.rs
@@ -343,9 +343,7 @@ impl TryFromSlice for Addr {
 }
 
 impl From<ExtendedAddr> for Addr {
-    fn from(ea: ExtendedAddr) -> Self {
-        Addr(cbor!(ea).unwrap()) // unwrap should never fail from strongly typed extended addr to addr
-    }
+    fn from(ea: ExtendedAddr) -> Self { ea.to_address() }
 }
 
 impl fmt::Display for Addr {
@@ -373,6 +371,10 @@ impl ExtendedAddr {
     // bootstrap era + no hdpayload address
     pub fn new_simple(xpub: XPub) -> Self {
         ExtendedAddr::new(AddrType::ATPubKey, SpendingData::PubKeyASD(xpub), Attributes::new_bootstrap_era(None))
+    }
+
+    pub fn to_address(&self) -> Addr {
+        Addr(cbor!(self).unwrap()) // unwrap should never fail from strongly typed extended addr to addr
     }
 
 }
@@ -417,7 +419,7 @@ impl cbor_event::de::Deserialize for ExtendedAddr {
 }
 impl fmt::Display for ExtendedAddr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", base58::encode(&cbor!(self).unwrap()))
+        write!(f, "{}", self.to_address())
     }
 }
 #[cfg(feature = "generic-serialization")]

--- a/cardano/src/address.rs
+++ b/cardano/src/address.rs
@@ -51,7 +51,7 @@ impl AddrType {
         match self {
             AddrType::ATPubKey => 0,
             AddrType::ATScript => 1,
-            AddrType::ATRedeem => 2
+            AddrType::ATRedeem => 2,
         }
     }
 }

--- a/cardano/src/address.rs
+++ b/cardano/src/address.rs
@@ -324,6 +324,7 @@ impl FromStr for HashedSpendingData {
 }
 
 /// A valid cardano Address that is displayed in base58
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub struct Addr(Vec<u8>);
 
 impl Addr {

--- a/cardano/src/address.rs
+++ b/cardano/src/address.rs
@@ -1,4 +1,13 @@
 //! Address creation and parsing
+//!
+//! Address components are:
+//! * `HashedSpendingData` computed from `SpendingData`
+//! * `Attributes`
+//! * `AddrType`
+//!
+//! All this components form an `ExtendedAddr`, which serialized
+//! to binary makes an `Addr`
+//!
 use std::{fmt, str::{FromStr}, ops::{Deref}};
 #[cfg(feature = "generic-serialization")]
 use serde;

--- a/cardano/src/util/arbitrary.rs
+++ b/cardano/src/util/arbitrary.rs
@@ -63,7 +63,7 @@ impl Arbitrary for Wrapper<(hdwallet::XPrv, address::ExtendedAddr)> {
             stake_distribution: address::StakeDistribution::BootstrapEraDistr
         };
         let addr_type = address::AddrType::ATPubKey;
-        let addr = address::Addr::new(
+        let addr = address::HashedSpendingData::new(
             addr_type,
             &address::SpendingData::PubKeyASD(xprv.public()),
             &attributes


### PR DESCRIPTION
* rename Addr to HashedSpendingData
* introduce a new type Addr to be able to keep the address in binary form but validated. this is the equivalent to the result of the cbor serialization of ExtendedAddr