### PR TITLE
wallet::rindex: Add method RootKey::into_xprv()

### DIFF
--- a/cardano/src/wallet/rindex.rs
+++ b/cardano/src/wallet/rindex.rs
@@ -315,6 +315,11 @@ impl RootKey {
         Ok(RootKey::new(xprv, derivation_scheme))
     }
 
+    /// Converts into the inner `XPrv` value
+    pub fn into_xprv(self) -> XPrv {
+        self.root_key
+    }
+
     pub fn address_generator(&self) -> AddressGenerator<XPrv>
     {
         AddressGenerator::<XPrv>::new(self.root_key.clone(), self.derivation_scheme)


### PR DESCRIPTION
This comes handy in code that needs to extract the inner XPrv value
from a RootKey that can be moved, rather than doing `(*root_key).clone()`.

The method name follows the [Rust API conventions][c-conv] for ad-hoc conversion methods.

[c-conv]: https://rust-lang-nursery.github.io/api-guidelines/naming.html#c-conv