### PR TITLE
mockchain: Make transaction checker more strict.

### DIFF
--- a/chain-impl-mockchain/src/error.rs
+++ b/chain-impl-mockchain/src/error.rs
@@ -1,7 +1,7 @@
 //! Errors taht may happen in the ledger and mockchain.
 use crate::transaction::*;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Error {
     /// If the Ledger could not find the given input in the UTxO list it will
     /// report this error.
@@ -36,6 +36,11 @@ pub enum Error {
     /// Transaction sum is not equal to zero, this means that we
     /// either generate or lose some money during the transaction.
     TransactionSumIsNonZero(u64, u64),
+
+    /// Transaction does not have enough signatures.
+    /// First value represents number of inputs (required signatures)
+    /// Send value represents actual number of singatures.
+    NotEnoughSignatures(usize, usize),
 }
 
 impl std::fmt::Display for Error {
@@ -49,6 +54,11 @@ impl std::fmt::Display for Error {
             Error::InvalidSignature(_, _, _) => write!(f, "Input is not signed properly"),
             Error::InvalidTxSignature(_) => write!(f, "Transaction was not signed"),
             Error::TransactionSumIsNonZero(_, _) => write!(f, "Transaction sum is non zero"),
+            Error::NotEnoughSignatures(required, actual) => write!(
+                f,
+                "Transaction has not enough signatures: {} out of {}",
+                actual, required
+            ),
         }
     }
 }

--- a/chain-impl-mockchain/src/key.rs
+++ b/chain-impl-mockchain/src/key.rs
@@ -38,6 +38,9 @@ impl PrivateKey {
     pub fn sign(&self, data: &[u8]) -> Signature {
         Signature(self.0.sign(data))
     }
+    pub fn normalize_bytes(xprv: [u8; crypto::XPRV_SIZE]) -> Self {
+        PrivateKey(crypto::XPrv::normalize_bytes(xprv))
+    }
 }
 
 /// Hash that is used as an address of the various components.

--- a/chain-impl-mockchain/src/transaction.rs
+++ b/chain-impl-mockchain/src/transaction.rs
@@ -66,7 +66,7 @@ pub struct Output(pub Address, pub Value);
 
 /// Id of the transaction.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
-pub struct TransactionId(Hash);
+pub struct TransactionId(pub Hash);
 impl AsRef<[u8]> for TransactionId {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()


### PR DESCRIPTION
Check if the number of signatures matches the number of
inputs in the mockchain.