### PR TITLE
property: Add Update and Settings traits

### DIFF
--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -145,6 +145,8 @@ pub trait Update {
     /// node has decided to rollback to a previous fork and un apply the
     /// given update.
     fn inverse(self) -> Self;
+
+    fn empty() -> Self;
 }
 
 /// Define the Ledger side of the blockchain. This is not really on the blockchain

--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -300,7 +300,7 @@ pub mod testing {
 
     /// test that arbitrary generated transaction fails, this test requires
     /// that all the objects inside the transaction are arbitrary generated.
-    /// There is a very small propability of the event that all the objects
+    /// There is a very small probability of the event that all the objects
     /// will match, i.e. the contents of the transaction list of the subscribers
     /// and signatures will compose into a valid transaction, but if such
     /// event would happen it can be treated as error due to lack of the

--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -212,7 +212,7 @@ pub trait LeaderSelection {
     /// * generic testing;
     /// * diff based storage;
     ///
-    type Update;
+    type Update: Update;
 
     /// the block that we will get the information from
     type Block: Block;
@@ -245,7 +245,7 @@ pub trait LeaderSelection {
 /// the blockchain protocol update details:
 ///
 pub trait Settings {
-    type Update;
+    type Update: Update;
     type Block: Block;
     type Error: std::error::Error;
 

--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -377,12 +377,61 @@ pub mod testing {
         (id1 == id2 && tx1 == tx2) || (id1 != id2 && tx1 != tx2)
     }
 
-    pub fn update_inverse_of_inverse_is_id<U>(update: U) -> bool
+    /// Checks the associativity
+    /// i.e.
+    ///
+    /// ```text
+    /// forall u : Update, v: Update, w:Update . u.union(v.union(w))== (u.union(v)).union(w)
+    /// ```
+    pub fn update_associativity<U>(u: U, v: U, w: U) -> bool
+    where
+        U: Update + Arbitrary + PartialEq + Clone,
+    {
+        let result1 = u.clone().union(v.clone().union(w.clone()));
+        let result2 = (u.clone().union(v.clone())).union(w.clone());
+        result1 == result2
+    }
+
+    /// Checks the identify element
+    /// i.e.
+    ///
+    /// ```text
+    /// forall u : Update . u.union(empty)== u
+    /// ```
+    pub fn update_identity_element<U>(update: U) -> bool
+    where
+        U: Update + Arbitrary + PartialEq + Clone,
+    {
+        let result = update.clone().union(U::empty());
+        result == update
+    }
+
+    /// Checks for the inverse element
+    /// i.e.
+    ///
+    /// ```text
+    /// forall u : Update . u.inverse().union(u) == empty
+    /// ```
+    pub fn update_inverse_element<U>(update: U) -> bool
     where
         U: Update + Arbitrary + PartialEq + Clone,
     {
         let inversed = update.clone().inverse();
-        let reversed = inversed.inverse();
-        reversed == update
+        inversed.union(update) == U::empty()
+    }
+
+    /// Checks the commutativity of the Union
+    /// i.e.
+    ///
+    /// ```text
+    /// forall u : Update, v: Update . u.union(v)== v.union(u)
+    /// ```
+    pub fn update_union_commutative<U>(u1: U, u2: U) -> bool
+    where
+        U: Update + Arbitrary + PartialEq + Clone,
+    {
+        let r1 = u1.clone().union(u2.clone());
+        let r2 = u2.clone().union(u1.clone());
+        r1 == r2
     }
 }

--- a/chain-impl-mockchain/src/ledger.rs
+++ b/chain-impl-mockchain/src/ledger.rs
@@ -44,7 +44,7 @@ impl property::Update for Diff {
         }
     }
 
-    fn union(mut self, other: Self) -> Self {
+    fn union(&mut self, other: Self) -> &mut Self {
         // 1. other might be spending outputs that were _new_ in self
         //    we need to remove them first.
         for other_spending in other.spent_outputs.into_iter() {

--- a/chain-impl-mockchain/src/ledger.rs
+++ b/chain-impl-mockchain/src/ledger.rs
@@ -29,19 +29,46 @@ pub struct Diff {
     /// List of the new outputs that were produced by the transaction.
     new_unspent_outputs: HashMap<UtxoPointer, Output>,
 }
-impl Diff {
-    fn new() -> Self {
+impl property::Update for Diff {
+    fn empty() -> Self {
         Diff {
             spent_outputs: HashMap::new(),
             new_unspent_outputs: HashMap::new(),
         }
     }
 
-    fn extend(&mut self, other: Self) {
-        self.new_unspent_outputs.extend(other.new_unspent_outputs);
-        self.spent_outputs.extend(other.spent_outputs);
+    fn inverse(self) -> Self {
+        Diff {
+            spent_outputs: self.new_unspent_outputs,
+            new_unspent_outputs: self.spent_outputs,
+        }
+    }
+
+    fn union(mut self, other: Self) -> Self {
+        // 1. other might be spending outputs that were _new_ in self
+        //    we need to remove them first.
+        for other_spending in other.spent_outputs.into_iter() {
+            if let Some(_) = self.new_unspent_outputs.remove(&other_spending.0) {
+                // just ignore the deleted output
+            } else {
+                self.spent_outputs
+                    .insert(other_spending.0, other_spending.1);
+            }
+        }
+
+        // 2. other might be spending outputs that were _new_ in self
+        for other_output in other.new_unspent_outputs.into_iter() {
+            if let Some(_) = self.spent_outputs.remove(&other_output.0) {
+                // just ignore and drop the value
+            } else {
+                self.new_unspent_outputs
+                    .insert(other_output.0, other_output.1);
+            }
+        }
+        self
     }
 }
+
 impl property::Ledger<SignedTransaction> for Ledger {
     type Update = Diff;
     type Error = Error;
@@ -62,7 +89,7 @@ impl property::Ledger<SignedTransaction> for Ledger {
     ) -> Result<Self::Update, Self::Error> {
         use chain_core::property::Transaction;
 
-        let mut diff = Diff::new();
+        let mut diff = <Diff as property::Update>::empty();
         let id = transaction.id();
         // 0. verify that number of signatures matches number of
         // transactions
@@ -114,19 +141,6 @@ impl property::Ledger<SignedTransaction> for Ledger {
         Ok(diff)
     }
 
-    fn diff<'a, I>(&self, transactions: I) -> Result<Self::Update, Self::Error>
-    where
-        I: IntoIterator<Item = &'a SignedTransaction> + Sized,
-    {
-        let mut diff = Diff::new();
-
-        for transaction in transactions {
-            diff.extend(self.diff_transaction(transaction)?);
-        }
-
-        Ok(diff)
-    }
-
     fn apply(&mut self, diff: Self::Update) -> Result<&mut Self, Self::Error> {
         for spent_output in diff.spent_outputs.keys() {
             if let None = self.unspent_outputs.remove(spent_output) {
@@ -152,6 +166,15 @@ mod test {
     use crate::key::{Hash, PrivateKey};
     use cardano::hdwallet as crypto;
     use quickcheck::{Arbitrary, Gen};
+
+    impl Arbitrary for Diff {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            Diff {
+                spent_outputs: Arbitrary::arbitrary(g),
+                new_unspent_outputs: Arbitrary::arbitrary(g),
+            }
+        }
+    }
 
     impl Arbitrary for Ledger {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
@@ -259,6 +282,21 @@ mod test {
             Err(Error::TransactionSumIsNonZero(10, 9)),
             ledger.diff_transaction(&signed_tx)
         )
+    }
+
+    quickcheck! {
+        fn diff_union_is_associative(types: (Diff, Diff, Diff)) -> bool {
+            property::testing::update_associativity(types.0, types.1, types.2)
+        }
+        fn diff_union_has_identity_element(diff: Diff) -> bool {
+            property::testing::update_identity_element(diff)
+        }
+        fn diff_union_has_inverse_element(diff: Diff) -> bool {
+            property::testing::update_inverse_element(diff)
+        }
+        fn diff_union_is_commutative(types: (Diff, Diff)) -> bool {
+            property::testing::update_union_commutative(types.0, types.1)
+        }
     }
 
 }


### PR DESCRIPTION
# Update

Now we force Update objects to implement the Update trait. This will allow us to enforce some basic property requirements to the Update objects: i.e. we want to make sure that we can use the Update objects as intermediate steps to register the state of the blockchain (i.e. allowing to update the state and to easily rollback).

# Settings

this trait will monitor the blockchain settings (protocol versions...)