### PR TITLE
storage-units: Make utils::Lock accept generic path arguments

### DIFF
--- a/storage-units/src/utils/lock.rs
+++ b/storage-units/src/utils/lock.rs
@@ -96,10 +96,10 @@ impl Lock {
     /// already exists, the function fail straight away and do not wait
     /// for the other process to release the `Lock`.
     ///
-    pub fn lock(path: PathBuf) -> Result<Self> {
+    pub fn lock<P: Into<PathBuf>>(path: P) -> Result<Self> {
         let lock = Lock {
             id: process::id(),
-            path,
+            path: path.into(),
         };
         lock.acquire()?;
         Ok(lock)


### PR DESCRIPTION
Make it work with more types of file name arguments in a backward-compatible way.