### PR TITLE
prevent decrypt of payload that are way too large to be valid

### DIFF
--- a/cardano/src/hdpayload.rs
+++ b/cardano/src/hdpayload.rs
@@ -233,6 +233,21 @@ mod tests {
     }
 
     #[test]
+    fn decrypt_too_large() {
+        const TOO_LARGE_PAYLOAD : usize = 2 * MAX_PAYLOAD_SIZE;
+        let bytes = vec![42u8; TOO_LARGE_PAYLOAD];
+        let seed = hdwallet::Seed::from_bytes([0;hdwallet::SEED_SIZE]);
+        let sk = hdwallet::XPrv::generate_from_seed(&seed);
+        let pk = sk.public();
+
+        let key = HDKey::new(&pk);
+        match key.decrypt(&bytes).unwrap_err() {
+            Error::PayloadIsTooLarge(len) => assert_eq!(len, TOO_LARGE_PAYLOAD - TAG_LEN),
+            err => assert!(false, "expecting Error::PayloadIsTooLarge({}) but got {:#?}", TOO_LARGE_PAYLOAD - TAG_LEN, err),
+        }
+    }
+
+    #[test]
     fn path_cbor_encoding() {
         let path = Path::new(vec![0,1,2]);
         let cbor = path.cbor();


### PR DESCRIPTION
relates to input-output-hk/cardano-cli#73

currently set the limit to 48 bytes of encrypted materials. This does not prevent the creation of addresses with very large size, only prevent trying to decrypt something that is very large and should not be in an address.

Like it can be seen in the transaction: [0cf622af7bcd5e75e763f25e727137e1bcb10951d1d2977b47c6fb67ee29c593](https://cardanoexplorer.com/tx/0cf622af7bcd5e75e763f25e727137e1bcb10951d1d2977b47c6fb67ee29c593).