### PR TITLE
Add a function that returns the chain state at an arbitrary block

### DIFF
--- a/cardano/src/config.rs
+++ b/cardano/src/config.rs
@@ -87,7 +87,7 @@ impl Default for Config {
 /// parent of the genesis block of epoch 0. (Note that "genesis data"
 /// is something completely different from a epoch genesis block. The
 /// genesis data is not stored in the chain as a block.)
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GenesisData {
     pub genesis_prev: block::HeaderHash,
     pub epoch_stability_depth: usize, // a.k.a. 'k'

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -33,6 +33,7 @@ use storage_units::{indexfile, packfile, reffile};
 pub enum Error {
     StorageError(StorageError),
     CborBlockError(cbor_event::Error),
+    BlockError(cardano::block::Error),
     RefPackUnexpectedBoundary(SlotId),
 
     HashNotFound(HeaderHash),
@@ -59,11 +60,17 @@ impl From<cbor_event::Error> for Error {
         Error::CborBlockError(e)
     }
 }
+impl From<cardano::block::Error> for Error {
+    fn from(e: cardano::block::Error) -> Self {
+        Error::BlockError(e)
+    }
+}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Error::StorageError(_) => write!(f, "Storage error"),
             Error::CborBlockError(_) => write!(f, "Encoding error"),
+            Error::BlockError(_) => write!(f, "Block error"),
             Error::HashNotFound(hh) => write!(f, "Hash not found {}", hh),
             Error::RefPackUnexpectedBoundary(sid) => write!(f, "Ref pack has an unexpected Boundary `{}`", sid),
             Error::EpochExpectingBoundary => write!(f, "Expected a boundary block"),
@@ -79,6 +86,7 @@ impl error::Error for Error {
         match self {
             Error::StorageError(ref err) => Some(err),
             Error::CborBlockError(ref err) => Some(err),
+            Error::BlockError(ref err) => Some(err),
             Error::HashNotFound(_) => None,
             Error::RefPackUnexpectedBoundary(_) => None,
             Error::EpochExpectingBoundary => None,


### PR DESCRIPTION
It seeks backwards through the chain until it reaches a block that has chain state on disk. It then goes forward again to verify and apply the missing blocks.

This function can be quite slow in debug mode because it has to read/verify up to an epoch's worth of blocks, but in release mode it only takes a few seconds. In the future we may want to write chain state deltas more frequently than once per epoch though.