### PR TITLE
Genesis generation

### DIFF
--- a/cardano-c/src/transaction.rs
+++ b/cardano-c/src/transaction.rs
@@ -106,10 +106,10 @@ pub extern "C" fn cardano_transaction_builder_fee(tb: TransactionBuilderPtr) -> 
     let fee_algo = LinearFee::default();
 
     if let Ok(fee) = builder.calculate_fee(&fee_algo) {
-        *fee.to_coin() as u64
+        u64::from(fee.to_coin())
     } else {
         // failed to calculate transaction fee, return zero
-        *fee::Fee::new(Coin::zero()).to_coin() as u64
+        u64::from(fee::Fee::new(Coin::zero()).to_coin())
     }
 }
 

--- a/cardano/Cargo.toml
+++ b/cardano/Cargo.toml
@@ -27,6 +27,7 @@ rand = "0.5"
 serde_json = "1.0"
 unicode-normalization = "0.1"
 quickcheck = "0.7"
+base64 = "0.9"
 
 [features]
 default = []

--- a/cardano/src/block/sign.rs
+++ b/cardano/src/block/sign.rs
@@ -158,9 +158,7 @@ impl ProxySecretKey {
     ) -> Vec<u8> {
         // Yes, this really is
         // CBOR-in-byte-vector-in-CBOR-in-byte-vector...
-        let mut buf2 = vec![];
-        buf2.push('0' as u8);
-        buf2.push('0' as u8);
+        let mut buf2 = vec!['0' as u8, '0' as u8];
         buf2.extend(delegate_pk.as_ref());
         se::Serializer::new(&mut buf2).serialize(&omega).unwrap();
 

--- a/cardano/src/block/sign.rs
+++ b/cardano/src/block/sign.rs
@@ -67,10 +67,9 @@ where
     let mut buf = vec!['0' as u8, '1' as u8];
 
     buf.extend(proxy_sig.psk.issuer_pk.as_ref());
+    buf.push(tag as u8);
 
     se::Serializer::new(&mut buf)
-        .serialize(&(tag as u8))
-        .unwrap()
         .serialize(&protocol_magic)
         .unwrap()
         .serialize(data)

--- a/cardano/src/block/types.rs
+++ b/cardano/src/block/types.rs
@@ -106,25 +106,24 @@ impl chain_core::property::Deserialize for HeaderHash {
 impl chain_core::property::BlockId for HeaderHash {}
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
-pub struct BlockVersion(u16, u16, u8);
+pub struct BlockVersion {
+    pub major: u16,
+    pub minor: u16,
+    pub alt: u8,
+}
 impl BlockVersion {
-    pub fn new(major: u16, minor: u16, revision: u8) -> Self {
-        BlockVersion(major, minor, revision)
+    pub fn new(major: u16, minor: u16, alt: u8) -> Self {
+        BlockVersion { major, minor, alt }
     }
 }
 impl fmt::Debug for BlockVersion {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}.{}.{}", self.0, self.1, self.2)
+        write!(f, "{}.{}.{}", self.major, self.minor, self.alt)
     }
 }
 impl fmt::Display for BlockVersion {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
-    }
-}
-impl Default for BlockVersion {
-    fn default() -> Self {
-        BlockVersion::new(0, 1, 0)
     }
 }
 
@@ -302,21 +301,17 @@ impl cbor_event::se::Serialize for BlockVersion {
         &self,
         serializer: &'se mut Serializer<W>,
     ) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer
-            .write_array(cbor_event::Len::Len(3))?
-            .write_unsigned_integer(self.0 as u64)?
-            .write_unsigned_integer(self.1 as u64)?
-            .write_unsigned_integer(self.2 as u64)
+        serializer.serialize(&(&self.major, &self.minor, &self.alt))
     }
 }
 impl cbor_event::de::Deserialize for BlockVersion {
     fn deserialize<R: BufRead>(raw: &mut Deserializer<R>) -> cbor_event::Result<Self> {
         raw.tuple(3, "BlockVersion")?;
-        let major = raw.unsigned_integer()? as u16;
-        let minor = raw.unsigned_integer()? as u16;
-        let revision = raw.unsigned_integer()? as u8;
-
-        Ok(BlockVersion::new(major, minor, revision))
+        Ok(Self {
+            major: raw.deserialize()?,
+            minor: raw.deserialize()?,
+            alt: raw.deserialize()?,
+        })
     }
 }
 

--- a/cardano/src/block/update.rs
+++ b/cardano/src/block/update.rs
@@ -72,7 +72,7 @@ impl cbor_event::de::Deserialize for UpdateProof {
 
 #[derive(Debug, Clone)]
 pub struct UpdateProposal {
-    pub block_version: BlockVersion,
+    pub block_version: types::BlockVersion,
     pub block_version_mod: BlockVersionModifier,
     pub software_version: types::SoftwareVersion,
     pub data: BTreeMap<SystemTag, UpdateData>,
@@ -112,33 +112,6 @@ impl cbor_event::de::Deserialize for UpdateProposal {
             attributes: raw.deserialize()?,
             from: raw.deserialize()?,
             signature: raw.deserialize()?,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct BlockVersion {
-    pub major: u16,
-    pub minor: u16,
-    pub alt: u8,
-}
-
-impl cbor_event::se::Serialize for BlockVersion {
-    fn serialize<'se, W: Write>(
-        &self,
-        serializer: &'se mut Serializer<W>,
-    ) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.serialize(&(&self.major, &self.minor, &self.alt))
-    }
-}
-
-impl cbor_event::de::Deserialize for BlockVersion {
-    fn deserialize<R: BufRead>(raw: &mut Deserializer<R>) -> cbor_event::Result<Self> {
-        raw.tuple(3, "BlockVersion")?;
-        Ok(Self {
-            major: raw.deserialize()?,
-            minor: raw.deserialize()?,
-            alt: raw.deserialize()?,
         })
     }
 }
@@ -312,7 +285,7 @@ impl cbor_event::de::Deserialize for UpdateVote {
 
 #[derive(Debug, Clone)]
 pub struct UpdateProposalToSign<'a> {
-    pub block_version: &'a BlockVersion,
+    pub block_version: &'a types::BlockVersion,
     pub block_version_mod: &'a BlockVersionModifier,
     pub software_version: &'a types::SoftwareVersion,
     pub data: &'a BTreeMap<SystemTag, UpdateData>,

--- a/cardano/src/block/verify.rs
+++ b/cardano/src/block/verify.rs
@@ -335,21 +335,13 @@ impl Verify for VssCertificates {
 
         // verify every certificate's signature
         for vss_cert in self.iter() {
-            let mut buf = {
-                let mut serializer = se::Serializer::new_vec();
-                serializer
-                    .serialize(&(tags::SigningTag::VssCert as u8))
-                    .unwrap()
-                    .serialize(&protocol_magic)
-                    .unwrap();
-                serializer.write_array(cbor_event::Len::Len(2))?;
-                serializer
-                    .serialize(&vss_cert.vss_key)
-                    .unwrap()
-                    .serialize(&vss_cert.expiry_epoch)
-                    .unwrap();
-                serializer.finalize()
-            };
+            let mut buf = vec![];
+            buf.push(tags::SigningTag::VssCert as u8);
+            se::Serializer::new(&mut buf)
+                .serialize(&protocol_magic)?
+                .write_array(cbor_event::Len::Len(2))?
+                .serialize(&vss_cert.vss_key)?
+                .serialize(&vss_cert.expiry_epoch)?;
 
             if !vss_cert.signing_key.verify(
                 &buf,

--- a/cardano/src/block/verify.rs
+++ b/cardano/src/block/verify.rs
@@ -376,13 +376,11 @@ impl Verify for update::UpdateProposal {
             attributes: &self.attributes.clone(),
         };
 
+        buf.push(tags::SigningTag::USProposal as u8);
+
         se::Serializer::new(&mut buf)
-            .serialize(&(tags::SigningTag::USProposal as u8))
-            .unwrap()
-            .serialize(&protocol_magic)
-            .unwrap()
-            .serialize(&to_sign)
-            .unwrap();
+            .serialize(&protocol_magic)?
+            .serialize(&to_sign)?;
 
         if !self.from.verify(
             &buf,

--- a/cardano/src/coin.rs
+++ b/cardano/src/coin.rs
@@ -113,12 +113,6 @@ impl Coin {
         }
     }
 }
-impl ::std::ops::Deref for Coin {
-    type Target = u64;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
 impl fmt::Display for Coin {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}.{:06}", self.0 / 1000000, self.0 % 1000000)

--- a/cardano/src/config.rs
+++ b/cardano/src/config.rs
@@ -129,8 +129,9 @@ impl Default for Config {
 /// parent of the genesis block of epoch 0. (Note that "genesis data"
 /// is something completely different from a epoch genesis block. The
 /// genesis data is not stored in the chain as a block.)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GenesisData {
+    // FIXME: genesis_prev shouldn't be here since it's computed *from* the GenesisData.
     pub genesis_prev: block::HeaderHash,
     pub epoch_stability_depth: usize, // a.k.a. 'k'
     pub start_time: SystemTime,

--- a/cardano/src/config.rs
+++ b/cardano/src/config.rs
@@ -9,6 +9,7 @@ use block;
 use cbor_event::{self, de::Deserializer, se::Serializer};
 use coin;
 use fee;
+use hdwallet;
 use redeem;
 use std::{
     collections::BTreeMap,
@@ -138,4 +139,15 @@ pub struct GenesisData {
     pub fee_policy: fee::LinearFee,
     pub avvm_distr: BTreeMap<redeem::PublicKey, coin::Coin>, // AVVM = Ada Voucher Vending Machine
     pub non_avvm_balances: BTreeMap<address::Addr, coin::Coin>,
+    pub boot_stakeholders: BTreeMap<address::StakeholderId, BootStakeholder>,
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BootStakeholder {
+    pub weight: BootStakeWeight,
+    pub issuer_pk: hdwallet::XPub,
+    pub delegate_pk: hdwallet::XPub,
+    pub cert: hdwallet::Signature<()>,
+}
+
+pub type BootStakeWeight = u16;

--- a/cardano/src/fee.rs
+++ b/cardano/src/fee.rs
@@ -59,7 +59,7 @@ impl ::std::fmt::Display for Error {
 
 #[derive(PartialEq, Eq, PartialOrd, Debug, Clone, Copy)]
 #[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
-pub struct Milli(pub u64);
+pub struct Milli(u64);
 impl Milli {
     pub fn new(i: u64, f: u64) -> Self {
         Milli(i * 1000 + f % 1000)
@@ -109,9 +109,9 @@ impl Mul for Milli {
 #[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct LinearFee {
     /// this is the minimal fee
-    constant: Milli,
+    pub constant: Milli,
     /// the transaction's size coefficient fee
-    coefficient: Milli,
+    pub coefficient: Milli,
 }
 impl LinearFee {
     pub fn new(constant: Milli, coefficient: Milli) -> Self {

--- a/cardano/src/input_selection/simple_selections.rs
+++ b/cardano/src/input_selection/simple_selections.rs
@@ -98,7 +98,7 @@ impl<Addressing> Blackjack<Addressing> {
     }
 
     pub fn new(dust_threshold: Coin, inputs: Vec<Input<Addressing>>) -> Self {
-        let seed = inputs.len() as u64 + *dust_threshold;
+        let seed = inputs.len() as u64 + u64::from(dust_threshold);
         Blackjack {
             inputs: inputs.into_iter().map(|i| (false, i)).collect(),
             total_input_selected: Coin::zero(),

--- a/cardano/src/lib.rs
+++ b/cardano/src/lib.rs
@@ -44,6 +44,9 @@ extern crate cbor_event;
 
 extern crate chain_core;
 
+#[cfg(test)]
+extern crate base64;
+
 pub mod address;
 pub mod coin;
 pub mod config;

--- a/exe-common/examples/generate_genesis_data.rs
+++ b/exe-common/examples/generate_genesis_data.rs
@@ -1,0 +1,121 @@
+extern crate cardano;
+extern crate exe_common;
+extern crate rand;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+
+use cardano::{
+    address, block, coin, config, fee,
+    hdwallet::{self, Seed, XPrv},
+};
+use rand::{thread_rng, Rng};
+use std::collections::BTreeMap;
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+fn generate_key() -> XPrv {
+    let mut seed = [0u8; hdwallet::SEED_SIZE];
+    thread_rng().fill(&mut seed[..]);
+    let seed = Seed::from_bytes(seed);
+    XPrv::generate_from_seed(&seed)
+}
+
+fn write_file(path: &Path, s: &String) {
+    let mut file = File::create(path).unwrap();
+    file.write_all(s.as_bytes()).unwrap();
+}
+
+#[derive(Serialize)]
+struct BootAddress {
+    xprv: String,
+    addr: String,
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let dest_dir = Path::new(&args[1]);
+    let nr_nodes = args[2].parse::<usize>().unwrap();
+    let nr_addresses = args[3].parse::<usize>().unwrap();
+
+    let protocol_magic = 328429219.into();
+
+    let mut boot_stakeholders = BTreeMap::new();
+
+    for n in 0..nr_nodes {
+        let stakeholder_prv = generate_key();
+        let stakeholder_pk = stakeholder_prv.public();
+        let delegate_prv = generate_key();
+        let delegate_pk = delegate_prv.public();
+
+        write_file(
+            &dest_dir.join(format!("stakeholder-{}.xprv", n)),
+            &stakeholder_prv.to_string(),
+        );
+        write_file(
+            &dest_dir.join(format!("delegate-{}.xprv", n)),
+            &delegate_prv.to_string(),
+        );
+
+        let stakeholder_id = address::StakeholderId::new(&stakeholder_pk);
+
+        let psk =
+            block::sign::ProxySecretKey::sign(&stakeholder_prv, delegate_pk, 0, protocol_magic);
+
+        boot_stakeholders.insert(
+            stakeholder_id,
+            config::BootStakeholder {
+                weight: 1,
+                issuer_pk: psk.issuer_pk,
+                delegate_pk: psk.delegate_pk,
+                cert: psk.cert,
+            },
+        );
+    }
+
+    let mut non_avvm_balances = BTreeMap::new();
+    let mut boot_addresses = vec![];
+
+    for _ in 0..nr_addresses {
+        // FIXME: generate from HD wallets?
+        let addr_prv = generate_key();
+        let addr: address::Addr =
+            address::ExtendedAddr::new_simple(addr_prv.public(), protocol_magic.into()).into();
+        boot_addresses.push(BootAddress {
+            xprv: addr_prv.to_string(),
+            addr: addr.to_string(),
+        });
+        non_avvm_balances.insert(addr, coin::Coin::new(19999999999999).unwrap());
+    }
+
+    let genesis_data = config::GenesisData {
+        genesis_prev: cardano::block::HeaderHash::new(&[0; cardano::hash::Blake2b256::HASH_SIZE]),
+        epoch_stability_depth: 2160,
+        start_time: SystemTime::UNIX_EPOCH + Duration::from_secs(1548089245),
+        slot_duration: Duration::from_millis(20000),
+        protocol_magic,
+        fee_policy: fee::LinearFee::new(
+            fee::Milli::integral(43946000),
+            fee::Milli::integral(155381000000),
+        ),
+        avvm_distr: BTreeMap::new(),
+        non_avvm_balances,
+        boot_stakeholders,
+    };
+
+    let (genesis_data, genesis_hash) = exe_common::genesisdata::print::print(genesis_data).unwrap();
+
+    eprintln!("Genesis hash = {}", genesis_hash);
+
+    write_file(&dest_dir.join("genesis.json"), &genesis_data);
+
+    write_file(
+        &dest_dir.join("addresses.json"),
+        &serde_json::to_string_pretty(&boot_addresses).unwrap(),
+    );
+
+    write_file(&dest_dir.join("genesis.hash"), &genesis_hash.to_string());
+}

--- a/exe-common/src/genesisdata/mod.rs
+++ b/exe-common/src/genesisdata/mod.rs
@@ -1,2 +1,3 @@
 pub mod parse;
+pub mod print;
 pub mod raw;

--- a/exe-common/src/genesisdata/mod.rs
+++ b/exe-common/src/genesisdata/mod.rs
@@ -1,1 +1,2 @@
+pub mod parse;
 pub mod raw;

--- a/exe-common/src/genesisdata/parse.rs
+++ b/exe-common/src/genesisdata/parse.rs
@@ -17,8 +17,8 @@ pub fn parse<R: Read>(json: R) -> config::GenesisData {
 
     let parse_fee_constant = |s: &str| {
         let n = s.parse::<u64>().unwrap();
-        assert!(n % 1000000 == 0);
-        fee::Milli(n / 1000000)
+        assert!(n % 1000 == 0);
+        fee::Milli::integral(n / 1000)
     };
 
     let mut avvm_distr = BTreeMap::new();

--- a/exe-common/src/genesisdata/parse.rs
+++ b/exe-common/src/genesisdata/parse.rs
@@ -59,9 +59,11 @@ pub fn parse<R: Read>(json: R) -> config::GenesisData {
 
         let psk = cardano::block::sign::ProxySecretKey {
             omega: 0,
-            issuer_pk: hdwallet::XPub::from_slice(&base64::decode(&heavy.issuerPk).unwrap()).unwrap(),
-            delegate_pk: hdwallet::XPub::from_slice(&base64::decode(&heavy.delegatePk).unwrap()).unwrap(),
-            cert: hdwallet::Signature::<()>::from_hex(&heavy.cert).unwrap()
+            issuer_pk: hdwallet::XPub::from_slice(&base64::decode(&heavy.issuerPk).unwrap())
+                .unwrap(),
+            delegate_pk: hdwallet::XPub::from_slice(&base64::decode(&heavy.delegatePk).unwrap())
+                .unwrap(),
+            cert: hdwallet::Signature::<()>::from_hex(&heavy.cert).unwrap(),
         };
 
         // Check that the stakeholder ID corresponds to the issuer public key.

--- a/exe-common/src/genesisdata/parse.rs
+++ b/exe-common/src/genesisdata/parse.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, SystemTime};
 
 use genesisdata::raw;
 
-pub fn parse_genesis_data<R: Read>(json: R) -> config::GenesisData {
+pub fn parse<R: Read>(json: R) -> config::GenesisData {
     // FIXME: use Result
 
     let data_value: serde_json::Value = serde_json::from_reader(json).unwrap();

--- a/exe-common/src/genesisdata/print.rs
+++ b/exe-common/src/genesisdata/print.rs
@@ -1,0 +1,75 @@
+use cardano::{block::HeaderHash, config};
+use genesisdata::{parse, raw};
+use std::time::SystemTime;
+
+/// Return a canonical JSON representation of the given genesis data,
+/// as well as the corresponding genesis hash.
+pub fn print(
+    mut genesis_data: config::GenesisData,
+) -> Result<(String, HeaderHash), std::io::Error> {
+    let raw = raw::GenesisData {
+        avvmDistr: genesis_data
+            .avvm_distr
+            .iter()
+            .map(|(avvm, balance)| {
+                (
+                    base64::encode_config(avvm, base64::URL_SAFE),
+                    u64::from(*balance).to_string(),
+                )
+            })
+            .collect(),
+        nonAvvmBalances: genesis_data
+            .non_avvm_balances
+            .iter()
+            .map(|(address, balance)| (address.to_string(), u64::from(*balance).to_string()))
+            .collect(),
+        bootStakeholders: genesis_data
+            .boot_stakeholders
+            .iter()
+            .map(|(stakeholder_id, stakeholder)| (stakeholder_id.to_string(), stakeholder.weight))
+            .collect(),
+        heavyDelegation: genesis_data
+            .boot_stakeholders
+            .iter()
+            .map(|(stakeholder_id, stakeholder)| {
+                (
+                    stakeholder_id.to_string(),
+                    raw::HeavyDelegation {
+                        issuerPk: base64::encode(&stakeholder.issuer_pk),
+                        delegatePk: base64::encode(&stakeholder.delegate_pk),
+                        cert: stakeholder.cert.to_string(),
+                    },
+                )
+            })
+            .collect(),
+        protocolConsts: raw::ProtocolConsts {
+            k: genesis_data.epoch_stability_depth,
+            protocolMagic: *genesis_data.protocol_magic,
+        },
+        startTime: genesis_data
+            .start_time
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        blockVersionData: raw::BlockVersionData {
+            slotDuration: (genesis_data.slot_duration.as_secs() as u64 * 1000
+                + genesis_data.slot_duration.subsec_millis() as u64)
+                .to_string(),
+            txFeePolicy: raw::TxFeePolicy {
+                summand: (genesis_data.fee_policy.constant.to_integral() * 1000).to_string(),
+                multiplier: (genesis_data.fee_policy.coefficient.to_integral() * 1000).to_string(),
+            },
+        },
+    };
+
+    let json = serde_json::to_string(&raw)?;
+
+    // Compute the hash over the canonical JSON.
+    let canon_json = parse::canonicalize_json(json.as_bytes());
+    let genesis_hash = HeaderHash::new(canon_json.as_bytes());
+
+    genesis_data.genesis_prev = genesis_hash.clone(); // ugly
+    assert_eq!(genesis_data, parse::parse(json.as_bytes()));
+
+    Ok((canon_json, genesis_hash))
+}

--- a/exe-common/src/genesisdata/raw.rs
+++ b/exe-common/src/genesisdata/raw.rs
@@ -1,11 +1,13 @@
 use std::collections::HashMap;
+use cardano::config;
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Debug)]
 pub struct GenesisData {
     pub avvmDistr: HashMap<String, String>,
     pub nonAvvmBalances: HashMap<String, String>,
-    pub bootStakeholders: HashMap<String, u32>,
+    pub bootStakeholders: HashMap<String, config::BootStakeWeight>,
+    pub heavyDelegation: HashMap<String, HeavyDelegation>,
     pub protocolConsts: ProtocolConsts,
     pub startTime: u64,
     pub blockVersionData: BlockVersionData,
@@ -52,4 +54,13 @@ pub struct SoftforkRule {
     pub initThd: String,
     pub minThd: String,
     pub thdDecrement: String,
+}
+
+
+#[allow(non_snake_case)]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct HeavyDelegation {
+    pub issuerPk: String,
+    pub delegatePk: String,
+    pub cert: String,
 }

--- a/exe-common/src/genesisdata/raw.rs
+++ b/exe-common/src/genesisdata/raw.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
 use cardano::config;
+use std::collections::HashMap;
 
 #[allow(non_snake_case)]
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct GenesisData {
     pub avvmDistr: HashMap<String, String>,
     pub nonAvvmBalances: HashMap<String, String>,
@@ -14,48 +14,47 @@ pub struct GenesisData {
 }
 
 #[allow(non_snake_case)]
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ProtocolConsts {
     pub k: usize,
     pub protocolMagic: u32,
-    pub vssMaxTTL: u32,
-    pub vssMinTTL: u32,
+    //pub vssMaxTTL: u32,
+    //pub vssMinTTL: u32,
 }
 
 #[allow(non_snake_case)]
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct BlockVersionData {
-    pub heavyDelThd: String,
-    pub maxBlockSize: String,
-    pub maxHeaderSize: String,
-    pub maxProposalSize: String,
-    pub maxTxSize: String,
-    pub mpcThd: String,
-    pub scriptVersion: u32,
+    //pub heavyDelThd: String,
+    //pub maxBlockSize: String,
+    //pub maxHeaderSize: String,
+    //pub maxProposalSize: String,
+    //pub maxTxSize: String,
+    //pub mpcThd: String,
+    //pub scriptVersion: u32,
     pub slotDuration: String,
-    pub softforkRule: SoftforkRule,
+    //pub softforkRule: SoftforkRule,
     pub txFeePolicy: TxFeePolicy,
-    pub unlockStakeEpoch: String,
-    pub updateImplicit: String,
-    pub updateProposalThd: String,
-    pub updateVoteThd: String,
+    //pub unlockStakeEpoch: String,
+    //pub updateImplicit: String,
+    //pub updateProposalThd: String,
+    //pub updateVoteThd: String,
 }
 
 #[allow(non_snake_case)]
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct TxFeePolicy {
     pub summand: String,
     pub multiplier: String,
 }
 
 #[allow(non_snake_case)]
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct SoftforkRule {
     pub initThd: String,
     pub minThd: String,
     pub thdDecrement: String,
 }
-
 
 #[allow(non_snake_case)]
 #[derive(Serialize, Deserialize, Debug)]

--- a/exe-common/src/lib.rs
+++ b/exe-common/src/lib.rs
@@ -23,6 +23,5 @@ pub mod genesis_data;
 pub mod genesisdata;
 mod mstream;
 pub mod network;
-pub mod parse_genesis_data;
 pub mod sync;
 pub mod utils;

--- a/exe-common/src/lib.rs
+++ b/exe-common/src/lib.rs
@@ -6,6 +6,8 @@ extern crate rand;
 extern crate storage_units;
 #[macro_use]
 extern crate log;
+#[cfg(test)]
+extern crate rand;
 
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
This is for https://github.com/input-output-hk/jormungandr/issues/35. It adds a program (currently in exe-common/examples, but should probably be moved somewhere else) that generates a genesis data file (in canonicalized JSON format), as well as private keys for the nodes and some initial non-AVVM balances. See 0c920f89b614dbaf33165343004f9324c9dc32e2 for usage info.

There are currently a bunch of genesis fields missing because they're not represented in `config::GenesisData`. I once added them to `config::GenesisData` as a `ChainParameters` struct in the unmerged PR #300, so if desired I could move that over to here (i.e. minus the update handling). However we're not currently using them anywhere.

There's also some miscellaneous cleanup to `Coin` and `Milli` (to catch some potential bugs) and to `BlockVersion` (cherry-picked from PR #300, but in retrospect not really needed here...).