### PR TITLE
storage: Improved block location API

### DIFF
--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -1,6 +1,6 @@
 use config::net;
 use network::{Peer, api::Api, api::BlockRef, Result};
-use cardano_storage::{tag, Error, block_read, epoch::{self, epoch_exists}, blob, pack, Storage, types, chain_state};
+use cardano_storage::{tag, Error, epoch::{self, epoch_exists}, blob, pack, Storage, types, chain_state};
 use cardano::block::{BlockDate, EpochId, HeaderHash, BlockHeader, Block, RawBlock, ChainState};
 use cardano::config::{GenesisData};
 use cardano::util::{hex};
@@ -118,7 +118,7 @@ fn net_sync_to<A: Api>(
         // Iterate to the last block in the previous epoch.
         let mut cur_hash = our_tip.0.hash.clone();
         loop {
-            let block_raw = block_read(&storage, &cur_hash.into()).unwrap();
+            let block_raw = storage.read_block(&cur_hash.into()).unwrap();
             let block = block_raw.decode().unwrap();
             let hdr = block.get_header();
             assert!(hdr.get_blockdate().get_epochid() == first_unstable_epoch);
@@ -277,7 +277,7 @@ fn get_unpacked_blocks_in_epoch(storage: &Storage, last_block: &HeaderHash, epoc
     let mut cur_hash = last_block.clone();
     let mut blocks = vec![];
     loop {
-        let block_raw = block_read(&storage, &cur_hash.clone().into()).unwrap();
+        let block_raw = storage.read_block(&cur_hash.clone().into()).unwrap();
         blobs_to_delete.push(cur_hash.clone());
         let block = block_raw.decode().unwrap();
         let hdr = block.get_header();

--- a/storage/src/iter/mod.rs
+++ b/storage/src/iter/mod.rs
@@ -20,7 +20,7 @@ pub use self::reverse::iter as reverse_iter;
 
 use super::Result;
 
-use super::{BlockLocation2, Storage};
+use super::{BlockLocation, Storage};
 
 use cardano::block::{Block, RawBlock};
 use storage_units::hash::BlockHash;
@@ -77,7 +77,7 @@ impl<'a> Iterator for IteratorType<'a> {
             }
             IteratorType::Loose(ref storage, ref mut range) => {
                 if let Some(bh) = range.next() {
-                    let location = BlockLocation2::Loose(bh);
+                    let location = BlockLocation::Loose(bh);
                     Some(storage.read_block_at(&location))
                 } else {
                     None
@@ -121,7 +121,7 @@ impl<'a> Iter<'a> {
         to: BlockHash,
     ) -> Result<Self> {
         let iterator = match storage.block_location(&from)? {
-            BlockLocation2::Loose(to) => {
+            BlockLocation::Loose(to) => {
                 let mut range = range_iter(storage, from, to)?;
                 IteratorType::Loose(storage, range)
             }

--- a/storage/src/iter/reverse.rs
+++ b/storage/src/iter/reverse.rs
@@ -1,7 +1,7 @@
 //! objects to iterate through the blocks depending on the backend used
 //!
 
-use super::super::{block_location, block_read_location, Storage};
+use super::super::Storage;
 use cardano::block::{Block, HeaderHash};
 
 use std::iter;
@@ -19,9 +19,7 @@ pub fn iter<'a>(
     hh: HeaderHash
 ) -> Result<ReverseIter<'a>> {
     let hash = hh.clone().into();
-    if let Err(e) = block_location(storage, &hash) {
-        return Err(e);
-    }
+    storage.block_location(&hash)?;
     let ri = ReverseIter {
         storage: storage,
         current_block: Some(hh),
@@ -45,8 +43,8 @@ impl<'a> iter::Iterator for ReverseIter<'a> {
         };
 
         let hash = hh.clone().into();
-        let loc = block_location(&self.storage, &hash).expect("block location");
-        let blk = block_read_location(&self.storage, &loc, &hash).unwrap();
+        let loc = self.storage.block_location(&hash).expect("block location");
+        let blk = self.storage.read_block_at(&loc).unwrap();
         let block = blk.decode().unwrap();
         let hdr = block.get_header();
         self.current_block = Some(hdr.get_previous_header());

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -107,6 +107,24 @@ pub struct Storage {
     lookups: BTreeMap<PackHash, indexfile::Lookup>,
 }
 
+macro_rules! try_open {
+    ($open_fn:path, $path:expr, $what:expr) => {
+        {
+            let filepath = $path;
+            match $open_fn(filepath) {
+                Ok(file) => file,
+                Err(e) => {
+                    warn!(
+                        "cannot read {} `{}': {}",
+                        $what, filepath.to_string_lossy(), e
+                    );
+                    return Err(e.into());
+                }
+            }
+        }
+    };
+}
+
 impl Storage {
     pub fn init(cfg: &StorageConfig) -> Result<Self> {
         let mut lookups = BTreeMap::new();
@@ -149,10 +167,73 @@ impl Storage {
         iter::reverse_iter(self, hh)
     }
 
+    pub fn block_location(&self, hash: &BlockHash) -> Result<BlockLocation2> {
+        for (packref, lookup) in self.lookups.iter() {
+            let (start, nb) = lookup.fanout.get_indexer_by_hash(hash);
+            match nb {
+                indexfile::FanoutNb(0) => {}
+                _ => {
+                    if lookup.bloom.search(hash) {
+                        let idx_filepath = self.config.get_index_filepath(packref);
+                        let mut idx_file = indexfile::Reader::init(idx_filepath).unwrap();
+                        match idx_file.search(&lookup.params, hash, start, nb) {
+                            None => {}
+                            Some(iloc) => return Ok(BlockLocation2::Packed(packref.clone(), iloc)),
+                        }
+                    }
+                }
+            }
+        }
+        if blob::exist(self, hash) {
+            return Ok(BlockLocation2::Loose(hash.clone()));
+        }
+        Err(Error::BlockNotFound(hash.clone()))
+    }
+
+    pub fn read_block_at(
+        &self,
+        loc: &BlockLocation2,
+    ) -> Result<RawBlock> {
+        match loc {
+            BlockLocation2::Loose(hash) => blob::read(self, hash),
+            BlockLocation2::Packed(ref packref, ref iofs) => {
+                match self.lookups.get(packref) {
+                    None => {
+                        unreachable!();
+                    }
+                    Some(lookup) => {
+                        let idx_filepath = self.config.get_index_filepath(packref);
+                        let mut idx_file = try_open!(
+                            indexfile::ReaderNoLookup::init,
+                            &idx_filepath,
+                            "index file"
+                        );
+                        let pack_offset = idx_file.resolve_index_offset(lookup, *iofs);
+                        let pack_filepath = self.config.get_pack_filepath(packref);
+                        let mut pack_file = try_open!(
+                            packfile::Seeker::init,
+                            &pack_filepath,
+                            "pack file"
+                        );
+                        let rblk = pack_file
+                            .get_at_offset(pack_offset)
+                            .and_then(|x| Ok(RawBlock(x)))?;
+                        Ok(rblk)
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn read_block(&self, hash: &BlockHash) -> Result<RawBlock> {
+        let loc = self.block_location(hash)?;
+        self.read_block_at(&loc)
+    }
+
     pub fn get_block_from_tag(&self, tag: &str) -> Result<Block> {
         match tag::read_hash(&self, &tag) {
             None => Err(Error::NoSuchTag),
-            Some(hash) => Ok(block_read(&self, &hash.as_hash_bytes())?.decode()?)
+            Some(hash) => Ok(self.read_block(&hash.as_hash_bytes())?.decode()?)
         }
     }
 
@@ -212,12 +293,22 @@ pub mod blob {
     }
 }
 
+#[deprecated(note = "will be replaced by BlockLocation2")]
+#[allow(deprecated)]
 #[derive(Clone, Debug)]
 pub enum BlockLocation {
     Packed(PackHash, indexfile::IndexOffset),
     Loose,
 }
 
+#[derive(Clone, Debug)]
+pub enum BlockLocation2 {
+    Packed(PackHash, indexfile::IndexOffset),
+    Loose(BlockHash),
+}
+
+#[deprecated(note = "use Storage::block_location")]
+#[allow(deprecated)]
 pub fn block_location(storage: &Storage, hash: &BlockHash) -> Result<BlockLocation> {
     for (packref, lookup) in storage.lookups.iter() {
         let (start, nb) = lookup.fanout.get_indexer_by_hash(hash);
@@ -241,6 +332,8 @@ pub fn block_location(storage: &Storage, hash: &BlockHash) -> Result<BlockLocati
     Err(Error::BlockNotFound(hash.clone()))
 }
 
+#[deprecated(note = "use Storage::read_block_at")]
+#[allow(deprecated)]
 pub fn block_read_location(
     storage: &Storage,
     loc: &BlockLocation,
@@ -265,12 +358,14 @@ pub fn block_read_location(
     }
 }
 
+#[deprecated(note = "use Storage::read_block")]
+#[allow(deprecated)]
 pub fn block_read(storage: &Storage, hash: &BlockHash) -> Result<RawBlock> {
     block_read_location(storage, &block_location(storage, hash)?, hash)
 }
 
 pub fn block_exists(storage: &Storage, hash: &BlockHash) -> Result<bool> {
-    match block_location(storage, hash) {
+    match storage.block_location(hash) {
         Ok(_) => Ok(true),
         Err(Error::BlockNotFound(_)) => Ok(false),
         Err(err) => Err(err),
@@ -329,7 +424,7 @@ pub fn resolve_date_to_blockhash(
             Ok(r)
         }
         Err(_) => {
-            match block_read(&storage, tip.as_hash_bytes()) {
+            match storage.read_block(tip.as_hash_bytes()) {
                 Err(Error::BlockNotFound(_)) => Ok(None),
                 Err(err) => Err(err),
                 Ok(rblk) => {

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -202,6 +202,14 @@ impl Storage {
         Err(Error::BlockNotFound(hash.clone()))
     }
 
+    pub fn block_exists(&self, hash: &BlockHash) -> Result<bool> {
+        match self.block_location(hash) {
+            Ok(_) => Ok(true),
+            Err(Error::BlockNotFound(_)) => Ok(false),
+            Err(err) => Err(err),
+        }
+    }
+
     pub fn read_block_at(
         &self,
         loc: &BlockLocation,
@@ -309,14 +317,6 @@ pub mod blob {
 pub enum BlockLocation {
     Packed(PackHash, indexfile::IndexOffset),
     Loose(BlockHash),
-}
-
-pub fn block_exists(storage: &Storage, hash: &BlockHash) -> Result<bool> {
-    match storage.block_location(hash) {
-        Ok(_) => Ok(true),
-        Err(Error::BlockNotFound(_)) => Ok(false),
-        Err(err) => Err(err),
-    }
 }
 
 enum ReverseSearch {


### PR DESCRIPTION
The `Loose` variant of `BlockLocation` can carry the hash that was sought.
This removes a redundant, error-prone parameter of `block_read_location`.

Free functions in crate `storage` that have `Storage` as the first
parameter are replaced with methods on `Storage`. The existing functions
are marked deprecated:

- `block_location`
- `block_read_location`
- `block_read`

`BlockLocation` is also deprecated in favor of `BlockLocation2`, which will
be renamed back to `BlockLocation` in the next breaking release.