### PR TITLE
network: Rename StreamBlocksTo* to PullBlocksTo*

### DIFF
--- a/network-core/src/client/block.rs
+++ b/network-core/src/client/block.rs
@@ -16,16 +16,16 @@ pub trait BlockService<T: Block> {
     fn tip(&mut self) -> Self::TipFuture;
 
     /// The type of an asynchronous stream that provides blocks in
-    /// response to method `stream_blocks_to_tip`.
-    type StreamBlocksToTipStream: Stream<Item = T, Error = Error>;
+    /// response to method `pull_blocks_to_tip`.
+    type PullBlocksToTipStream: Stream<Item = T, Error = Error>;
 
-    /// The type of asynchronous futures returned by method `stream_blocks_to_tip`.
+    /// The type of asynchronous futures returned by method `pull_blocks_to_tip`.
     ///
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a server-streamed response.
-    type StreamBlocksToTipFuture: Future<Item = Self::StreamBlocksToTipStream, Error = Error>;
+    type PullBlocksToTipFuture: Future<Item = Self::PullBlocksToTipStream, Error = Error>;
 
-    fn stream_blocks_to_tip(&mut self, from: &[T::Id]) -> Self::StreamBlocksToTipFuture;
+    fn pull_blocks_to_tip(&mut self, from: &[T::Id]) -> Self::PullBlocksToTipFuture;
 
     /// The type of an asynchronous stream that provides blocks in
     /// response to method `get_blocks`.

--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -35,23 +35,23 @@ pub trait BlockService {
     type GetBlocksFuture: Future<Item = Self::GetBlocksStream, Error = BlockError>;
 
     /// The type of an asynchronous stream that provides blocks in
-    /// response to method `stream_blocks_to_tip`.
-    type StreamBlocksToTipStream: Stream<Item = Self::Block, Error = BlockError>;
+    /// response to method `pull_blocks_to_tip`.
+    type PullBlocksToTipStream: Stream<Item = Self::Block, Error = BlockError>;
 
-    /// The type of asynchronous futures returned by method `stream_blocks_to_tip`.
+    /// The type of asynchronous futures returned by method `pull_blocks_to_tip`.
     ///
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a server-streamed response.
-    type StreamBlocksFuture: Future<Item = Self::StreamBlocksToTipStream, Error = BlockError>;
+    type PullBlocksFuture: Future<Item = Self::PullBlocksToTipStream, Error = BlockError>;
 
     fn tip(&mut self) -> Self::TipFuture;
-    fn stream_blocks_to_tip(&mut self, from: &[Self::BlockId]) -> Self::StreamBlocksFuture;
+    fn pull_blocks_to_tip(&mut self, from: &[Self::BlockId]) -> Self::PullBlocksFuture;
 
-    fn stream_blocks_to(
+    fn pull_blocks_to(
         &mut self,
         from: &[Self::BlockId],
         to: &Self::BlockId,
-    ) -> Self::StreamBlocksFuture;
+    ) -> Self::PullBlocksFuture;
 }
 
 /// Interface for the blockchain node service implementation responsible for

--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -326,8 +326,8 @@ where
 {
     type TipFuture = ResponseFuture<(T::Id, T::Date), gen::node::TipResponse>;
 
-    type StreamBlocksToTipStream = ResponseStream<T, gen::node::Block>;
-    type StreamBlocksToTipFuture = ResponseStreamFuture<T, gen::node::Block>;
+    type PullBlocksToTipStream = ResponseStream<T, gen::node::Block>;
+    type PullBlocksToTipFuture = ResponseStreamFuture<T, gen::node::Block>;
 
     type GetBlocksStream = ResponseStream<T, gen::node::Block>;
     type GetBlocksFuture = ResponseStreamFuture<T, gen::node::Block>;
@@ -338,10 +338,10 @@ where
         ResponseFuture::new(future)
     }
 
-    fn stream_blocks_to_tip(&mut self, from: &[T::Id]) -> Self::StreamBlocksToTipFuture {
+    fn pull_blocks_to_tip(&mut self, from: &[T::Id]) -> Self::PullBlocksToTipFuture {
         let from = serialize_to_vec(from);
-        let req = gen::node::StreamBlocksToTipRequest { from };
-        let future = self.node.stream_blocks_to_tip(Request::new(req));
+        let req = gen::node::PullBlocksToTipRequest { from };
+        let future = self.node.pull_blocks_to_tip(Request::new(req));
         ResponseStreamFuture::new(future)
     }
 }

--- a/network-grpc/src/service.rs
+++ b/network-grpc/src/service.rs
@@ -296,13 +296,13 @@ where
         Self::GetHeadersStream,
         <<T as Node>::HeaderService as HeaderService>::GetHeadersFuture,
     >;
-    type StreamBlocksToTipStream = ResponseStream<
+    type PullBlocksToTipStream = ResponseStream<
         gen::node::Block,
-        <<T as Node>::BlockService as BlockService>::StreamBlocksToTipStream,
+        <<T as Node>::BlockService as BlockService>::PullBlocksToTipStream,
     >;
-    type StreamBlocksToTipFuture = ResponseFuture<
-        Self::StreamBlocksToTipStream,
-        <<T as Node>::BlockService as BlockService>::StreamBlocksFuture,
+    type PullBlocksToTipFuture = ResponseFuture<
+        Self::PullBlocksToTipStream,
+        <<T as Node>::BlockService as BlockService>::PullBlocksFuture,
     >;
     type ProposeTransactionsFuture = ResponseFuture<
         gen::node::ProposeTransactionsResponse,
@@ -335,10 +335,10 @@ where
         unimplemented!()
     }
 
-    fn stream_blocks_to_tip(
+    fn pull_blocks_to_tip(
         &mut self,
-        req: Request<gen::node::StreamBlocksToTipRequest>,
-    ) -> Self::StreamBlocksToTipFuture {
+        req: Request<gen::node::PullBlocksToTipRequest>,
+    ) -> Self::PullBlocksToTipFuture {
         let service = match self.block_service {
             None => return ResponseFuture::unimplemented(),
             Some(ref mut service) => service,
@@ -350,7 +350,7 @@ where
             }
             Err(e) => panic!("unexpected error {:?}", e),
         };
-        ResponseFuture::new(service.stream_blocks_to_tip(&block_ids))
+        ResponseFuture::new(service.pull_blocks_to_tip(&block_ids))
     }
 
     fn propose_transactions(

--- a/network-ntt/src/server.rs
+++ b/network-ntt/src/server.rs
@@ -223,7 +223,7 @@ where
                             .node
                             .block_service()
                             .expect("block service is not implemented")
-                            .stream_blocks_to(&vec![get_blocks.from], &get_blocks.to)
+                            .pull_blocks_to(&vec![get_blocks.from], &get_blocks.to)
                             .map_err(|err| err.to_string())
                             .and_then(move |blocks| {
                                 let inner1 = sink.clone();

--- a/network-proto/node.proto
+++ b/network-proto/node.proto
@@ -27,8 +27,8 @@ message GetBlocksRequest {
     uint64 size = 3;
 }
 
-// Request message for method StreamBlocksToTip.
-message StreamBlocksToTipRequest {
+// Request message for method PullBlocksToTip.
+message PullBlocksToTipRequest {
     // The identifiers of blocks to consider as the
     // starting point, in order of appearance.
     repeated bytes from = 1;
@@ -89,7 +89,7 @@ service Node {
     rpc GetHeaders (GetBlocksRequest) returns (stream Header) {
         option idempotency_level = NO_SIDE_EFFECTS;
     }
-    rpc StreamBlocksToTip (StreamBlocksToTipRequest) returns (stream Block);
+    rpc PullBlocksToTip (PullBlocksToTipRequest) returns (stream Block);
     rpc ProposeTransactions (ProposeTransactionsRequest) returns (ProposeTransactionsResponse);
     rpc RecordTransaction (RecordTransactionRequest) returns (RecordTransactionResponse);
 }


### PR DESCRIPTION
"Stream" looks redundant in protobuf, especially in generated names like
`StreamBlocksToTipStream`; "Pull" better reflects the use case.