### PR TITLE
Move protocol magic check

### DIFF
--- a/cardano/src/block/block.rs
+++ b/cardano/src/block/block.rs
@@ -5,7 +5,8 @@ use std::{fmt};
 use std::ops::{Deref, DerefMut};
 
 use cbor_event::{self, de::RawCbor};
-use super::types::HeaderHash;
+use super::types::{HeaderHash};
+use super::super::config::ProtocolMagic;
 use super::date::BlockDate;
 use super::boundary;
 use super::normal;
@@ -155,6 +156,13 @@ impl Block {
         match self {
             &Block::BoundaryBlock(_) => None,
             &Block::MainBlock(ref blk) => Some(blk.body.tx.clone()),
+        }
+    }
+
+    pub fn get_protocol_magic(&self) -> ProtocolMagic {
+        match self {
+            &Block::BoundaryBlock(ref blk) => blk.header.protocol_magic,
+            &Block::MainBlock(ref blk) => blk.header.protocol_magic,
         }
     }
 }

--- a/cardano/src/block/verify_chain.rs
+++ b/cardano/src/block/verify_chain.rs
@@ -104,7 +104,12 @@ impl ChainState {
     fn do_verify(&self, block_hash: &HeaderHash, blk: &Block) -> Result<(), Error>
     {
         // Perform stateless checks.
-        verify_block(self.protocol_magic, block_hash, blk)?;
+        verify_block(block_hash, blk)?;
+
+        // Check the protocol magic.
+        if blk.get_protocol_magic() != self.protocol_magic {
+            return Err(Error::WrongMagic);
+        }
 
         let prev_block = blk.get_header().get_previous_header();
         if prev_block != self.last_block {


### PR DESCRIPTION
This moves the protocol magic check from `verify_block()` to `ChainState::verify_block()`. This way, the former no longer relies on any chain configuration and *only* checks the internal correctness of the block.

This allows having an abstract `Block` trait with a simple `verify()` method, e.g.
```
  pub trait Block {
      type VerificationError : std::error::Error;
      fn verify(&self) -> Result<(), Self::VerificationError>;
  }
```
which can be implemented by `cardano::block::Block`.