### PR TITLE
cardano: Implement Display for proof hash types

### DIFF
--- a/cardano/src/block/normal.rs
+++ b/cardano/src/block/normal.rs
@@ -68,6 +68,12 @@ impl DlgProof {
     }
 }
 
+impl fmt::Display for DlgProof {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 impl cbor_event::se::Serialize for DlgProof {
     fn serialize<W: ::std::io::Write>(&self, serializer: cbor_event::se::Serializer<W>) -> cbor_event::Result<cbor_event::se::Serializer<W>> {
         serializer.serialize(&self.0)

--- a/cardano/src/block/update.rs
+++ b/cardano/src/block/update.rs
@@ -1,8 +1,12 @@
 use cbor_event::{self, de::RawCbor};
 use hash::{self, Blake2b256};
 use hdwallet;
-use std::collections::{BTreeMap};
 use super::types;
+
+use std::{
+    collections::{BTreeMap},
+    fmt,
+};
 
 #[derive(Debug, Clone)]
 pub struct UpdatePayload {
@@ -36,6 +40,12 @@ impl UpdateProof {
     pub fn generate(update: &UpdatePayload) -> Self {
         let h = Blake2b256::new(&cbor!(update).unwrap());
         UpdateProof(h)
+    }
+}
+
+impl fmt::Display for UpdateProof {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 


### PR DESCRIPTION
The CLI needs `Display` implemented for `block::normal::DlgProof` and `block::update::UpdateProof`.