### PR TITLE
make rand's version static in the chain-impl-mockchain

### DIFF
--- a/chain-impl-mockchain/Cargo.toml
+++ b/chain-impl-mockchain/Cargo.toml
@@ -16,7 +16,7 @@ bincode = "^1.0.1"
 quickcheck = { version = "0.8" }
 chain-core = { path = "../chain-core" }
 chain-addr = { path = "../chain-addr" }
-rand = "*"
+rand = "0.6"
 
 [dependencies.cardano]
 path = "../cardano"


### PR DESCRIPTION
fix compilation issue when rand version is prior **0.6**.