### PR TITLE
storage-units: Use 64-bit math to calculate reffile offset

### DIFF
--- a/storage-units/src/reffile.rs
+++ b/storage-units/src/reffile.rs
@@ -26,8 +26,8 @@ impl Reader {
     }
 
     pub fn getref_at_index(&mut self, index: u32) -> io::Result<Option<BlockHash>> {
-        let offset = index as usize * HASH_SIZE;
-        self.handle.seek(SeekFrom::Start(offset as u64))?;
+        let offset = (index as u64) * (HASH_SIZE as u64);
+        self.handle.seek(SeekFrom::Start(offset))?;
         self.next()
     }
 


### PR DESCRIPTION
This prevents integer overflows on 32-bit platforms.