### PR TITLE
Chain core update: small changes on the property interfaces

### DIFF
--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -67,7 +67,7 @@ pub trait Block: Serializable {
     fn parent_id(&self) -> &Self::Id;
 
     /// get the block date of the block
-    fn date(&self) -> &Self::Date;
+    fn date(&self) -> Self::Date;
 }
 
 /// define a transaction within the blockchain. This transaction can be used

--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -203,7 +203,7 @@ pub trait Serializable: Sized {
 
     fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error>;
 
-    fn deserialize<R: std::io::Read>(reader: R) -> Result<Self, Self::Error>;
+    fn deserialize<R: std::io::BufRead>(reader: R) -> Result<Self, Self::Error>;
 }
 
 #[cfg(feature = "property-test-api")]

--- a/chain-impl-mockchain/src/block.rs
+++ b/chain-impl-mockchain/src/block.rs
@@ -37,8 +37,8 @@ impl property::Block for Block {
     }
 
     /// Date of the block.
-    fn date(&self) -> &Self::Date {
-        &self.slot_id
+    fn date(&self) -> Self::Date {
+        self.slot_id
     }
 }
 


### PR DESCRIPTION
1. make the Block::date() returns a value and not a reference. This is because some representation will not match the idea of a generic representation (i.e. the underlying type will old different kind of Date representation -- mainly thinking about boundary block or ZK);
2. use BufRead as a dependency for the Serialise trait. This is because of the deserialisation algorithm requires to accept buffer.