### PR TITLE
Property traits for blockchain data entities

### DIFF
--- a/cardano/src/block/block.rs
+++ b/cardano/src/block/block.rs
@@ -80,6 +80,8 @@ pub enum BlockHeader {
     MainBlockHeader(normal::BlockHeader),
 }
 
+impl core::property::Header for BlockHeader {}
+
 /// BlockHeaders is a vector of block headers, as produced by
 /// MsgBlocks.
 #[derive(Debug, Clone)]
@@ -205,6 +207,7 @@ impl fmt::Display for Block {
 impl core::property::Block for Block {
     type Id = HeaderHash;
     type Date = BlockDate;
+    type Header = BlockHeader;
 
     fn id(&self) -> Self::Id {
         self.get_header().compute_hash()
@@ -222,7 +225,12 @@ impl core::property::Block for Block {
             Block::BoundaryBlock(ref block) => block.header.consensus.epoch.into(),
         }
     }
+
+    fn header(&self) -> BlockHeader {
+        self.get_header()
+    }
 }
+
 impl core::property::HasTransaction<TxAux> for Block {
     fn transactions<'a>(&'a self) -> std::slice::Iter<'a, TxAux> {
         match self {

--- a/cardano/src/block/date.rs
+++ b/cardano/src/block/date.rs
@@ -1,5 +1,7 @@
 use super::types::{EpochId, EpochSlotId, SlotId};
 
+use chain_core::property;
+
 use std::{
     cmp::{Ord, Ordering},
     error::Error,
@@ -16,6 +18,9 @@ pub enum BlockDate {
     Boundary(EpochId),
     Normal(EpochSlotId),
 }
+
+impl property::BlockDate for BlockDate {}
+
 impl ::std::ops::Sub<BlockDate> for BlockDate {
     type Output = usize;
     fn sub(self, rhs: Self) -> Self::Output {

--- a/cardano/src/block/types.rs
+++ b/cardano/src/block/types.rs
@@ -1,5 +1,6 @@
 use super::normal::SscPayload;
 use cbor_event::{self, de::Deserializer, se::Serializer};
+use chain_core::property;
 use hash::Blake2b256;
 use util::try_from_slice::TryFromSlice;
 
@@ -35,7 +36,7 @@ impl fmt::Display for Version {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct HeaderHash(Blake2b256);
 impl HeaderHash {
@@ -47,6 +48,9 @@ impl HeaderHash {
         self.0.as_hash_bytes()
     }
 }
+
+impl property::BlockId for HeaderHash {}
+
 impl fmt::Display for HeaderHash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)

--- a/cardano/src/lib.rs
+++ b/cardano/src/lib.rs
@@ -15,11 +15,14 @@
 //!
 #![cfg_attr(feature = "with-bench", feature(test))]
 
+extern crate chain_core;
+
 #[cfg(feature = "generic-serialization")]
 #[macro_use]
 extern crate serde_derive;
 #[cfg(feature = "generic-serialization")]
 extern crate serde;
+
 #[cfg(test)]
 extern crate serde_json;
 #[cfg(test)]

--- a/cardano/src/tx.rs
+++ b/cardano/src/tx.rs
@@ -11,23 +11,25 @@ use std::{
     io::{BufRead, Write},
 };
 
-use hash::Blake2b256;
+use crate::{
+    address::{AddrType, Attributes, ExtendedAddr, SpendingData},
+    coin::{self, Coin},
+    config::ProtocolMagic,
+    hash::Blake2b256,
+    hdwallet::{Signature, XPrv, XPub, SIGNATURE_SIZE, XPUB_SIZE},
+    merkle, redeem,
+    tags::SigningTag,
+};
 
 use cbor_event::{self, de::Deserializer, se::Serializer};
-use config::ProtocolMagic;
-use merkle;
-use redeem;
-use tags::SigningTag;
-
-use address::{AddrType, Attributes, ExtendedAddr, SpendingData};
-use coin::{self, Coin};
-use hdwallet::{Signature, XPrv, XPub, SIGNATURE_SIZE, XPUB_SIZE};
-
-use core;
+use chain_core::property;
 
 // Transaction IDs are either a hash of the CBOR serialisation of a
 // given Tx, or a hash of a redeem address.
 pub type TxId = Blake2b256;
+
+// FIXME: This is dodgy because TxId is not currently a dedicated type.
+impl property::TransactionId for TxId {}
 
 pub fn redeem_pubkey_to_txid(
     pubkey: &redeem::PublicKey,

--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -35,6 +35,21 @@
 //! is selected to write a block in the chain.
 //!
 
+use std::hash::Hash;
+
+/// Trait identifying the block identifier type.
+pub trait BlockId: Eq + Hash {}
+
+/// Trait identifying the block date type.
+pub trait BlockDate: Eq + Ord {}
+
+/// Trait identifying the transaction identifier type.
+pub trait TransactionId: Eq + Hash {}
+
+/// Trait identifying the block header type.
+/// TODO: provide header in the data model.
+pub trait Header {}
+
 /// Block property
 ///
 /// a block is part of a chain of block called Blockchain.
@@ -51,13 +66,13 @@ pub trait Block: Serializable {
     ///
     /// In bitcoin this block is a SHA2 256bits. For Cardano's
     /// blockchain it is Blake2b 256bits.
-    type Id;
+    type Id: BlockId;
 
     /// the block date (also known as a block number) represents the
     /// absolute position of the block in the chain. This can be used
     /// for random access (if the storage algorithm allows it) or for
     /// identifying the position of a block in a given epoch or era.
-    type Date;
+    type Date: BlockDate;
 
     /// return the Block's identifier.
     fn id(&self) -> Self::Id;
@@ -81,7 +96,7 @@ pub trait Transaction: Serializable {
     type Output;
     /// a unique identifier of the transaction. For 2 different transactions
     /// we must have 2 different `Id` values.
-    type Id;
+    type Id: TransactionId;
 
     fn inputs<'a>(&'a self) -> std::slice::Iter<'a, Self::Input>;
     fn outputs<'a>(&'a self) -> std::slice::Iter<'a, Self::Output>;

--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -47,8 +47,9 @@ pub trait BlockDate: Eq + Ord {}
 pub trait TransactionId: Eq + Hash {}
 
 /// Trait identifying the block header type.
-/// TODO: provide header in the data model.
 pub trait Header {}
+
+impl Header for () {}
 
 /// Block property
 ///
@@ -74,6 +75,13 @@ pub trait Block: Serializable {
     /// identifying the position of a block in a given epoch or era.
     type Date: BlockDate;
 
+    /// The block header. If provided by the blockchain, the header
+    /// can be used to transmit block's metadata via a network protocol
+    /// or in other uses where the full content of the block is not desirable.
+    /// An implementation that does not feature headers can use the unit
+    /// type `()`.
+    type Header: Header;
+
     /// return the Block's identifier.
     fn id(&self) -> Self::Id;
 
@@ -83,6 +91,9 @@ pub trait Block: Serializable {
 
     /// get the block date of the block
     fn date(&self) -> Self::Date;
+
+    /// Gets the block's header.
+    fn header(&self) -> Self::Header;
 }
 
 /// define a transaction within the blockchain. This transaction can be used

--- a/chain-impl-mockchain/src/block.rs
+++ b/chain-impl-mockchain/src/block.rs
@@ -1,6 +1,6 @@
 //! Representation of the block in the mockchain.
-use crate::key::*;
-use crate::transaction::*;
+use crate::key::Hash;
+use crate::transaction::SignedTransaction;
 use chain_core::property;
 
 /// Non unique identifier of the transaction position in the
@@ -8,6 +8,8 @@ use chain_core::property;
 /// `SlotId`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 pub struct SlotId(u32, u32);
+
+impl property::BlockDate for SlotId {}
 
 /// `Block` is an element of the blockchain it contains multiple
 /// transaction and a reference to the parent block. Alongside

--- a/chain-impl-mockchain/src/block.rs
+++ b/chain-impl-mockchain/src/block.rs
@@ -1,6 +1,6 @@
 //! Representation of the block in the mockchain.
-use crate::key::Hash;
-use crate::transaction::SignedTransaction;
+use crate::key::*;
+use crate::transaction::*;
 use chain_core::property;
 
 /// Non unique identifier of the transaction position in the
@@ -25,6 +25,7 @@ pub struct Block {
 impl property::Block for Block {
     type Id = Hash;
     type Date = SlotId;
+    type Header = ();
 
     /// Identifier of the block, currently the hash of the
     /// serialized transaction.
@@ -41,6 +42,10 @@ impl property::Block for Block {
     /// Date of the block.
     fn date(&self) -> Self::Date {
         self.slot_id
+    }
+
+    fn header(&self) -> Self::Header {
+        ()
     }
 }
 

--- a/chain-impl-mockchain/src/key.rs
+++ b/chain-impl-mockchain/src/key.rs
@@ -3,6 +3,7 @@
 //!
 use cardano::hash;
 use cardano::hdwallet as crypto;
+use chain_core::property;
 
 // TODO: this public key contains the chain code in it too
 // during serialisation this might not be needed
@@ -52,6 +53,8 @@ impl AsRef<[u8]> for Hash {
         self.0.as_ref()
     }
 }
+
+impl property::BlockId for Hash {}
 
 /// Cryptographic signature.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]

--- a/chain-impl-mockchain/src/transaction.rs
+++ b/chain-impl-mockchain/src/transaction.rs
@@ -73,6 +73,8 @@ impl AsRef<[u8]> for TransactionId {
     }
 }
 
+impl property::TransactionId for TransactionId {}
+
 /// Transaction, transaction maps old unspent tokens into the
 /// set of the new addresses.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]


### PR DESCRIPTION
Add empty property traits that are used to denote types representing
specific entities of the blockchain data model:

- `BlockId` implemented by block identifier type,
- `BlockDate` implemented by block date type,
- `TxId` implemented by transaction identifier type,
- `Header` implemented by block header type.

These continue the system of existing entity identification traits
such as `Block`, `Transaction`, and `Ledger`, except that the new traits
do not (yet) feature any methods.

Resolves #375