### PR TITLE
Make Header an optional property of Block

### DIFF
--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -48,9 +48,7 @@ pub trait BlockDate: Eq + Ord + Clone {}
 pub trait TransactionId: Eq + Hash {}
 
 /// Trait identifying the block header type.
-pub trait Header {}
-
-impl Header for () {}
+pub trait Header: Serialize + Deserialize {}
 
 /// Block property
 ///
@@ -76,13 +74,6 @@ pub trait Block: Serialize + Deserialize {
     /// identifying the position of a block in a given epoch or era.
     type Date: BlockDate;
 
-    /// The block header. If provided by the blockchain, the header
-    /// can be used to transmit block's metadata via a network protocol
-    /// or in other uses where the full content of the block is not desirable.
-    /// An implementation that does not feature headers can use the unit
-    /// type `()`.
-    type Header: Header;
-
     /// return the Block's identifier.
     fn id(&self) -> Self::Id;
 
@@ -92,8 +83,18 @@ pub trait Block: Serialize + Deserialize {
 
     /// get the block date of the block
     fn date(&self) -> Self::Date;
+}
 
-    /// Gets the block's header.
+/// Access to the block header.
+///
+/// If featured by the blockchain, the header can be used to transmit
+/// block's metadata via a network protocol or in other uses where the
+/// full content of the block is too bulky and not necessary.
+pub trait HasHeader {
+    /// The block header type.
+    type Header: Header;
+
+    /// Retrieves the block's header.
     fn header(&self) -> Self::Header;
 }
 

--- a/chain-impl-mockchain/src/block.rs
+++ b/chain-impl-mockchain/src/block.rs
@@ -26,7 +26,6 @@ pub struct Block {
 impl property::Block for Block {
     type Id = Hash;
     type Date = SlotId;
-    type Header = ();
 
     /// Identifier of the block, currently the hash of the
     /// serialized transaction.
@@ -43,10 +42,6 @@ impl property::Block for Block {
     /// Date of the block.
     fn date(&self) -> Self::Date {
         self.slot_id
-    }
-
-    fn header(&self) -> Self::Header {
-        ()
     }
 }
 
@@ -130,16 +125,11 @@ impl property::Deserialize for SignedBlock {
 impl property::Block for SignedBlock {
     type Id = <Block as property::Block>::Id;
     type Date = <Block as property::Block>::Date;
-    type Header = <Block as property::Block>::Header;
 
     /// Identifier of the block, currently the hash of the
     /// serialized transaction.
     fn id(&self) -> Self::Id {
         self.block.id()
-    }
-
-    fn header(&self) -> Self::Header {
-        self.block.header()
     }
 
     /// Id of the parent block.

--- a/network-core/src/client/block.rs
+++ b/network-core/src/client/block.rs
@@ -1,10 +1,10 @@
 use super::Error;
 
-use chain_core::property::Block;
+use chain_core::property::{Block, HasHeader};
 
 use futures::prelude::*;
 
-/// Interface for the blockchain node service implementation responsible for
+/// Interface for the blockchain node service responsible for
 /// providing access to blocks.
 pub trait BlockService<T: Block> {
     /// The type of asynchronous futures returned by method `tip`.
@@ -36,7 +36,11 @@ pub trait BlockService<T: Block> {
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a server-streamed response.
     type GetBlocksFuture: Future<Item = Self::GetBlocksStream, Error = Error>;
+}
 
+/// Interface for the blockchain node service responsible for
+/// providing access to block headers.
+pub trait HeaderService<T: HasHeader> {
     /// The type of an asynchronous stream that provides block headers in
     /// response to method `get_headers`.
     type GetHeadersStream: Stream<Item = T::Header, Error = Error>;

--- a/network-core/src/server.rs
+++ b/network-core/src/server.rs
@@ -12,14 +12,21 @@ pub trait Node {
     /// The implementation of the block service.
     type BlockService: block::BlockService;
 
+    /// The implementation of the header service.
+    type HeaderService: block::HeaderService;
+
     /// The implementation of the transaction service.
     type TransactionService: transaction::TransactionService;
 
-    /// Instantiates the block service implementation,
+    /// Instantiates the block service,
     /// if supported by this node.
     fn block_service(&self) -> Option<Self::BlockService>;
 
-    /// Instantiates the transaction service implementation,
+    /// Instantiates the header service,
+    /// if supported by this node.
+    fn header_service(&self) -> Option<Self::HeaderService>;
+
+    /// Instantiates the transaction service,
     /// if supported by this node.
     fn transaction_service(&self) -> Option<Self::TransactionService>;
 }

--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -18,11 +18,6 @@ pub trait BlockService {
     /// The type representing a block on the blockchain.
     type Block: Block<Id = Self::BlockId, Date = Self::BlockDate>;
 
-    /// The type representing metadata header of a block.
-    /// If the blockchain does not feature headers, this can be the unit type
-    /// `()`.
-    type Header: Header + Serialize;
-
     /// The type of asynchronous futures returned by method `tip`.
     ///
     /// The future resolves to the block identifier and the block date
@@ -39,16 +34,6 @@ pub trait BlockService {
     /// implementation to produce a server-streamed response.
     type GetBlocksFuture: Future<Item = Self::GetBlocksStream, Error = BlockError>;
 
-    /// The type of an asynchronous stream that provides block headers in
-    /// response to method `get_headers`.
-    type GetHeadersStream: Stream<Item = Self::Header, Error = BlockError>;
-
-    /// The type of asynchronous futures returned by method `get_headers`.
-    ///
-    /// The future resolves to a stream that will be used by the protocol
-    /// implementation to produce a server-streamed response.
-    type GetHeadersFuture: Future<Item = Self::GetHeadersStream, Error = BlockError>;
-
     /// The type of an asynchronous stream that provides blocks in
     /// response to method `stream_blocks_to_tip`.
     type StreamBlocksToTipStream: Stream<Item = Self::Block, Error = BlockError>;
@@ -61,6 +46,23 @@ pub trait BlockService {
 
     fn tip(&mut self) -> Self::TipFuture;
     fn stream_blocks_to_tip(&mut self, from: &[Self::BlockId]) -> Self::StreamBlocksToTipFuture;
+}
+
+/// Interface for the blockchain node service implementation responsible for
+/// providing access to block headers.
+pub trait HeaderService {
+    /// The type representing metadata header of a block.
+    type Header: Header + Serialize;
+
+    /// The type of an asynchronous stream that provides block headers in
+    /// response to method `get_headers`.
+    type GetHeadersStream: Stream<Item = Self::Header, Error = BlockError>;
+
+    /// The type of asynchronous futures returned by method `get_headers`.
+    ///
+    /// The future resolves to a stream that will be used by the protocol
+    /// implementation to produce a server-streamed response.
+    type GetHeadersFuture: Future<Item = Self::GetHeadersStream, Error = BlockError>;
 }
 
 /// Represents errors that can be returned by the node service implementation.

--- a/network-grpc/src/server.rs
+++ b/network-grpc/src/server.rs
@@ -23,8 +23,9 @@ use std::path::Path;
 pub struct Server<T, E>
 where
     T: Node,
-    <T as Node>::BlockService: Clone,
-    <T as Node>::TransactionService: Clone,
+    T::BlockService: Clone,
+    T::HeaderService: Clone,
+    T::TransactionService: Clone,
 {
     h2: tower_h2::Server<
         gen_server::NodeServer<NodeService<T>>,
@@ -38,8 +39,9 @@ pub struct Connection<S, T, E>
 where
     S: AsyncRead + AsyncWrite,
     T: Node,
-    <T as Node>::BlockService: Clone,
-    <T as Node>::TransactionService: Clone,
+    T::BlockService: Clone,
+    T::HeaderService: Clone,
+    T::TransactionService: Clone,
 {
     h2: tower_h2::server::Connection<
         S,
@@ -54,8 +56,9 @@ impl<S, T, E> Future for Connection<S, T, E>
 where
     S: AsyncRead + AsyncWrite,
     T: Node + 'static,
-    <T as Node>::BlockService: Clone,
-    <T as Node>::TransactionService: Clone,
+    T::BlockService: Clone,
+    T::HeaderService: Clone,
+    T::TransactionService: Clone,
     E: Executor<
         tower_h2::server::Background<
             gen_server::node::ResponseFuture<NodeService<T>>,
@@ -73,8 +76,9 @@ where
 impl<T, E> Server<T, E>
 where
     T: Node + 'static,
-    <T as Node>::BlockService: Clone,
-    <T as Node>::TransactionService: Clone,
+    T::BlockService: Clone,
+    T::HeaderService: Clone,
+    T::TransactionService: Clone,
     E: Executor<
             tower_h2::server::Background<
                 gen_server::node::ResponseFuture<NodeService<T>>,
@@ -146,8 +150,9 @@ type H2Error<T> = tower_h2::server::Error<gen_server::NodeServer<NodeService<T>>
 impl<T> From<H2Error<T>> for Error
 where
     T: Node,
-    <T as Node>::BlockService: Clone,
-    <T as Node>::TransactionService: Clone,
+    T::BlockService: Clone,
+    T::HeaderService: Clone,
+    T::TransactionService: Clone,
 {
     fn from(err: H2Error<T>) -> Self {
         use tower_h2::server::Error::*;


### PR DESCRIPTION
In the chain-core abstractions, decouple the header access API from that
of `Block`. Add property trait `HasHeader` which should only be implemented
for blockchains that feature block headers. This removes the need to
define `Block::Header` to a dummy type in header-less implementations.

In network-core, split header-related methods and types from
`BlockService` to `HeaderService`. This can be optionally implemented.