### PR TITLE
network-core: Make client::Error more informative

### DIFF
--- a/network-core/src/client.rs
+++ b/network-core/src/client.rs
@@ -1,26 +1,7 @@
 //! Abstractions for the client-side network interface of a blockchain node.
 
-use std::{error, fmt};
-
 pub mod block;
 
-/// Represents errors that can be returned by the node client implementation.
-#[derive(Debug)]
-pub enum Error {
-    /// Error with protocol payload
-    Format,
-    /// An error with the protocol RPC call
-    Rpc,
-    // FIXME: add underlying error payload
-}
+mod error;
 
-impl error::Error for Error {}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Error::Format => write!(f, "malformed block received"),
-            Error::Rpc => write!(f, "protocol error occurred"),
-        }
-    }
-}
+pub use error::{Error, ErrorKind};

--- a/network-core/src/client/error.rs
+++ b/network-core/src/client/error.rs
@@ -1,0 +1,51 @@
+use std::{error, fmt};
+
+/// Represents errors that can be returned by the node client implementation.
+#[derive(Debug)]
+pub struct Error {
+    kind: ErrorKind,
+    source: Box<dyn error::Error + Send + Sync>,
+}
+
+/// A list of general causes of client request errors.
+///
+/// This list is intended to grow over time and it is not recommended to
+/// exhaustively match against it.
+#[derive(Clone, Copy, Debug)]
+pub enum ErrorKind {
+    /// Error with protocol payload
+    Format,
+    /// An error with the protocol RPC call
+    Rpc,
+}
+
+impl Error {
+    pub fn new<E>(kind: ErrorKind, source: E) -> Self
+    where
+        E: Into<Box<dyn error::Error + Send + Sync>>,
+    {
+        Error {
+            kind,
+            source: source.into(),
+        }
+    }
+
+    pub fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+}
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.kind {
+            ErrorKind::Format => write!(f, "malformed payload received"),
+            ErrorKind::Rpc => write!(f, "protocol error"),
+        }
+    }
+}


### PR DESCRIPTION
The causes enumeration is now `ErrorKind` and the `Error` struct contains it
as a property. It also contains a chained error from the implementation.