### PR TITLE
Conditionally disable Deref impls for hash types

### DIFF
--- a/cardano/Cargo.toml
+++ b/cardano/Cargo.toml
@@ -28,6 +28,7 @@ unicode-normalization = "0.1"
 quickcheck = "0.7"
 
 [features]
-default = []
+default = ["bad-deref"]
+bad-deref = []
 with-bench = []
 generic-serialization = ["serde", "serde_derive"]

--- a/cardano/Cargo.toml
+++ b/cardano/Cargo.toml
@@ -28,7 +28,6 @@ unicode-normalization = "0.1"
 quickcheck = "0.7"
 
 [features]
-default = ["bad-deref"]
-bad-deref = []
+default = []
 with-bench = []
 generic-serialization = ["serde", "serde_derive"]

--- a/cardano/src/address.rs
+++ b/cardano/src/address.rs
@@ -8,7 +8,6 @@
 //! All this components form an `ExtendedAddr`, which serialized
 //! to binary makes an `Addr`
 //!
-use std::{fmt, str::{FromStr}, ops::{Deref}};
 #[cfg(feature = "generic-serialization")]
 use serde;
 
@@ -21,6 +20,14 @@ use cbor_event::{self, de::RawCbor, se::{Serializer}};
 use hdwallet::{XPub};
 use hdpayload::{HDAddressPayload};
 use config::{NetworkMagic};
+
+use std::{
+    fmt,
+    str::{FromStr},
+};
+
+#[cfg(feature = "bad-deref")]
+use std::ops::Deref;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
 #[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
@@ -84,6 +91,10 @@ impl StakeholderId {
         let hash = Sha3_256::new(&buf);
         StakeholderId(Blake2b224::new(hash.as_ref()))
     }
+
+    pub fn as_hash_bytes(&self) -> &[u8; Blake2b224::HASH_SIZE] {
+        self.0.as_hash_bytes()
+    }
 }
 impl cbor_event::se::Serialize for StakeholderId {
     fn serialize<W: ::std::io::Write>(&self, serializer: Serializer<W>) -> cbor_event::Result<Serializer<W>> {
@@ -106,6 +117,7 @@ impl TryFromSlice for StakeholderId {
         Ok(Self::from(Blake2b224::try_from_slice(slice)?))
     }
 }
+#[cfg(feature = "bad-deref")]
 impl Deref for StakeholderId {
     type Target = <Blake2b224 as Deref>::Target;
     fn deref(&self) -> &Self::Target { self.0.deref() }
@@ -300,6 +312,10 @@ impl HashedSpendingData {
         let hash = Sha3_256::new(&buf);
         HashedSpendingData(Blake2b224::new(hash.as_ref()))
     }
+
+    pub fn as_hash_bytes(&self) -> &[u8; Blake2b224::HASH_SIZE] {
+        self.0.as_hash_bytes()
+    }
 }
 impl fmt::Display for HashedSpendingData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -322,6 +338,7 @@ impl TryFromSlice for HashedSpendingData {
         Ok(Self::from(Blake2b224::try_from_slice(slice)?))
     }
 }
+#[cfg(feature = "bad-deref")]
 impl Deref for HashedSpendingData {
     type Target = <Blake2b224 as Deref>::Target;
     fn deref(&self) -> &Self::Target { self.0.deref() }

--- a/cardano/src/address.rs
+++ b/cardano/src/address.rs
@@ -26,9 +26,6 @@ use std::{
     str::{FromStr},
 };
 
-#[cfg(feature = "bad-deref")]
-use std::ops::Deref;
-
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
 #[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub enum AddrType {
@@ -116,11 +113,6 @@ impl TryFromSlice for StakeholderId {
     fn try_from_slice(slice: &[u8]) -> ::std::result::Result<Self, Self::Error> {
         Ok(Self::from(Blake2b224::try_from_slice(slice)?))
     }
-}
-#[cfg(feature = "bad-deref")]
-impl Deref for StakeholderId {
-    type Target = <Blake2b224 as Deref>::Target;
-    fn deref(&self) -> &Self::Target { self.0.deref() }
 }
 impl AsRef<[u8]> for StakeholderId {
     fn as_ref(&self) -> &[u8] { self.0.as_ref() }
@@ -337,11 +329,6 @@ impl TryFromSlice for HashedSpendingData {
     fn try_from_slice(slice: &[u8]) -> ::std::result::Result<Self, Self::Error> {
         Ok(Self::from(Blake2b224::try_from_slice(slice)?))
     }
-}
-#[cfg(feature = "bad-deref")]
-impl Deref for HashedSpendingData {
-    type Target = <Blake2b224 as Deref>::Target;
-    fn deref(&self) -> &Self::Target { self.0.deref() }
 }
 impl AsRef<[u8]> for HashedSpendingData {
     fn as_ref(&self) -> &[u8] { self.0.as_ref() }

--- a/cardano/src/block/types.rs
+++ b/cardano/src/block/types.rs
@@ -8,9 +8,6 @@ use std::{
     str::{FromStr},
 };
 
-#[cfg(feature = "bad-deref")]
-use std::ops::Deref;
-
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub struct Version {
    major:    u32,
@@ -51,11 +48,6 @@ impl TryFromSlice for HeaderHash {
     fn try_from_slice(slice: &[u8]) -> ::std::result::Result<Self, Self::Error> {
         Ok(Self::from(Blake2b256::try_from_slice(slice)?))
     }
-}
-#[cfg(feature = "bad-deref")]
-impl Deref for HeaderHash {
-    type Target = <Blake2b256 as Deref>::Target;
-    fn deref(&self) -> &Self::Target { self.0.deref() }
 }
 impl AsRef<[u8]> for HeaderHash {
     fn as_ref(&self) -> &[u8] { self.0.as_ref() }

--- a/cardano/src/block/types.rs
+++ b/cardano/src/block/types.rs
@@ -1,8 +1,15 @@
-use std::{fmt, str::{FromStr}, ops::{Deref}};
 use hash::{Blake2b256};
 use cbor_event::{self, de::RawCbor};
 use util::try_from_slice::TryFromSlice;
 use super::normal::SscPayload;
+
+use std::{
+    fmt,
+    str::{FromStr},
+};
+
+#[cfg(feature = "bad-deref")]
+use std::ops::Deref;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub struct Version {
@@ -29,6 +36,10 @@ impl fmt::Display for Version {
 pub struct HeaderHash(Blake2b256);
 impl HeaderHash {
     pub fn new(bytes: &[u8]) -> Self { HeaderHash(Blake2b256::new(bytes))  }
+
+    pub fn as_hash_bytes(&self) -> &[u8; Blake2b256::HASH_SIZE] {
+        self.0.as_hash_bytes()
+    }
 }
 impl fmt::Display for HeaderHash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -41,6 +52,7 @@ impl TryFromSlice for HeaderHash {
         Ok(Self::from(Blake2b256::try_from_slice(slice)?))
     }
 }
+#[cfg(feature = "bad-deref")]
 impl Deref for HeaderHash {
     type Target = <Blake2b256 as Deref>::Target;
     fn deref(&self) -> &Self::Target { self.0.deref() }

--- a/cardano/src/hash.rs
+++ b/cardano/src/hash.rs
@@ -8,10 +8,6 @@ use std::{
     str::FromStr,
 };
 
-#[cfg(feature = "bad-deref")]
-use std::ops::Deref;
-
-
 use cryptoxide::digest::Digest;
 use cryptoxide::blake2b::Blake2b;
 use cryptoxide::sha3::Sha3;
@@ -77,11 +73,6 @@ macro_rules! define_hash_object {
             pub fn as_hash_bytes(&self) -> &[u8; Self::HASH_SIZE] {
                 &self.0
             }
-        }
-        #[cfg(feature = "bad-deref")]
-        impl Deref for $hash_ty {
-            type Target = [u8; Self::HASH_SIZE];
-            fn deref(&self) -> &Self::Target { &self.0 }
         }
         impl AsRef<[u8]> for $hash_ty {
             fn as_ref(&self) -> &[u8] { self.0.as_ref() }

--- a/cardano/src/hash.rs
+++ b/cardano/src/hash.rs
@@ -1,7 +1,16 @@
 //! module to provide some handy interfaces atop the hashes so we have
 //! the common interfaces for the project to work with.
 
-use std::{fmt, result, str::{FromStr}, ops::{Deref}, hash::{Hash, Hasher}};
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+    result,
+    str::FromStr,
+};
+
+#[cfg(feature = "bad-deref")]
+use std::ops::Deref;
+
 
 use cryptoxide::digest::Digest;
 use cryptoxide::blake2b::Blake2b;
@@ -64,7 +73,12 @@ macro_rules! define_hash_object {
     ($hash_ty:ty, $constructor:expr, $hash_size:ident) => {
         impl $hash_ty {
             pub const HASH_SIZE: usize = $hash_size;
+
+            pub fn as_hash_bytes(&self) -> &[u8; Self::HASH_SIZE] {
+                &self.0
+            }
         }
+        #[cfg(feature = "bad-deref")]
         impl Deref for $hash_ty {
             type Target = [u8; Self::HASH_SIZE];
             fn deref(&self) -> &Self::Target { &self.0 }

--- a/cardano/src/merkle.rs
+++ b/cardano/src/merkle.rs
@@ -50,8 +50,8 @@ impl MerkleNode {
             let a = MerkleNode::make_tree(&xs[0..i]);
             let b = MerkleNode::make_tree(&xs[i..]);
             let mut bs = vec![1u8];
-            bs.extend(a.get_root_hash().iter());
-            bs.extend(b.get_root_hash().iter());
+            bs.extend(a.get_root_hash().as_hash_bytes());
+            bs.extend(b.get_root_hash().as_hash_bytes());
             MerkleNode::Branch(Hash::new(&bs), Box::new(a), Box::new(b))
         }
     }

--- a/storage/src/iter/mod.rs
+++ b/storage/src/iter/mod.rs
@@ -171,9 +171,9 @@ impl<'a> Iterator for Iter<'a> {
                     Ok(raw_block) => {
                         let block = raw_block.decode().unwrap();
                         let hh = block.get_header().compute_hash();
-                        let end = *hh == self.starting_from;
+                        let end = hh.as_hash_bytes() == &self.starting_from;
                         next = Some(Ok((raw_block, block)));
-                        self.last_known_block_hash = Some(*hh);
+                        self.last_known_block_hash = Some(hh.as_hash_bytes().clone());
                         if end { break; }
                     }
                 }
@@ -200,7 +200,7 @@ impl<'a> Iterator for Iter<'a> {
                 Some(Ok(raw_block)) => {
                     let block = raw_block.decode().unwrap();
                     let hh = block.get_header().compute_hash();
-                    self.last_known_block_hash = Some(*hh);
+                    self.last_known_block_hash = Some(hh.as_hash_bytes().clone());
                     Some(Ok((raw_block, block)))
                 }
             }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -329,7 +329,7 @@ pub fn resolve_date_to_blockhash(
             Ok(r)
         }
         Err(_) => {
-            match block_read(&storage, tip) {
+            match block_read(&storage, tip.as_hash_bytes()) {
                 Err(Error::BlockNotFound(_)) => Ok(None),
                 Err(err) => Err(err),
                 Ok(rblk) => {

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -152,7 +152,7 @@ impl Storage {
     pub fn get_block_from_tag(&self, tag: &str) -> Result<Block> {
         match tag::read_hash(&self, &tag) {
             None => Err(Error::NoSuchTag),
-            Some(hash) => Ok(block_read(&self, &hash)?.decode()?)
+            Some(hash) => Ok(block_read(&self, &hash.as_hash_bytes())?.decode()?)
         }
     }
 


### PR DESCRIPTION
Automatic dereferencing from hash newtypes to their underlying byte
arrays is fraught with possibility of overlooked coercions and method
API drift.

As the first step, introduce a feature "bad-deref", enabled by default,
to conditionally disable the `Deref` impls for hash types and make sure
the libraries compile without the feature. Provide an ad-hoc
reference conversion method `.as_hash_bytes()` on hash types to access
the byte array in a more explicit fashion.