### PR TITLE
[WIP] Update handling

### DIFF
--- a/cardano/src/block/update.rs
+++ b/cardano/src/block/update.rs
@@ -30,7 +30,7 @@ impl cbor_event::de::Deserialize for UpdatePayload {
 
 #[derive(Debug, Clone)]
 pub struct UpdateProposal {
-    pub block_version: BlockVersion,
+    pub block_version: types::BlockVersion,
     pub block_version_mod: BlockVersionModifier,
     pub software_version: types::SoftwareVersion,
     pub data: BTreeMap<SystemTag, UpdateData>,
@@ -66,30 +66,6 @@ impl cbor_event::de::Deserialize for UpdateProposal {
             attributes: raw.deserialize()?,
             from: raw.deserialize()?,
             signature: raw.deserialize()?
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct BlockVersion {
-    pub major: u16,
-    pub minor: u16,
-    pub alt: u8,
-}
-
-impl cbor_event::se::Serialize for BlockVersion {
-    fn serialize<W: ::std::io::Write>(&self, serializer: cbor_event::se::Serializer<W>) -> cbor_event::Result<cbor_event::se::Serializer<W>> {
-        serializer.serialize(&(&self.major, &self.minor, &self.alt))
-    }
-}
-
-impl cbor_event::de::Deserialize for BlockVersion {
-    fn deserialize<'a>(raw: &mut RawCbor<'a>) -> cbor_event::Result<Self> {
-        raw.tuple(3, "BlockVersion")?;
-        Ok(Self {
-            major: raw.deserialize()?,
-            minor: raw.deserialize()?,
-            alt: raw.deserialize()?
         })
     }
 }
@@ -248,7 +224,7 @@ impl cbor_event::de::Deserialize for UpdateVote {
 
 #[derive(Debug, Clone)]
 pub struct UpdateProposalToSign<'a> {
-    pub block_version: &'a BlockVersion,
+    pub block_version: &'a types::BlockVersion,
     pub block_version_mod: &'a BlockVersionModifier,
     pub software_version: &'a types::SoftwareVersion,
     pub data: &'a BTreeMap<SystemTag, UpdateData>,

--- a/cardano/src/block/verify_chain.rs
+++ b/cardano/src/block/verify_chain.rs
@@ -1,29 +1,68 @@
 use std::mem;
+use std::cmp;
 use block::*;
 use address;
-use config::{ProtocolMagic, GenesisData};
+use config::{GenesisData, ChainParameters, BootStakeholder};
 use coin;
 use tx::{self, TxAux, TxoPointer, TxOut, TxInWitness};
-use std::collections::BTreeMap;
-use fee::{self, FeeAlgorithm};
+use std::collections::{BTreeMap, BTreeSet};
+use fee::{FeeAlgorithm};
+use hash;
 
 pub type Utxos = BTreeMap<TxoPointer, TxOut>;
 
 #[derive(Debug, Clone)]
 pub struct ChainState {
-    // FIXME: maybe we should just keep a ref to GenesisData?  Though
-    // I guess at least the fee policy could change in an update.
-    pub protocol_magic: ProtocolMagic,
-    pub fee_policy: fee::LinearFee,
+    // The current protocol version. All blocks are verified according
+    // to the protocol parameters / rules corresponding to
+    // adopted_version regardless of the version specified in the
+    // block's header. The latter is only used (at the start of a new
+    // epoch) to decide whether to adopt a new version (namely if a
+    // sufficient number of stakeholders have upgraded).
+    pub adopted_version: BlockVersion,
+
+    // The protocol parameters corresponding to adopted_version. These
+    // may change when a new version is adopted.
+    pub chain_parameters: ChainParameters,
+
+    // Note: currently, stakeholders == boot_stakeholders. FIXME: we
+    // may want a map indexed by delegate_pk.
+    pub stakeholders: BTreeMap<address::StakeholderId, BootStakeholder>,
+    pub total_stake_weight: StakeWeight,
 
     pub prev_block: HeaderHash,
     pub prev_date: Option<BlockDate>,
     pub slot_leaders: Vec<address::StakeholderId>,
     pub utxos: Utxos,
 
+    // Updates.
+    pub active_proposals: BTreeMap<update::UpId, ActiveProposal>,
+    pub competing_proposals: BTreeMap<BlockVersion, CompetingProposal>,
+
     // Some stats.
     pub nr_transactions: u64,
     pub spend_txos: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct ActiveProposal {
+    pub date: BlockDate,
+    pub proposal: update::UpdateProposal,
+    pub votes: Vec<(update::UpdateVote, StakeWeight)>,
+}
+
+pub type StakeWeight = u64;
+
+#[derive(Debug, Clone)]
+pub struct CompetingProposal {
+    pub proposal: update::UpdateProposal,
+
+    // This is 'k' blocks after the block where the proposal was
+    // accepted.
+    pub confirmation_date: BlockDate,
+
+    // Stakeholders that have issued blocks with this version.
+    pub issuers: BTreeSet<address::StakeholderId>,
 }
 
 impl ChainState {
@@ -44,12 +83,16 @@ impl ChainState {
         // FIXME: implement non_avvm_balances.
 
         ChainState {
-            protocol_magic: genesis_data.protocol_magic,
-            fee_policy: genesis_data.fee_policy,
+            adopted_version: BlockVersion::new(0, 0, 0),
+            chain_parameters: genesis_data.chain_parameters.clone(),
+            stakeholders: genesis_data.boot_stakeholders.clone(),
+            total_stake_weight: genesis_data.boot_stakeholders.iter().map(|(_, v)| v.weight as u64).sum(),
             prev_block: genesis_data.genesis_prev.clone(),
             prev_date: None,
             slot_leaders: vec![],
             utxos,
+            active_proposals: BTreeMap::new(),
+            competing_proposals: BTreeMap::new(),
             nr_transactions: 0,
             spend_txos: 0,
         }
@@ -75,39 +118,90 @@ impl ChainState {
     /// errors, the chain state is updated to reflect the changes
     /// introduced by this block.
     /// FIXME: we may want to return all errors rather than just the first.
-    pub fn verify_block(&mut self, block_hash: &HeaderHash, blk: &Block) -> Result<(), Error> {
-
+    pub fn verify_block(&mut self, block_hash: &HeaderHash,
+                        blk: &Block, rblk: &RawBlock)
+                        -> Result<(), Error>
+    {
         let mut res = Ok(());
 
-        add_error(&mut res, self.do_verify(block_hash, blk));
+        let date = blk.get_header().get_blockdate();
 
-        self.prev_block = block_hash.clone();
-        self.prev_date = Some(blk.get_header().get_blockdate());
+        add_error(&mut res, self.do_verify(block_hash, blk, rblk));
 
         match blk {
 
             Block::BoundaryBlock(blk) => {
                 self.slot_leaders = blk.body.slot_leaders.clone();
+                // TODO: check leaders
+
+                // Check whether any competing proposals have reached
+                // the adoption threshold.
+                let mut new_version = None;
+
+                for (competitor_version, competitor) in &self.competing_proposals {
+
+                    let mut stake_weight: StakeWeight = 0;
+
+                    for issuer in &competitor.issuers {
+                        let stakeholder = self.stakeholders.get(issuer).unwrap();
+                        stake_weight += stakeholder.weight as StakeWeight;
+                    }
+
+                    let threshold = cmp::max(self.chain_parameters.softfork_min_thd,
+                                             self.chain_parameters.softfork_init_thd -
+                                             (date.get_epochid() - competitor.confirmation_date.get_epochid()) // FIXME: underflow
+                                             * self.chain_parameters.softfork_thd_decrement);
+
+                    //debug!("competitor {} has stake {}, threshold is {}", competitor_version, stake_weight, threshold);
+
+                    if (stake_weight as f64) / (self.total_stake_weight as f64) * 1e15 >= threshold as f64 {
+                        //debug!("block version {} adopted at {}", competitor_version, date);
+                        new_version = Some(competitor_version.clone());
+                    }
+                }
+
+                if let Some(new_version) = new_version {
+                    let competitor = self.competing_proposals.remove(&new_version).unwrap();
+                    self.adopt_new_version(&competitor.proposal);
+                }
             },
 
-            Block::MainBlock(_) => {
+            Block::MainBlock(blk) => {
+
+                // Check the block version: it must be either the
+                // currently adopted version or a competing version.
+                let block_version = blk.header.extra_data.block_version;
+                if let Some(competitor) = self.competing_proposals.get_mut(&block_version) {
+                    if date >= competitor.confirmation_date {
+                        competitor.issuers.insert(
+                            address::StakeholderId::new(&blk.header.consensus.leader_key));
+                    } else {
+                        add_error(&mut res, Err(Error::WrongBlockVersion(block_version)));
+                    }
+                } else if block_version != self.adopted_version {
+                    add_error(&mut res, Err(Error::WrongBlockVersion(block_version)));
+                }
+
+                // Update the utxos from the transactions.
+                for txaux in blk.body.tx.iter() {
+                    add_error(&mut res, self.verify_tx(txaux));
+                }
+
+                // Add update proposals and/or votes.
+                add_error(&mut res, self.handle_update(&blk.body.update, &date));
             }
         };
 
-        // Update the utxos from the transactions.
-        if let Block::MainBlock(blk) = blk {
-            for txaux in blk.body.tx.iter() {
-                add_error(&mut res, self.verify_tx(txaux));
-            }
-        }
+        self.prev_block = block_hash.clone();
+        self.prev_date = Some(date);
 
         res
     }
 
-    fn do_verify(&self, block_hash: &HeaderHash, blk: &Block) -> Result<(), Error>
+    fn do_verify(&self, block_hash: &HeaderHash, blk: &Block, rblk: &RawBlock) -> Result<(), Error>
     {
         // Perform stateless checks.
-        verify_block(self.protocol_magic, block_hash, blk)?;
+        verify_block(&self.chain_parameters, block_hash, blk, rblk)?;
 
         if blk.get_header().get_previous_header() != self.prev_block {
             return Err(Error::WrongPreviousBlock)
@@ -156,8 +250,13 @@ impl ChainState {
                 if slot_leader != &address::StakeholderId::new(&blk.header.consensus.leader_key) {
                     return Err(Error::WrongSlotLeader)
                 }
+
+                // TODO: properly check that block_signature is
+                // issued/delegated by the slot leader.
             }
         };
+
+        // FIXME: check that block version is currently adopted or competing.
 
         Ok(())
     }
@@ -241,7 +340,7 @@ impl ChainState {
         let min_fee =
             if nr_redeems == tx.inputs.len() { coin::Coin::zero() }
             else {
-                match self.fee_policy.calculate_for_txaux(&txaux) {
+                match self.chain_parameters.fee_policy.calculate_for_txaux(&txaux) {
                     Ok(fee) => fee.to_coin(),
                     Err(err) => {
                         add_error(&mut res, Err(Error::FeeError(err)));
@@ -273,6 +372,128 @@ impl ChainState {
 
         res
     }
+
+    fn handle_update(&mut self, update: &update::UpdatePayload, date: &BlockDate) -> Result<(), Error> {
+        let mut res = Ok(());
+
+        if let Some(proposal) = &update.proposal {
+            let proposal_id = hash::Blake2b256::new(&cbor!(proposal)?);
+
+            let stakeholder = self.stakeholders.iter().find(|&(_, v)| v.delegate_pk == proposal.from);
+
+            if let Some((_, stakeholder)) = stakeholder {
+
+                // Check that the proposer has sufficient stake.
+                // FIXME: investigate exactly how we're supposed to handle precision etc.
+                if (stakeholder.weight as f64) / (self.total_stake_weight as f64) * 1e15
+                    < self.chain_parameters.update_proposal_thd as f64
+                {
+                    add_error(&mut res, Err(Error::InsufficientProposerStake));
+                }
+
+            } else {
+                add_error(&mut res, Err(Error::UnknownProposer));
+            }
+
+            self.active_proposals.insert(proposal_id, ActiveProposal {
+                date: date.clone(),
+                proposal: proposal.clone(),
+                votes: vec![],
+            });
+        }
+
+        for vote in &update.votes {
+
+            // "Voter stake check"
+            let stakeholder = self.stakeholders.iter().find(|&(_, v)| v.delegate_pk == vote.key);
+
+            if let Some((_, stakeholder)) = stakeholder {
+
+                // FIXME: investigate exactly how we're supposed to handle precision etc.
+                if (stakeholder.weight as f64) / (self.total_stake_weight as f64) * 1e15
+                    < self.chain_parameters.update_vote_thd as f64
+                {
+                    add_error(&mut res, Err(Error::InsufficientVoterStake));
+                }
+
+                // "Existence proposal check" and "Active proposal check"
+                let mut approved = false;
+                let mut rejected = false;
+
+                if let Some(proposal) = self.active_proposals.get_mut(&vote.proposal_id) {
+                    // TODO: "Revote check"
+                    proposal.votes.push((vote.clone(), stakeholder.weight as StakeWeight));
+
+                    // Check whether the proposal has reached 50% stake in favor or against.
+                    // TODO: do proposals ever expire?
+                    let mut stake_weight_for = 0;
+                    let mut stake_weight_against = 0;
+                    for vote in &proposal.votes {
+                        if vote.0.decision {
+                            stake_weight_for += vote.1;
+                        } else {
+                            stake_weight_against += vote.1;
+                        }
+                    }
+
+                    if (stake_weight_for as f64) / (self.total_stake_weight as f64) > 0.5 {
+                        approved = true;
+                    } else if (stake_weight_against as f64) / (self.total_stake_weight as f64) > 0.5 {
+                        rejected = true;
+                    }
+
+                } else {
+                    add_error(&mut res, Err(Error::MissingProposal));
+                }
+
+                if approved {
+                    //debug!("proposal {} approved at {}", vote.proposal_id, date);
+                    let proposal = self.active_proposals.remove(&vote.proposal_id).unwrap();
+
+                    // Ignore proposals that don't change the
+                    // version. Presumably they just deploy a new
+                    // software version. TODO: verify that this
+                    // proposal's block_version_mod doesn't change any
+                    // parameters.
+                    if proposal.proposal.block_version != self.adopted_version {
+                        self.competing_proposals.insert(
+                            proposal.proposal.block_version.clone(),
+                            CompetingProposal {
+                                proposal: proposal.proposal,
+                                confirmation_date: *date /* + k */, // FIXME
+                                issuers: BTreeSet::new(),
+                            });
+                    }
+                }
+
+                if rejected {
+                    //debug!("proposal {} rejected at {}", vote.proposal_id, date);
+                    self.active_proposals.remove(&vote.proposal_id);
+                }
+
+            } else {
+                add_error(&mut res, Err(Error::UnknownVoter));
+            }
+        }
+
+        res
+    }
+
+    /// Apply any chain parameters changes from the given update
+    /// proposal.
+    fn adopt_new_version(&mut self, proposal: &update::UpdateProposal) {
+        self.adopted_version = proposal.block_version;
+        let mods = &proposal.block_version_mod;
+        maybe_assign(&mut self.chain_parameters.max_block_size, &mods.max_block_size);
+        maybe_assign(&mut self.chain_parameters.max_header_size, &mods.max_header_size);
+        maybe_assign(&mut self.chain_parameters.max_tx_size, &mods.max_tx_size);
+        maybe_assign(&mut self.chain_parameters.max_proposal_size, &mods.max_proposal_size);
+        // TODO
+        //maybe_assign(&mut self.chain_parameters.fee_policy, &mods.tx_fee_policy);
+        //maybe_assign(&mut self.chain_parameters.update_proposal_thd, &mods.update_proposal_thd);
+        //maybe_assign(&mut self.chain_parameters.update_vote_thd, &mods.update_vote_thd);
+        // softfork_rule
+    }
 }
 
 // FIXME: might be nice to return a list of errors. Currently we only
@@ -280,5 +501,11 @@ impl ChainState {
 fn add_error(res: &mut Result<(), Error>, err: Result<(), Error>) {
     if res.is_ok() && err.is_err() {
         mem::replace(res, err);
+    }
+}
+
+fn maybe_assign<T: Clone>(dst: &mut T, src: &Option<T>) {
+    if let Some(src) = src {
+        mem::replace(dst, src.clone());
     }
 }

--- a/exe-common/src/parse_genesis_data.rs
+++ b/exe-common/src/parse_genesis_data.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, BTreeMap};
+use std::str::FromStr;
 use serde_json;
-use cardano::{config, fee, block, coin, redeem};
+use cardano::{config, fee, block, coin, redeem, address, hdwallet};
 use base64;
 
 #[allow(non_snake_case)]
@@ -10,6 +11,9 @@ struct RawGenesisData {
     nonAvvmBalances: HashMap<String, String>,
     protocolConsts: ProtocolConsts,
     blockVersionData: BlockVersionData,
+    bootStakeholders: HashMap<String, config::BootStakeWeight>,
+    heavyDelegation: HashMap<String, HeavyDelegation>,
+    //vssCerts: HashMap<String, VssCert>,
 }
 
 #[allow(non_snake_case)]
@@ -22,13 +26,35 @@ struct ProtocolConsts {
 #[allow(non_snake_case)]
 #[derive(Deserialize, Debug)]
 struct BlockVersionData {
+    maxBlockSize: String,
+    maxHeaderSize: String,
+    maxTxSize: String,
+    maxProposalSize: String,
+    softforkRule: SoftforkRule,
     txFeePolicy: TxFeePolicy,
+    updateProposalThd: String,
+    updateVoteThd: String,
+}
+
+#[allow(non_snake_case)]
+#[derive(Deserialize, Debug)]
+struct SoftforkRule {
+    initThd: String,
+    minThd: String,
+    thdDecrement: String,
 }
 
 #[derive(Deserialize, Debug)]
 struct TxFeePolicy {
     summand: String,
     multiplier: String,
+}
+
+#[allow(non_snake_case)]
+#[derive(Deserialize, Debug)]
+struct HeavyDelegation {
+    issuerPk: String,
+    delegatePk: String,
 }
 
 pub fn parse_genesis_data(json: &str) -> config::GenesisData { // FIXME: use Result
@@ -49,15 +75,48 @@ pub fn parse_genesis_data(json: &str) -> config::GenesisData { // FIXME: use Res
             coin::Coin::new(balance.parse::<u64>().unwrap()).unwrap());
     }
 
+    let mut boot_stakeholders = BTreeMap::new();
+
+    for (stakeholder_id, weight) in &data.bootStakeholders {
+        let heavy = data.heavyDelegation.get(stakeholder_id).unwrap();
+
+        let stakeholder_id = address::StakeholderId::from_str(stakeholder_id).unwrap();
+
+        let issuer_pk = hdwallet::XPub::from_slice(
+            &base64::decode(&heavy.issuerPk).unwrap()).unwrap();
+
+        assert_eq!(stakeholder_id, address::StakeholderId::new(&issuer_pk));
+
+        boot_stakeholders.insert(
+            stakeholder_id,
+            config::BootStakeholder {
+                weight: *weight,
+                delegate_pk: hdwallet::XPub::from_slice(
+                    &base64::decode(&heavy.delegatePk).unwrap()).unwrap()
+            });
+    }
+
     config::GenesisData {
         genesis_prev: block::HeaderHash::new(canonicalize_json(json).as_bytes()),
-        epoch_stability_depth: data.protocolConsts.k,
-        protocol_magic: config::ProtocolMagic::from(data.protocolConsts.protocolMagic),
-        fee_policy: fee::LinearFee::new(
-            parse_fee_constant(&data.blockVersionData.txFeePolicy.summand),
-            parse_fee_constant(&data.blockVersionData.txFeePolicy.multiplier)),
         avvm_distr,
         non_avvm_balances: BTreeMap::new(), // FIXME
+        chain_parameters: config::ChainParameters {
+            protocol_magic: config::ProtocolMagic::from(data.protocolConsts.protocolMagic),
+            epoch_stability_depth: data.protocolConsts.k,
+            max_block_size: data.blockVersionData.maxBlockSize.parse().unwrap(),
+            max_header_size: data.blockVersionData.maxHeaderSize.parse().unwrap(),
+            max_tx_size: data.blockVersionData.maxTxSize.parse().unwrap(),
+            max_proposal_size: data.blockVersionData.maxProposalSize.parse().unwrap(),
+            softfork_init_thd: data.blockVersionData.softforkRule.initThd.parse().unwrap(),
+            softfork_min_thd: data.blockVersionData.softforkRule.minThd.parse().unwrap(),
+            softfork_thd_decrement: data.blockVersionData.softforkRule.thdDecrement.parse().unwrap(),
+            fee_policy: fee::LinearFee::new(
+                parse_fee_constant(&data.blockVersionData.txFeePolicy.summand),
+                parse_fee_constant(&data.blockVersionData.txFeePolicy.multiplier)),
+            update_proposal_thd: data.blockVersionData.updateProposalThd.parse().unwrap(),
+            update_vote_thd: data.blockVersionData.updateVoteThd.parse().unwrap(),
+        },
+        boot_stakeholders
     }
 }
 

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -173,7 +173,7 @@ fn net_sync_to<A: Api>(
             if let Some(epoch_writer_state) = epoch_writer_state.as_mut() {
 
                 // FIXME: propagate errors
-                epoch_writer_state.chain_state.verify_block(block_hash, block)
+                epoch_writer_state.chain_state.verify_block(block_hash, block, block_raw)
                     .expect(&format!("Block {} failed to verify.", block_hash));
 
                 epoch_writer_state.writer.append(
@@ -272,7 +272,7 @@ fn append_blocks_to_epoch_reverse(
     while let Some((hash, block_raw, block)) = blocks.pop() {
 
         // FIXME: propagate errors
-        epoch_writer_state.chain_state.verify_block(&hash, &block)
+        epoch_writer_state.chain_state.verify_block(&hash, &block, &block_raw)
             .expect(&format!("Block {} failed to verify.", hash));
 
         epoch_writer_state.writer.append(&types::header_to_blockhash(&hash),


### PR DESCRIPTION
This is not finished yet (there are a bunch of update validity checks missing, among other things), but it does already handle the maximum transaction size change in version 0.1.0 of mainnet. So `ChainState::verify_block()` now correctly enforces such size limits.