### PR TITLE
cardano: Re-export bip44::bip44::Error as bip44::Error

### DIFF
--- a/cardano/src/wallet/bip44.rs
+++ b/cardano/src/wallet/bip44.rs
@@ -12,7 +12,7 @@ use std::{ops::Deref, collections::{BTreeMap}};
 use super::scheme::{self};
 use super::keygen;
 
-pub use bip::bip44::{self, AddrType, Addressing, Change, Index};
+pub use bip::bip44::{self, AddrType, Addressing, Change, Error, Index};
 
 /// BIP44 based wallet, i.e. using sequential indexing.
 ///


### PR DESCRIPTION
That's one less `bip44`.

`pub use bip::bip44::{self}` should be re-considered in the long term.