### PR TITLE
CircleCI: remove junit result converter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,10 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - cargo-v1-{{ checksum "Cargo.toml" }}-
-            - cargo-v1-
+            - cargo-v2-{{ checksum "Cargo.toml" }}-
+            - cargo-v2-
       - run: cargo update
       - run: cargo fetch
-      - run: cargo install cargo-junit
       - persist_to_workspace:
           root: "."
           paths:
@@ -22,7 +21,6 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - /usr/local/cargo/git
-            - /usr/local/cargo/bin
   test:
     docker:
       - image: rust:latest
@@ -35,14 +33,11 @@ jobs:
           keys:
             - cargo-v2-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
       - run:
-          name: create test-results directory
-          command: mkdir -p ~/test-results/${CIRCLE_JOB}
-      - run:
           name: Print version information
           command: rustc --version; cargo --version
       - run:
           name: Build and test
-          command: cargo junit --name ~/test-results/${CIRCLE_JOB}/results.xml
+          command: cargo test --frozen --verbose
           environment:
             # Need this for the coverage run
             RUSTFLAGS: "-C link-dead-code"
@@ -52,11 +47,6 @@ jobs:
             for file in target/debug/* target/debug/.??*; do
               [ -d $file -o ! -x $file ] && rm -r $file
             done
-      - store_test_results:
-          path: ~/test-results
-      - store_artifacts:
-          path: ~/test-results
-          destination: test_results
       - persist_to_workspace:
           root: "."
           paths:
@@ -73,19 +63,11 @@ jobs:
           keys:
             - cargo-v2-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
       - run:
-          name: create test-results directory
-          command: mkdir -p ~/test-results/${CIRCLE_JOB}
-      - run:
           name: Print version information
           command: rustc --version; cargo --version
       - run:
           name: Build and test in release profile
-          command: cargo junit --name ~/test-results/${CIRCLE_JOB}/results.xml
-      - store_test_results:
-          path: ~/test-results
-      - store_artifacts:
-          path: ~/test-results
-          destination: test_results
+          command: cargo test --release --frozen --verbose
   test_nightly:
     docker:
       - image: rustlang/rust:nightly
@@ -98,19 +80,11 @@ jobs:
           keys:
             - cargo-v2-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
       - run:
-          name: create test-results directory
-          command: mkdir -p ~/test-results/${CIRCLE_JOB}
-      - run:
           name: Print version information
           command: rustc --version; cargo --version
       - run:
           name: Build and test with nightly Rust
-          command: cargo junit --name ~/test-results/${CIRCLE_JOB}/results.xml
-      - store_test_results:
-          path: ~/test-results
-      - store_artifacts:
-          path: ~/test-results
-          destination: test_results
+          command: cargo test --frozen --verbose
   coverage:
     docker:
       - image: ragnaroek/kcov:v33


### PR DESCRIPTION
`cargo junit` exits with zero status even when test build fails, producing false positive status.

Installing cargo-junit on every fetch job was wrong, too.
A pipeline that uses cargo-junit needs a custom Docker image with the tool installed.