### PR TITLE
Update CBOR event library dependency

### DIFF
--- a/cardano/Cargo.toml
+++ b/cardano/Cargo.toml
@@ -15,7 +15,7 @@ keywords = [ "Cardano", "Wallet", "Crypto" ]
 
 [dependencies]
 cryptoxide = "0.1"
-cbor_event = "^1.0.1"
+cbor_event = "^2.1.1"
 
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }

--- a/cardano/src/block/types.rs
+++ b/cardano/src/block/types.rs
@@ -1,9 +1,13 @@
 use super::normal::SscPayload;
-use cbor_event::{self, de::RawCbor};
+use cbor_event::{self, de::Deserializer, se::Serializer};
 use hash::Blake2b256;
 use util::try_from_slice::TryFromSlice;
 
-use std::{fmt, str::FromStr};
+use std::{
+    fmt,
+    io::{BufRead, Write},
+    str::FromStr,
+};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub struct Version {
@@ -251,10 +255,10 @@ impl ::std::ops::Sub<EpochSlotId> for EpochSlotId {
 // CBOR implementations
 // **************************************************************************
 impl cbor_event::se::Serialize for Version {
-    fn serialize<W: ::std::io::Write>(
+    fn serialize<'se, W: Write>(
         &self,
-        serializer: cbor_event::se::Serializer<W>,
-    ) -> cbor_event::Result<cbor_event::se::Serializer<W>> {
+        serializer: &'se mut Serializer<W>,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
         serializer
             .write_array(cbor_event::Len::Len(3))?
             .write_unsigned_integer(self.major as u64)?
@@ -263,7 +267,7 @@ impl cbor_event::se::Serialize for Version {
     }
 }
 impl cbor_event::de::Deserialize for Version {
-    fn deserialize<'a>(raw: &mut RawCbor<'a>) -> cbor_event::Result<Self> {
+    fn deserialize<R: BufRead>(raw: &mut Deserializer<R>) -> cbor_event::Result<Self> {
         raw.tuple(3, "Version")?;
         let major = raw.unsigned_integer()? as u32;
         let minor = raw.unsigned_integer()? as u32;
@@ -274,10 +278,10 @@ impl cbor_event::de::Deserialize for Version {
 }
 
 impl cbor_event::se::Serialize for BlockVersion {
-    fn serialize<W: ::std::io::Write>(
+    fn serialize<'se, W: Write>(
         &self,
-        serializer: cbor_event::se::Serializer<W>,
-    ) -> cbor_event::Result<cbor_event::se::Serializer<W>> {
+        serializer: &'se mut Serializer<W>,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
         serializer
             .write_array(cbor_event::Len::Len(3))?
             .write_unsigned_integer(self.0 as u64)?
@@ -286,7 +290,7 @@ impl cbor_event::se::Serialize for BlockVersion {
     }
 }
 impl cbor_event::de::Deserialize for BlockVersion {
-    fn deserialize<'a>(raw: &mut RawCbor<'a>) -> cbor_event::Result<Self> {
+    fn deserialize<R: BufRead>(raw: &mut Deserializer<R>) -> cbor_event::Result<Self> {
         raw.tuple(3, "BlockVersion")?;
         let major = raw.unsigned_integer()? as u16;
         let minor = raw.unsigned_integer()? as u16;
@@ -297,10 +301,10 @@ impl cbor_event::de::Deserialize for BlockVersion {
 }
 
 impl cbor_event::se::Serialize for SoftwareVersion {
-    fn serialize<W: ::std::io::Write>(
+    fn serialize<'se, W: Write>(
         &self,
-        serializer: cbor_event::se::Serializer<W>,
-    ) -> cbor_event::Result<cbor_event::se::Serializer<W>> {
+        serializer: &'se mut Serializer<W>,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
         serializer
             .write_array(cbor_event::Len::Len(2))?
             .write_text(&self.application_name)?
@@ -308,7 +312,7 @@ impl cbor_event::se::Serialize for SoftwareVersion {
     }
 }
 impl cbor_event::de::Deserialize for SoftwareVersion {
-    fn deserialize<'a>(raw: &mut RawCbor<'a>) -> cbor_event::Result<Self> {
+    fn deserialize<R: BufRead>(raw: &mut Deserializer<R>) -> cbor_event::Result<Self> {
         raw.tuple(2, "SoftwareVersion")?;
         let name = raw.text()?;
         let version = raw.unsigned_integer()? as u32;
@@ -318,38 +322,38 @@ impl cbor_event::de::Deserialize for SoftwareVersion {
 }
 
 impl cbor_event::se::Serialize for HeaderHash {
-    fn serialize<W: ::std::io::Write>(
+    fn serialize<'se, W: Write>(
         &self,
-        serializer: cbor_event::se::Serializer<W>,
-    ) -> cbor_event::Result<cbor_event::se::Serializer<W>> {
+        serializer: &'se mut Serializer<W>,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
         serializer.serialize(&self.0)
     }
 }
 impl cbor_event::de::Deserialize for HeaderHash {
-    fn deserialize<'a>(raw: &mut RawCbor<'a>) -> cbor_event::Result<Self> {
+    fn deserialize<R: BufRead>(raw: &mut Deserializer<R>) -> cbor_event::Result<Self> {
         cbor_event::de::Deserialize::deserialize(raw).map(|h| HeaderHash(h))
     }
 }
 
 impl cbor_event::se::Serialize for BlockHeaderAttributes {
-    fn serialize<W: ::std::io::Write>(
+    fn serialize<'se, W: Write>(
         &self,
-        serializer: cbor_event::se::Serializer<W>,
-    ) -> cbor_event::Result<cbor_event::se::Serializer<W>> {
+        serializer: &'se mut Serializer<W>,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
         serializer.serialize(&self.0)
     }
 }
 impl cbor_event::de::Deserialize for BlockHeaderAttributes {
-    fn deserialize<'a>(raw: &mut RawCbor<'a>) -> cbor_event::Result<Self> {
+    fn deserialize<R: BufRead>(raw: &mut Deserializer<R>) -> cbor_event::Result<Self> {
         Ok(BlockHeaderAttributes(raw.deserialize()?))
     }
 }
 
 impl cbor_event::se::Serialize for HeaderExtraData {
-    fn serialize<W: ::std::io::Write>(
+    fn serialize<'se, W: Write>(
         &self,
-        serializer: cbor_event::se::Serializer<W>,
-    ) -> cbor_event::Result<cbor_event::se::Serializer<W>> {
+        serializer: &'se mut Serializer<W>,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
         serializer
             .write_array(cbor_event::Len::Len(4))?
             .serialize(&self.block_version)?
@@ -359,7 +363,7 @@ impl cbor_event::se::Serialize for HeaderExtraData {
     }
 }
 impl cbor_event::de::Deserialize for HeaderExtraData {
-    fn deserialize<'a>(raw: &mut RawCbor<'a>) -> cbor_event::Result<Self> {
+    fn deserialize<R: BufRead>(raw: &mut Deserializer<R>) -> cbor_event::Result<Self> {
         raw.tuple(4, "HeaderExtraData")?;
         let block_version = cbor_event::de::Deserialize::deserialize(raw)?;
         let software_version = cbor_event::de::Deserialize::deserialize(raw)?;
@@ -376,10 +380,10 @@ impl cbor_event::de::Deserialize for HeaderExtraData {
 }
 
 impl cbor_event::se::Serialize for SscProof {
-    fn serialize<W: ::std::io::Write>(
+    fn serialize<'se, W: Write>(
         &self,
-        serializer: cbor_event::se::Serializer<W>,
-    ) -> cbor_event::Result<cbor_event::se::Serializer<W>> {
+        serializer: &'se mut Serializer<W>,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
         match self {
             &SscProof::Commitments(ref commhash, ref vss) => serializer
                 .write_array(cbor_event::Len::Len(3))?
@@ -404,7 +408,7 @@ impl cbor_event::se::Serialize for SscProof {
     }
 }
 impl cbor_event::de::Deserialize for SscProof {
-    fn deserialize<'a>(raw: &mut RawCbor<'a>) -> cbor_event::Result<Self> {
+    fn deserialize<R: BufRead>(raw: &mut Deserializer<R>) -> cbor_event::Result<Self> {
         let len = raw.array()?;
         if len != cbor_event::Len::Len(2) && len != cbor_event::Len::Len(3) {
             return Err(cbor_event::Error::CustomError(format!(
@@ -442,32 +446,32 @@ impl cbor_event::de::Deserialize for SscProof {
 }
 
 impl cbor_event::se::Serialize for ChainDifficulty {
-    fn serialize<W: ::std::io::Write>(
+    fn serialize<'se, W: Write>(
         &self,
-        serializer: cbor_event::se::Serializer<W>,
-    ) -> cbor_event::Result<cbor_event::se::Serializer<W>> {
+        serializer: &'se mut Serializer<W>,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
         serializer
             .write_array(cbor_event::Len::Len(1))?
             .write_unsigned_integer(self.0)
     }
 }
 impl cbor_event::de::Deserialize for ChainDifficulty {
-    fn deserialize<'a>(raw: &mut RawCbor<'a>) -> cbor_event::Result<Self> {
+    fn deserialize<R: BufRead>(raw: &mut Deserializer<R>) -> cbor_event::Result<Self> {
         raw.tuple(1, "ChainDifficulty")?;
         Ok(ChainDifficulty(raw.unsigned_integer()?))
     }
 }
 
 impl cbor_event::se::Serialize for EpochSlotId {
-    fn serialize<W: ::std::io::Write>(
+    fn serialize<'se, W: Write>(
         &self,
-        serializer: cbor_event::se::Serializer<W>,
-    ) -> cbor_event::Result<cbor_event::se::Serializer<W>> {
+        serializer: &'se mut Serializer<W>,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
         serializer.serialize(&(&self.epoch, &self.slotid))
     }
 }
 impl cbor_event::de::Deserialize for EpochSlotId {
-    fn deserialize<'a>(raw: &mut RawCbor<'a>) -> cbor_event::Result<Self> {
+    fn deserialize<R: BufRead>(raw: &mut Deserializer<R>) -> cbor_event::Result<Self> {
         raw.tuple(2, "SlotId")?;
         let epoch = raw.deserialize()?;
         let slotid = raw.deserialize()?;
@@ -498,16 +502,16 @@ impl CoinPortion {
 }
 
 impl cbor_event::se::Serialize for CoinPortion {
-    fn serialize<W: ::std::io::Write>(
+    fn serialize<'se, W: Write>(
         &self,
-        serializer: cbor_event::se::Serializer<W>,
-    ) -> cbor_event::Result<cbor_event::se::Serializer<W>> {
+        serializer: &'se mut Serializer<W>,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
         serializer.serialize(&self.0)
     }
 }
 
 impl cbor_event::de::Deserialize for CoinPortion {
-    fn deserialize<'a>(raw: &mut RawCbor<'a>) -> cbor_event::Result<Self> {
+    fn deserialize<R: BufRead>(raw: &mut Deserializer<R>) -> cbor_event::Result<Self> {
         Ok(CoinPortion::new(raw.deserialize()?)?)
     }
 }
@@ -536,16 +540,16 @@ impl SystemTag {
 }
 
 impl cbor_event::se::Serialize for SystemTag {
-    fn serialize<W: ::std::io::Write>(
+    fn serialize<'se, W: Write>(
         &self,
-        serializer: cbor_event::se::Serializer<W>,
-    ) -> cbor_event::Result<cbor_event::se::Serializer<W>> {
+        serializer: &'se mut Serializer<W>,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
         serializer.serialize(&self.0)
     }
 }
 
 impl cbor_event::de::Deserialize for SystemTag {
-    fn deserialize<'a>(raw: &mut RawCbor<'a>) -> cbor_event::Result<Self> {
+    fn deserialize<R: BufRead>(raw: &mut Deserializer<R>) -> cbor_event::Result<Self> {
         Ok(SystemTag::new(raw.deserialize()?)?)
     }
 }

--- a/cardano/src/config.rs
+++ b/cardano/src/config.rs
@@ -6,13 +6,16 @@
 
 use address;
 use block;
-use cbor_event::{self, de::RawCbor, se::Serializer};
+use cbor_event::{self, de::Deserializer, se::Serializer};
 use coin;
 use fee;
 use redeem;
-use std::collections::BTreeMap;
-use std::fmt;
-use std::time::{Duration, SystemTime};
+use std::{
+    collections::BTreeMap,
+    fmt,
+    io::{BufRead, Write},
+    time::{Duration, SystemTime},
+};
 
 /// this is the protocol magic number
 ///
@@ -61,16 +64,16 @@ impl Default for ProtocolMagic {
     }
 }
 impl cbor_event::se::Serialize for ProtocolMagic {
-    fn serialize<W: ::std::io::Write>(
+    fn serialize<'se, W: Write>(
         &self,
-        serializer: Serializer<W>,
-    ) -> cbor_event::Result<Serializer<W>> {
+        serializer: &'se mut Serializer<W>,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
         serializer.write_unsigned_integer(self.0 as u64)
     }
 }
 impl cbor_event::Deserialize for ProtocolMagic {
-    fn deserialize<'a>(raw: &mut RawCbor<'a>) -> cbor_event::Result<Self> {
-        let v = raw.unsigned_integer()? as u32;
+    fn deserialize<R: BufRead>(reader: &mut Deserializer<R>) -> cbor_event::Result<Self> {
+        let v = reader.unsigned_integer()? as u32;
         Ok(ProtocolMagic::from(v))
     }
 }

--- a/cardano/src/merkle.rs
+++ b/cardano/src/merkle.rs
@@ -41,9 +41,10 @@ impl MerkleNode {
         if xs.is_empty() {
             panic!("make_tree applied to empty list")
         } else if xs.len() == 1 {
-            let mut bs = vec![0u8];
-            xs[0].serialize(se::Serializer::new(&mut bs)).unwrap();
-            MerkleNode::Leaf(Hash::new(&bs))
+            let bs = vec![0u8];
+            let mut se = se::Serializer::new(bs);
+            xs[0].serialize(&mut se).unwrap();
+            MerkleNode::Leaf(Hash::new(&se.finalize()))
         } else {
             let i = xs.len().checked_next_power_of_two().unwrap() >> 1;
             let a = MerkleNode::make_tree(&xs[0..i]);

--- a/cardano/src/redeem.rs
+++ b/cardano/src/redeem.rs
@@ -7,13 +7,17 @@
 //! On the **mainnet** you can use the redeem keys to claim redeem addresses.
 //!
 
-use cbor_event::{self, de::RawCbor, se::Serializer};
+use cbor_event::{self, de::Deserializer, se::Serializer};
 use cryptoxide::ed25519;
 #[cfg(feature = "generic-serialization")]
 use serde;
 use util::hex;
 
-use std::{cmp, fmt, result};
+use std::{
+    cmp, fmt,
+    io::{BufRead, Write},
+    result,
+};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 #[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
@@ -221,16 +225,16 @@ impl Ord for Signature {
 // ---------------------------------------------------------------------------
 
 impl cbor_event::se::Serialize for PublicKey {
-    fn serialize<W: ::std::io::Write>(
+    fn serialize<'se, W: Write>(
         &self,
-        serializer: Serializer<W>,
-    ) -> cbor_event::Result<Serializer<W>> {
+        serializer: &'se mut Serializer<W>,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
         serializer.write_bytes(self.0.as_ref())
     }
 }
 impl cbor_event::de::Deserialize for PublicKey {
-    fn deserialize<'a>(raw: &mut RawCbor<'a>) -> cbor_event::Result<Self> {
-        match PublicKey::from_slice(&raw.bytes()?) {
+    fn deserialize<R: BufRead>(reader: &mut Deserializer<R>) -> cbor_event::Result<Self> {
+        match PublicKey::from_slice(&reader.bytes()?) {
             Ok(digest) => Ok(digest),
             Err(Error::InvalidPublicKeySize(sz)) => {
                 Err(cbor_event::Error::NotEnough(sz, PUBLICKEY_SIZE))
@@ -244,16 +248,16 @@ impl cbor_event::de::Deserialize for PublicKey {
 }
 
 impl cbor_event::se::Serialize for PrivateKey {
-    fn serialize<W: ::std::io::Write>(
+    fn serialize<'se, W: Write>(
         &self,
-        serializer: Serializer<W>,
-    ) -> cbor_event::Result<Serializer<W>> {
+        serializer: &'se mut Serializer<W>,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
         serializer.write_bytes(self.0.as_ref())
     }
 }
 impl cbor_event::de::Deserialize for PrivateKey {
-    fn deserialize<'a>(raw: &mut RawCbor<'a>) -> cbor_event::Result<Self> {
-        match PrivateKey::from_slice(&raw.bytes()?) {
+    fn deserialize<R: BufRead>(reader: &mut Deserializer<R>) -> cbor_event::Result<Self> {
+        match PrivateKey::from_slice(&reader.bytes()?) {
             Ok(digest) => Ok(digest),
             Err(Error::InvalidPrivateKeySize(sz)) => {
                 Err(cbor_event::Error::NotEnough(sz, PRIVATEKEY_SIZE))
@@ -267,16 +271,16 @@ impl cbor_event::de::Deserialize for PrivateKey {
 }
 
 impl cbor_event::se::Serialize for Signature {
-    fn serialize<W: ::std::io::Write>(
+    fn serialize<'se, W: Write>(
         &self,
-        serializer: Serializer<W>,
-    ) -> cbor_event::Result<Serializer<W>> {
+        serializer: &'se mut Serializer<W>,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
         serializer.write_bytes(self.0.as_ref())
     }
 }
 impl cbor_event::de::Deserialize for Signature {
-    fn deserialize<'a>(raw: &mut RawCbor<'a>) -> cbor_event::Result<Self> {
-        match Signature::from_slice(&raw.bytes()?) {
+    fn deserialize<R: BufRead>(reader: &mut Deserializer<R>) -> cbor_event::Result<Self> {
+        match Signature::from_slice(&reader.bytes()?) {
             Ok(digest) => Ok(digest),
             Err(Error::InvalidSignatureSize(sz)) => {
                 Err(cbor_event::Error::NotEnough(sz, SIGNATURE_SIZE))

--- a/cardano/src/txbuild.rs
+++ b/cardano/src/txbuild.rs
@@ -440,7 +440,7 @@ mod tests {
                     assert!(out_policy_length_expected(x));
                     fee_is_minimal(builder.balance(&alg).unwrap())
                 }
-                Err(Error::TxOutputPolicyNotEnoughCoins(c)) => {
+                Err(Error::TxOutputPolicyNotEnoughCoins(_c)) => {
                     // here we don't check that the fee is minimal, since we need to burn extra coins
                     fee_is_acceptable(builder.balance(&alg).unwrap())
                 }

--- a/cardano/src/wallet/rindex.rs
+++ b/cardano/src/wallet/rindex.rs
@@ -368,9 +368,9 @@ impl RootKey {
             blake2b.input(&entropy_cbor);
             let mut out = [0; 32];
             blake2b.result(&mut out);
-            cbor_event::se::Serializer::new_vec()
-                .write_bytes(&Vec::from(&out[..]))?
-                .finalize()
+            let mut se = cbor_event::se::Serializer::new_vec();
+            se.write_bytes(&Vec::from(&out[..]))?;
+            se.finalize()
         };
 
         let xprv = XPrv::generate_from_daedalus_seed(&seed);
@@ -589,17 +589,13 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::config::{NetworkMagic, ProtocolMagic};
+    use crate::config::ProtocolMagic;
     use crate::tx::TxoPointer;
     use crate::wallet::rindex;
     use crate::wallet::scheme::Wallet;
 
     const MNEMONICS: &'static str =
         "edge club wrap where juice nephew whip entry cover bullet cause jeans";
-    const ENTROPY: [u8; 16] = [
-        0x46, 0x45, 0x87, 0xf8, 0x7d, 0x27, 0x8d, 0x28, 0xbe, 0x9a, 0x5d, 0x31, 0x83, 0xc4, 0x92,
-        0x3b,
-    ];
 
     lazy_static! {
         static ref OUTPUT: ExtendedAddr = {

--- a/exe-common/Cargo.toml
+++ b/exe-common/Cargo.toml
@@ -14,7 +14,7 @@ Helpers and tools for the Cardano protocol. This includes keeping the blockchain
 cardano-storage = { path = "../storage" }
 storage-units = { path = "../storage-units" }
 protocol = { path = "../protocol" }
-cbor_event = "1.0"
+cbor_event = "2.1.2"
 log = "*"
 rand = "0.5"
 serde = "1.0"

--- a/protocol-tokio/Cargo.toml
+++ b/protocol-tokio/Cargo.toml
@@ -14,7 +14,7 @@ keywords = [ "Cardano", "Protocol" ]
 
 [dependencies]
 cardano    = { path = "../cardano" }
-cbor_event = "^1.0.1"
+cbor_event = "^2.1.1"
 futures = "^0.1.25"
 tokio-io = "^0.1.9"
 tokio-codec = "^0.1.1"

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -15,7 +15,7 @@ keywords = [ "Cardano", "Protocol" ]
 [build-dependencies]
 
 [dependencies]
-cbor_event = "1.0"
+cbor_event = "^2.1.2"
 cardano = { path = "../cardano" }
 log = "0.4"
 

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -15,7 +15,7 @@ intertwined with the Cardano blockchain itself.
 
 [dependencies]
 cardano = { path = "../cardano" }
-cbor_event = "1.0"
+cbor_event = "^2.1.1"
 storage-units = { path = "../storage-units" }
 log = "*"
 rand = "0.5"


### PR DESCRIPTION
The new version allows for streamable interface (and does not take ownership of the serializer).