### PR TITLE
Fix some net_sync problems

### DIFF
--- a/cardano/src/block/verify.rs
+++ b/cardano/src/block/verify.rs
@@ -42,7 +42,7 @@ pub enum Error {
     ZeroCoin,
 
     // Used by verify_block_in_chain.
-    WrongPreviousBlock,
+    WrongPreviousBlock(HeaderHash, HeaderHash), // actual, expected
     NonExistentSlot,
     BlockDateInPast,
     BlockDateInFuture,
@@ -84,7 +84,7 @@ impl fmt::Display for Error {
             WrongTxProof => write!(f, "transaction proof is invalid"),
             WrongUpdateProof => write!(f, "update proof is invalid"),
             ZeroCoin => write!(f, "output with no credited value"),
-            WrongPreviousBlock => write!(f, "block has wrong parent"),
+            WrongPreviousBlock(actual, expected) => write!(f, "block has parent {} while {} was expected", actual, expected),
             NonExistentSlot => write!(f, "slot does not have a leader"),
             BlockDateInPast => write!(f, "block's slot or epoch is earlier than its parent"),
             BlockDateInFuture => write!(f, "block is in a future epoch"),

--- a/cardano/src/block/verify_chain.rs
+++ b/cardano/src/block/verify_chain.rs
@@ -19,6 +19,7 @@ pub struct ChainState {
 
     pub last_block: HeaderHash,
     pub last_date: Option<BlockDate>,
+    pub last_boundary_block: Option<HeaderHash>,
     pub slot_leaders: Vec<address::StakeholderId>,
     pub utxos: Utxos,
     pub chain_length: u64,
@@ -56,6 +57,7 @@ impl ChainState {
             fee_policy: genesis_data.fee_policy,
             last_block: genesis_data.genesis_prev.clone(),
             last_date: None,
+            last_boundary_block: None,
             slot_leaders: vec![],
             utxos,
             chain_length: 0,
@@ -76,11 +78,13 @@ impl ChainState {
 
         self.last_block = block_hash.clone();
         self.last_date = Some(blk.get_header().get_blockdate());
+        // FIXME: count boundary blocks as part of the chain length?
         self.chain_length += 1;
 
         match blk {
 
             Block::BoundaryBlock(blk) => {
+                self.last_boundary_block = Some(block_hash.clone());
                 self.slot_leaders = blk.body.slot_leaders.clone();
             },
 

--- a/cardano/src/block/verify_chain.rs
+++ b/cardano/src/block/verify_chain.rs
@@ -1,4 +1,3 @@
-use std::mem;
 use block::*;
 use address;
 use config::{ProtocolMagic, GenesisData};
@@ -278,6 +277,6 @@ impl ChainState {
 // return the first.
 fn add_error(res: &mut Result<(), Error>, err: Result<(), Error>) {
     if res.is_ok() && err.is_err() {
-        mem::replace(res, err);
+        *res = err;
     }
 }

--- a/cardano/src/block/verify_chain.rs
+++ b/cardano/src/block/verify_chain.rs
@@ -103,8 +103,9 @@ impl ChainState {
         // Perform stateless checks.
         verify_block(self.protocol_magic, block_hash, blk)?;
 
-        if blk.get_header().get_previous_header() != self.last_block {
-            return Err(Error::WrongPreviousBlock)
+        let prev_block = blk.get_header().get_previous_header();
+        if prev_block != self.last_block {
+            return Err(Error::WrongPreviousBlock(prev_block, self.last_block.clone()))
         }
 
         // Check the block date.

--- a/cardano/src/txbuild.rs
+++ b/cardano/src/txbuild.rs
@@ -146,7 +146,6 @@ impl TxBuilder {
                 // being the maximum that can be paid, considering
                 // that the actual value is closer to max - cost(output_policy)
                 let mut out_total_max = max;
-                let mut out_total_min = Coin::zero();
                 let mut out_total = start;
                 loop {
                     let mut temp = self.clone();
@@ -163,7 +162,7 @@ impl TxBuilder {
                         // Input > Output+Fees. Effectively paying too much into fees
                         // need to assign more to out_total
                         CoinDiff::Positive(_x) => {
-                            out_total_min = out_total;
+                            let out_total_min = out_total;
                             if (out_total_min + Coin::unit())? == out_total_max {
                                 self.apply_policy_with(o, out_total);
                                 return Ok(outs)

--- a/exe-common/src/network/error.rs
+++ b/exe-common/src/network/error.rs
@@ -16,6 +16,7 @@ pub enum Error {
     HttpError(String, hyper::StatusCode),
     NoSuchBlock(HeaderHash),
     StorageError(storage::Error),
+    BlockError(cardano::block::Error),
 }
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Self { Error::IoError(e) }
@@ -35,6 +36,9 @@ impl From<cbor_event::Error> for Error {
 impl From<storage::Error> for Error {
     fn from(e: storage::Error) -> Self { Error::StorageError(e) }
 }
+impl From<cardano::block::Error> for Error {
+    fn from(e: cardano::block::Error) -> Self { Error::BlockError(e) }
+}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -47,6 +51,7 @@ impl fmt::Display for Error {
             Error::HttpError(err, code) => write!(f, "HTTP error {}: {}", code, err),
             Error::NoSuchBlock(hash) => write!(f, "Requested block {} does not exist", hash),
             Error::StorageError(_) => write!(f, "Storage error"),
+            Error::BlockError(_) => write!(f, "Block error"),
         }
     }
 }
@@ -62,6 +67,7 @@ impl error::Error for Error {
             Error::HttpError(_, _) => None,
             Error::NoSuchBlock(_) => None,
             Error::StorageError(ref err) => Some(err),
+            Error::BlockError(ref err) => Some(err),
         }
     }
 }

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -17,7 +17,6 @@ struct EpochWriterState {
     writer: packfile::Writer,
     write_start_time: SystemTime,
     blobs_to_delete: Vec<HeaderHash>,
-    chain_state: ChainState,
 }
 
 fn net_sync_to<A: Api>(
@@ -77,8 +76,6 @@ fn net_sync_to<A: Api>(
 
     let mut epoch_writer_state : Option<EpochWriterState> = None;
 
-    let mut last_block : Option<HeaderHash> = None;
-
     // If our tip is in an epoch that has become stable, we now need
     // to pack it. So read the previously fetched blocks in this epoch
     // and prepend them to the incoming blocks.
@@ -89,12 +86,12 @@ fn net_sync_to<A: Api>(
 
         // Read the blocks in the current epoch.
         let mut blobs_to_delete = vec![];
-        let (prev_hash, blocks) = get_unpacked_blocks_in_epoch(storage, &our_tip.0.hash, epoch_id, &mut blobs_to_delete);
+        let (last_block_in_prev_epoch, blocks) = get_unpacked_blocks_in_epoch(storage, &our_tip.0.hash, epoch_id, &mut blobs_to_delete);
 
         // If tip.slotid < w, the previous epoch won't have been
         // created yet either, so do that now.
         if epoch_id > net_cfg.epoch_start {
-            maybe_create_epoch(net_cfg, storage, genesis_data, epoch_id - 1, &prev_hash);
+            maybe_create_epoch(storage, genesis_data, epoch_id - 1, &last_block_in_prev_epoch)?;
         }
 
         // Initialize the epoch writer and add the blocks in the current epoch.
@@ -103,13 +100,13 @@ fn net_sync_to<A: Api>(
             writer: pack::packwriter_init(&storage.config).unwrap(),
             write_start_time: SystemTime::now(),
             blobs_to_delete,
-            chain_state: get_chain_state_at_start_of(
-                net_cfg, storage, epoch_id, &genesis_data)
         });
-        last_block = Some(our_tip.0.hash.clone());
+
+        let mut chain_state = chain_state::restore_chain_state(
+            storage, genesis_data, &last_block_in_prev_epoch)?;
 
         append_blocks_to_epoch_reverse(
-            epoch_writer_state.as_mut().unwrap(), blocks);
+            epoch_writer_state.as_mut().unwrap(), &mut chain_state, blocks)?;
     }
 
     // If the previous epoch has become stable, then we may need to
@@ -129,25 +126,35 @@ fn net_sync_to<A: Api>(
             if hdr.get_blockdate().is_boundary() { break }
         }
 
-        maybe_create_epoch(net_cfg, storage, genesis_data, first_unstable_epoch - 1, &cur_hash);
+        maybe_create_epoch(storage, genesis_data, first_unstable_epoch - 1, &cur_hash)?;
     }
+
+    let mut chain_state = chain_state::restore_chain_state(
+        storage, genesis_data,
+        if our_tip.1 { &our_tip.0.parent } else { &our_tip.0.hash })?;
 
     net.get_blocks(&our_tip.0, our_tip.1, &tip, &mut |block_hash, block, block_raw| {
         let date = block.get_header().get_blockdate();
 
-        // Flush the previous epoch (if any).
+        // Flush the previous epoch (if any). FIXME: shouldn't rely on
+        // 'date' here since the block hasn't been verified yet.
         if date.is_boundary() {
             let mut writer_state = None;
             mem::swap(&mut writer_state, &mut epoch_writer_state);
 
             if let Some(epoch_writer_state) = writer_state {
-                finish_epoch(storage, genesis_data, epoch_writer_state);
+                finish_epoch(storage, genesis_data, epoch_writer_state, &chain_state).unwrap();
 
                 // Checkpoint the tip so we don't have to refetch
                 // everything if we get interrupted.
-                tag::write(storage, &tag::HEAD, last_block.as_ref().unwrap().as_ref());
+                tag::write(storage, &tag::HEAD, &chain_state.last_block.as_ref());
             }
         }
+
+        // FIXME: propagate errors
+        chain_state.verify_block(block_hash, block)
+            .expect(&format!("Block {} ({}) failed to verify",
+                             block_hash, block.get_header().get_blockdate()));
 
         if date.get_epochid() >= first_unstable_epoch {
             // This block is not part of a stable epoch yet and could
@@ -164,33 +171,21 @@ fn net_sync_to<A: Api>(
                     writer: pack::packwriter_init(&storage.config).unwrap(),
                     write_start_time: SystemTime::now(),
                     blobs_to_delete: vec![],
-                    chain_state: get_chain_state_at_start_of(
-                        net_cfg, storage, date.get_epochid(), &genesis_data)
                 });
             }
 
             // And append the block to the epoch pack.
             if let Some(epoch_writer_state) = epoch_writer_state.as_mut() {
-
-                // FIXME: propagate errors
-                epoch_writer_state.chain_state.verify_block(block_hash, block)
-                    .expect(&format!("Block {} failed to verify.", block_hash));
-
                 epoch_writer_state.writer.append(
                     &types::header_to_blockhash(&block_hash), block_raw.as_ref()).unwrap();
             } else {
                 unreachable!();
             }
         }
-
-        last_block = Some(block_hash.clone());
     })?;
 
     // Update the tip tag to point to the most recent block.
-    if let Some(block_hash) = last_block {
-        tag::write(&storage, &tag::HEAD,
-                            &types::header_to_blockhash(&block_hash));
-    }
+    tag::write(&storage, &tag::HEAD, chain_state.last_block.as_ref());
 
     Ok(())
 }
@@ -233,11 +228,12 @@ pub fn net_sync<A: Api>(
 
 // Create an epoch from a complete set of previously fetched blocks on
 // disk.
-fn maybe_create_epoch(net_cfg: &net::Config, storage: &Storage,
+fn maybe_create_epoch(storage: &mut Storage,
                       genesis_data: &GenesisData,
                       epoch_id: EpochId, last_block: &HeaderHash)
+    -> Result<()>
 {
-    if epoch_exists(&storage.config, epoch_id).unwrap() { return }
+    if epoch_exists(&storage.config, epoch_id).unwrap() { return Ok(()); }
 
     info!("Packing epoch {}", epoch_id);
 
@@ -246,38 +242,32 @@ fn maybe_create_epoch(net_cfg: &net::Config, storage: &Storage,
         writer: pack::packwriter_init(&storage.config).unwrap(),
         write_start_time: SystemTime::now(),
         blobs_to_delete: vec![],
-        chain_state: get_chain_state_at_start_of(
-            net_cfg, storage, epoch_id, &genesis_data)
     };
 
-    read_and_append_blocks_to_epoch_reverse(&storage, &mut epoch_writer_state, last_block);
+    let (end_of_prev_epoch, blocks) = get_unpacked_blocks_in_epoch(storage, last_block, epoch_writer_state.epoch_id, &mut epoch_writer_state.blobs_to_delete);
 
-    finish_epoch(storage, genesis_data, epoch_writer_state);
-}
+    let mut chain_state = chain_state::restore_chain_state(storage, genesis_data, &end_of_prev_epoch)?;
 
-fn read_and_append_blocks_to_epoch_reverse(
-    storage: &Storage,
-    epoch_writer_state: &mut EpochWriterState,
-    last_block: &HeaderHash)
-{
-    let (_, blocks) = get_unpacked_blocks_in_epoch(storage, last_block, epoch_writer_state.epoch_id, &mut epoch_writer_state.blobs_to_delete);
+    append_blocks_to_epoch_reverse(&mut epoch_writer_state, &mut chain_state, blocks)?;
 
-    append_blocks_to_epoch_reverse(epoch_writer_state, blocks);
+    finish_epoch(storage, genesis_data, epoch_writer_state, &chain_state)?;
+
+    Ok(())
 }
 
 fn append_blocks_to_epoch_reverse(
     epoch_writer_state: &mut EpochWriterState,
+    chain_state: &mut ChainState,
     mut blocks: Vec<(HeaderHash, RawBlock, Block)>)
+    -> Result<()>
 {
     while let Some((hash, block_raw, block)) = blocks.pop() {
-
-        // FIXME: propagate errors
-        epoch_writer_state.chain_state.verify_block(&hash, &block)
-            .expect(&format!("Block {} failed to verify.", hash));
-
+        chain_state.verify_block(&hash, &block)?;
         epoch_writer_state.writer.append(&types::header_to_blockhash(&hash),
                                          block_raw.as_ref()).unwrap();
     }
+
+    Ok(())
 }
 
 fn get_unpacked_blocks_in_epoch(storage: &Storage, last_block: &HeaderHash, epoch_id: EpochId,
@@ -302,30 +292,32 @@ fn get_unpacked_blocks_in_epoch(storage: &Storage, last_block: &HeaderHash, epoc
 fn finish_epoch(
     storage: &mut Storage,
     genesis_data: &GenesisData,
-    epoch_writer_state: EpochWriterState)
+    epoch_writer_state: EpochWriterState,
+    chain_state: &ChainState)
+    -> Result<()>
 {
     let epoch_id = epoch_writer_state.epoch_id;
     let (packhash, index) = pack::packwriter_finalize(&storage.config, epoch_writer_state.writer);
     let (lookup, tmpfile) = pack::create_index(&storage, &index);
-    tmpfile.render_permanent(&storage.config.get_index_filepath(&packhash)).unwrap();
+    tmpfile.render_permanent(&storage.config.get_index_filepath(&packhash))?;
     storage.add_lookup(packhash, lookup);
     let epoch_time_elapsed = epoch_writer_state.write_start_time.elapsed().unwrap();
 
     if epoch_id > 0 {
         assert!(
-            epoch_exists(&storage.config, epoch_id - 1).unwrap(),
+            epoch_exists(&storage.config, epoch_id - 1)?,
             "Attempted finish_epoch() with non-existent previous epoch (ID {}, previous' ID {})",
             epoch_id,
             epoch_id - 1
         );
     }
 
-    assert_eq!(epoch_writer_state.chain_state.last_date.unwrap().get_epochid(), epoch_id);
+    assert_eq!(chain_state.last_date.unwrap().get_epochid(), epoch_id);
 
     epoch::epoch_create(&storage,
                         &packhash,
                         epoch_id,
-                        Some((&epoch_writer_state.chain_state, genesis_data)));
+                        Some((chain_state, genesis_data)));
 
     info!("=> pack {} written for epoch {} in {}", hex::encode(&packhash[..]),
           epoch_id, duration_print(epoch_time_elapsed));
@@ -334,6 +326,8 @@ fn finish_epoch(
         debug!("removing blob {}", hash);
         blob::remove(&storage, &hash.clone().into());
     }
+
+    Ok(())
 }
 
 pub fn get_peer(blockchain: &str, cfg: &net::Config, native: bool) -> Peer {
@@ -351,19 +345,13 @@ pub fn get_peer(blockchain: &str, cfg: &net::Config, native: bool) -> Peer {
     panic!("no peer to connect to")
 }
 
-pub fn get_chain_state_at_start_of(
-    net_cfg: &net::Config,
+pub fn get_chain_state_at_end_of(
     storage: &Storage,
     epoch_id: EpochId,
     genesis_data: &GenesisData)
-    -> ChainState
+    -> Result<ChainState>
 {
-    if epoch_id == net_cfg.epoch_start {
-        ChainState::new(genesis_data)
-    } else {
-        chain_state::read_chain_state(
-            storage, genesis_data,
-            &chain_state::get_first_block_of_epoch(storage, epoch_id - 1).unwrap())
-            .expect("unable to read epoch utxo state")
-    }
+    Ok(chain_state::read_chain_state(
+        storage, genesis_data,
+        &chain_state::get_last_block_of_epoch(storage, epoch_id)?)?)
 }

--- a/storage/src/iter/epoch.rs
+++ b/storage/src/iter/epoch.rs
@@ -44,7 +44,7 @@ impl Iterator for Iter {
 pub struct Epochs<'a> {
     storage_config: &'a StorageConfig,
 
-    epoch_id: EpochId,
+    epoch_id: EpochId
 }
 impl<'a> Epochs<'a> {
     pub fn new(storage: &'a StorageConfig) -> Self {
@@ -65,8 +65,8 @@ impl<'a> Iterator for Epochs<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let r = epoch_open_pack_reader(&self.storage_config, self.epoch_id);
         match r {
-            Err(e) => Some(Err(e)),
-            Ok(None) => None,
+            Err(e) => { Some(Err(e)) },
+            Ok(None) => { None },
             Ok(Some(r)) => {
                 let iter = Iter(r);
                 self.epoch_id += 1;

--- a/storage/src/iter/mod.rs
+++ b/storage/src/iter/mod.rs
@@ -67,7 +67,7 @@ impl<'a> Iterator for IteratorType<'a> {
             IteratorType::Loose(ref storage, ref mut range) => {
                 if let Some(bh) = range.next() {
                     let location = BlockLocation::Loose;
-                    Some(Ok(block_read_location(&storage, &location, &bh)?))
+                    Some(Ok(block_read_location(&storage, &location, &bh.into()).unwrap()))
                 } else {
                     None
                 }
@@ -90,13 +90,12 @@ pub struct Iter<'a> {
 }
 impl<'a> Iter<'a> {
     pub fn new(storage: &'a Storage, from: HeaderHash, to: HeaderHash) -> Result<Self> {
-        let iterator = match block_location(&storage, &from) {
-            None => panic!(),
-            Some(BlockLocation::Loose) => {
+        let iterator = match block_location(&storage, &from)? {
+            BlockLocation::Loose => {
                 let mut range = Range::new(storage, *from.clone(), *to.clone()).unwrap(); // TODO
                 IteratorType::Loose(storage, range)
             }
-            Some(location) => {
+            location => {
                 let block_header = block_read_location(&storage, &location, &from)
                     .unwrap()
                     .decode()?

--- a/storage/src/iter/range.rs
+++ b/storage/src/iter/range.rs
@@ -23,7 +23,7 @@ impl Range {
         }
 
         if !finished {
-            Err(Error::HashNotFound(to.into()))
+            Err(Error::BlockNotFound(to.into()))
         } else {
             Ok(Range(rp))
         }

--- a/storage/src/iter/reverse.rs
+++ b/storage/src/iter/reverse.rs
@@ -6,7 +6,7 @@ use cardano::block::{Block, HeaderHash};
 
 use std::iter;
 
-use super::super::{Error, Result};
+use super::super::{Result};
 
 /// reverse iterator over the block chain
 pub struct ReverseIter<'a> {
@@ -16,9 +16,7 @@ pub struct ReverseIter<'a> {
 impl<'a> ReverseIter<'a> {
     pub fn from(storage: &'a Storage, hh: HeaderHash) -> Result<Self> {
         let hash = hh.clone().into();
-        if let None = block_location(storage, &hash) {
-            return Err(Error::HashNotFound(hh));
-        }
+        block_location(storage, &hash)?;
         let ri = ReverseIter {
             storage: storage,
             current_block: Some(hh),
@@ -37,14 +35,10 @@ impl<'a> iter::Iterator for ReverseIter<'a> {
 
         let hash = hh.clone().into();
         let loc = block_location(&self.storage, &hash).expect("block location");
-        match block_read_location(&self.storage, &loc, &hash) {
-            None => panic!("error while reading block {}", hh),
-            Some(blk) => {
-                let block = blk.decode().unwrap();
-                let hdr = block.get_header();
-                self.current_block = Some(hdr.get_previous_header());
-                Some(block)
-            }
-        }
+        let blk = block_read_location(&self.storage, &loc, &hash).unwrap();
+        let block = blk.decode().unwrap();
+        let hdr = block.get_header();
+        self.current_block = Some(hdr.get_previous_header());
+        Some(block)
     }
 }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -265,6 +265,7 @@ pub fn block_read_location(
     }
 }
 
+// FIXME: return Result, and remove variants in cardano-cli and cardano-http-bridge.
 pub fn block_read(storage: &Storage, hash: &BlockHash) -> Option<RawBlock> {
     match block_location(storage, hash) {
         None => None,

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -261,6 +261,14 @@ pub fn block_read(storage: &Storage, hash: &HeaderHash) -> Result<RawBlock> {
     block_read_location(storage, &block_location(storage, hash)?, hash)
 }
 
+pub fn block_exists(storage: &Storage, hash: &HeaderHash) -> Result<bool> {
+    match block_location(storage, hash) {
+        Ok(_) => Ok(true),
+        Err(Error::HashNotFound(_)) => Ok(false),
+        Err(err) => Err(err),
+    }
+}
+
 enum ReverseSearch {
     Continue,
     Found,

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -144,13 +144,7 @@ impl Storage {
     pub fn get_block_from_tag(&self, tag: &str) -> Result<Block> {
         match tag::read_hash(&self, &tag) {
             None => Err(Error::NoSuchTag),
-            Some(hash) => match block_read(&self, &hash) {
-                None => {
-                    warn!("tag '{}' refers to non-existent block {}", tag, hash);
-                    Err(Error::NoSuchTag)
-                }
-                Some(block) => Ok(block.decode()?),
-            },
+            Some(hash) => Ok(block_read(&self, &hash)?.decode()?)
         }
     }
 
@@ -216,7 +210,7 @@ pub enum BlockLocation {
     Loose,
 }
 
-pub fn block_location(storage: &Storage, hash: &BlockHash) -> Option<BlockLocation> {
+pub fn block_location(storage: &Storage, hash: &HeaderHash) -> Result<BlockLocation> {
     for (packref, lookup) in storage.lookups.iter() {
         let (start, nb) = lookup.fanout.get_indexer_by_hash(hash);
         match nb {
@@ -227,25 +221,25 @@ pub fn block_location(storage: &Storage, hash: &BlockHash) -> Option<BlockLocati
                     let mut idx_file = indexfile::Reader::init(idx_filepath).unwrap();
                     match idx_file.search(&lookup.params, hash, start, nb) {
                         None => {}
-                        Some(iloc) => return Some(BlockLocation::Packed(packref.clone(), iloc)),
+                        Some(iloc) => return Ok(BlockLocation::Packed(packref.clone(), iloc)),
                     }
                 }
             }
         }
     }
     if blob::exist(storage, hash) {
-        return Some(BlockLocation::Loose);
+        return Ok(BlockLocation::Loose);
     }
-    None
+    Err(Error::HashNotFound(hash.clone()))
 }
 
 pub fn block_read_location(
     storage: &Storage,
     loc: &BlockLocation,
-    hash: &BlockHash,
-) -> Option<RawBlock> {
+    hash: &HeaderHash,
+) -> Result<RawBlock> {
     match loc {
-        &BlockLocation::Loose => blob::read(storage, hash).ok(),
+        &BlockLocation::Loose => blob::read(storage, hash),
         &BlockLocation::Packed(ref packref, ref iofs) => match storage.lookups.get(packref) {
             None => {
                 unreachable!();
@@ -256,21 +250,15 @@ pub fn block_read_location(
                 let pack_offset = idx_file.resolve_index_offset(lookup, *iofs);
                 let pack_filepath = storage.config.get_pack_filepath(packref);
                 let mut pack_file = packfile::Seeker::init(pack_filepath).unwrap();
-                pack_file
-                    .get_at_offset(pack_offset)
-                    .ok()
-                    .and_then(|x| Some(RawBlock(x)))
+                Ok(RawBlock(pack_file
+                    .get_at_offset(pack_offset)?))
             }
         },
     }
 }
 
-// FIXME: return Result, and remove variants in cardano-cli and cardano-http-bridge.
-pub fn block_read(storage: &Storage, hash: &BlockHash) -> Option<RawBlock> {
-    match block_location(storage, hash) {
-        None => None,
-        Some(loc) => block_read_location(storage, &loc, hash),
-    }
+pub fn block_read(storage: &Storage, hash: &HeaderHash) -> Result<RawBlock> {
+    block_read_location(storage, &block_location(storage, hash)?, hash)
 }
 
 enum ReverseSearch {
@@ -311,7 +299,7 @@ where
 
 pub fn resolve_date_to_blockhash(
     storage: &Storage,
-    tip: &BlockHash,
+    tip: &HeaderHash,
     date: &BlockDate,
 ) -> Result<Option<BlockHash>> {
     let epoch = date.get_epochid();
@@ -325,10 +313,10 @@ pub fn resolve_date_to_blockhash(
             Ok(r)
         }
         Err(_) => {
-            let tip_rblk = block_read(&storage, tip);
-            match tip_rblk {
-                None => return Ok(None),
-                Some(rblk) => {
+            match block_read(&storage, tip) {
+                Err(Error::HashNotFound(_)) => Ok(None),
+                Err(err) => Err(err),
+                Ok(rblk) => {
                     let blk = rblk.decode()?;
                     let found = block_reverse_search_from_tip(storage, &blk, |x| {
                         match x.get_header().get_blockdate().cmp(date) {

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -153,6 +153,10 @@ impl Storage {
             },
         }
     }
+
+    pub fn add_lookup(&mut self, packhash: PackHash, lookup: indexfile::Lookup) {
+        self.lookups.insert(packhash, lookup);
+    }
 }
 
 fn tmpfile_create_type(storage: &Storage, filetype: StorageFileType) -> TmpFile {


### PR DESCRIPTION
There was some confusion in `net_sync` because chain state deltas got written at the start of an epoch, but `net_sync` resumes from the end of an epoch. This caused validation errors because `ChainState.last_block` was wrong. Now chain state deltas are written for the *last* block in an epoch.

Also, `finish_epoch` now updates `storage.lookups`. Without this, attempts to read back packed blocks will fail (`write_chain_state` needs this). This does require `net_sync` to take a `&mut storage`.

Also some misc improvements:
* `block_read` and friends now return a `Result`. This removes the need for reimplementations like `get_block` in `cardano-cli` and in the block handler in `cardano-http-bridge`.
* `reffile::Reader::next()` now skips empty slots and returns `None` at the end (rather than an error).
* `exe_common::Error` propagates some more errors.