### PR TITLE
Extend Header property with Id information.

### DIFF
--- a/cardano/src/block/block.rs
+++ b/cardano/src/block/block.rs
@@ -321,9 +321,14 @@ impl chain_core::property::Block for Block {
 
 impl chain_core::property::HasHeader for Block {
     type Header = BlockHeader;
+    type Id = HeaderHash;
 
     fn header(&self) -> BlockHeader {
         self.header().into()
+    }
+
+    fn id(&self) -> Self::Id {
+        self.header().compute_hash()
     }
 }
 

--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -91,11 +91,17 @@ pub trait Block: Serialize + Deserialize {
 /// block's metadata via a network protocol or in other uses where the
 /// full content of the block is too bulky and not necessary.
 pub trait HasHeader {
+    /// The block header id.
+    type Id: BlockId;
+
     /// The block header type.
     type Header: Header;
 
     /// Retrieves the block's header.
     fn header(&self) -> Self::Header;
+
+    /// Retrieves the block's header id.
+    fn id(&self) -> Self::Id;
 }
 
 /// define a transaction within the blockchain. This transaction can be used

--- a/protocol-tokio/src/protocol/accepting.rs
+++ b/protocol-tokio/src/protocol/accepting.rs
@@ -51,8 +51,8 @@ impl<
 where
     B: cbor_event::Deserialize,
     B: cbor_event::Serialize,
-    B::Id: cbor_event::Deserialize,
-    B::Id: cbor_event::Serialize,
+    <B as property::Block>::Id: cbor_event::Deserialize,
+    <B as property::Block>::Id: cbor_event::Serialize,
     B::Header: cbor_event::Deserialize,
     B::Header: cbor_event::Serialize,
     Tx: cbor_event::Deserialize,

--- a/protocol-tokio/src/protocol/codec/message.rs
+++ b/protocol-tokio/src/protocol/codec/message.rs
@@ -87,12 +87,18 @@ pub enum Message<B: property::Block + property::HasHeader, Tx: property::Transac
     AckNodeId(nt::LightWeightConnectionId, NodeId),
     Bytes(nt::LightWeightConnectionId, Bytes),
 
-    GetBlockHeaders(nt::LightWeightConnectionId, GetBlockHeaders<B::Id>),
+    GetBlockHeaders(
+        nt::LightWeightConnectionId,
+        GetBlockHeaders<<B as property::Block>::Id>,
+    ),
     BlockHeaders(
         nt::LightWeightConnectionId,
         Response<BlockHeaders<B::Header>, String>,
     ),
-    GetBlocks(nt::LightWeightConnectionId, GetBlocks<B::Id>),
+    GetBlocks(
+        nt::LightWeightConnectionId,
+        GetBlocks<<B as property::Block>::Id>,
+    ),
     Block(nt::LightWeightConnectionId, Response<B, String>),
     SendTransaction(nt::LightWeightConnectionId, Tx),
     TransactionReceived(nt::LightWeightConnectionId, Response<bool, String>),
@@ -101,8 +107,8 @@ pub enum Message<B: property::Block + property::HasHeader, Tx: property::Transac
 
 impl<B: property::Block + property::HasHeader, Tx: property::TransactionId> Message<B, Tx>
 where
-    B::Id: cbor_event::Deserialize,
-    B::Id: cbor_event::Serialize,
+    <B as property::Block>::Id: cbor_event::Deserialize,
+    <B as property::Block>::Id: cbor_event::Serialize,
     B: cbor_event::Deserialize,
     B: cbor_event::Serialize,
     B::Header: cbor_event::Deserialize,

--- a/protocol-tokio/src/protocol/connecting.rs
+++ b/protocol-tokio/src/protocol/connecting.rs
@@ -57,8 +57,8 @@ impl<
 where
     B: cbor_event::Deserialize,
     B: cbor_event::Serialize,
-    B::Id: cbor_event::Deserialize,
-    B::Id: cbor_event::Serialize,
+    <B as property::Block>::Id: cbor_event::Deserialize,
+    <B as property::Block>::Id: cbor_event::Serialize,
     B::Header: cbor_event::Deserialize,
     B::Header: cbor_event::Serialize,
     Tx: cbor_event::Deserialize,

--- a/protocol-tokio/src/protocol/inbound_stream.rs
+++ b/protocol-tokio/src/protocol/inbound_stream.rs
@@ -51,12 +51,18 @@ pub enum Inbound<B: property::Block + property::HasHeader, Tx: property::Transac
 
     // need to call Connection::ack_node_id(node_id)
     NewNode(nt::LightWeightConnectionId, NodeId),
-    GetBlockHeaders(nt::LightWeightConnectionId, GetBlockHeaders<B::Id>),
+    GetBlockHeaders(
+        nt::LightWeightConnectionId,
+        GetBlockHeaders<<B as property::Block>::Id>,
+    ),
     BlockHeaders(
         nt::LightWeightConnectionId,
         Response<BlockHeaders<B::Header>, String>,
     ),
-    GetBlocks(nt::LightWeightConnectionId, GetBlocks<B::Id>),
+    GetBlocks(
+        nt::LightWeightConnectionId,
+        GetBlocks<<B as property::Block>::Id>,
+    ),
     Block(nt::LightWeightConnectionId, Response<B, String>),
     SendTransaction(nt::LightWeightConnectionId, Tx),
     TransactionReceived(nt::LightWeightConnectionId, Response<bool, String>),
@@ -74,8 +80,8 @@ impl<T: AsyncRead, B: property::Block + property::HasHeader, Tx: property::Trans
 where
     B: cbor_event::Deserialize,
     B: cbor_event::Serialize,
-    B::Id: cbor_event::Deserialize,
-    B::Id: cbor_event::Serialize,
+    <B as property::Block>::Id: cbor_event::Deserialize,
+    <B as property::Block>::Id: cbor_event::Serialize,
     B::Header: cbor_event::Deserialize,
     B::Header: cbor_event::Serialize,
     Tx: cbor_event::Deserialize,
@@ -97,10 +103,10 @@ where
 impl<T, B: property::Block + property::HasHeader, Tx: property::TransactionId>
     InboundStream<T, B, Tx>
 where
-    B::Id: std::marker::Sized,
+    <B as property::Block>::Id: std::marker::Sized,
     B::Header: std::marker::Sized,
-    B::Id: cbor_event::Deserialize,
-    B::Id: cbor_event::Serialize,
+    <B as property::Block>::Id: cbor_event::Deserialize,
+    <B as property::Block>::Id: cbor_event::Serialize,
     B: cbor_event::Deserialize,
     B: cbor_event::Serialize,
     B::Header: cbor_event::Deserialize,
@@ -147,8 +153,10 @@ where
             Message::AckNodeId(lwcid, node_id) => self.process_ack_node_id(lwcid, node_id),
             Message::Bytes(lwcid, bytes) => self.forward_message(lwcid, Inbound::Data, bytes),
             Message::GetBlockHeaders(lwcid, gdh) => {
-                let f: fn(nt::LightWeightConnectionId, GetBlockHeaders<B::Id>) -> Inbound<B, Tx> =
-                    Inbound::GetBlockHeaders;
+                let f: fn(
+                    nt::LightWeightConnectionId,
+                    GetBlockHeaders<<B as property::Block>::Id>,
+                ) -> Inbound<B, Tx> = Inbound::GetBlockHeaders;
                 self.forward_message(lwcid, f, gdh)
             }
             Message::BlockHeaders(lwcid, bh) => {

--- a/protocol-tokio/src/protocol/mod.rs
+++ b/protocol-tokio/src/protocol/mod.rs
@@ -111,8 +111,8 @@ impl<
     where
         B::Header: cbor_event::Serialize,
         B::Header: cbor_event::Deserialize,
-        B::Id: cbor_event::Serialize,
-        B::Id: cbor_event::Deserialize,
+        <B as property::Block>::Id: cbor_event::Serialize,
+        <B as property::Block>::Id: cbor_event::Deserialize,
         B: cbor_event::Serialize,
         B: cbor_event::Deserialize,
         Tx: cbor_event::Serialize,

--- a/protocol-tokio/src/protocol/outbound_sink.rs
+++ b/protocol-tokio/src/protocol/outbound_sink.rs
@@ -47,8 +47,8 @@ impl<T: AsyncWrite, B: property::Block + property::HasHeader, Tx: property::Tran
 where
     B: cbor_event::Deserialize,
     B: cbor_event::Serialize,
-    B::Id: cbor_event::Deserialize,
-    B::Id: cbor_event::Serialize,
+    <B as property::Block>::Id: cbor_event::Deserialize,
+    <B as property::Block>::Id: cbor_event::Serialize,
     B::Header: cbor_event::Deserialize,
     B::Header: cbor_event::Serialize,
     Tx: cbor_event::Serialize,
@@ -148,8 +148,8 @@ impl<T: AsyncWrite, B: property::Block + property::HasHeader, Tx: property::Tran
 where
     B: cbor_event::Deserialize,
     B: cbor_event::Serialize,
-    B::Id: cbor_event::Deserialize,
-    B::Id: cbor_event::Serialize,
+    <B as property::Block>::Id: cbor_event::Deserialize,
+    <B as property::Block>::Id: cbor_event::Serialize,
     B::Header: cbor_event::Deserialize,
     B::Header: cbor_event::Serialize,
     Tx: cbor_event::Serialize,


### PR DESCRIPTION
Provide additional properties for the Header, so we
can retrieve block id from the header. This API may
be needed if blockchain implementation uses Headers
in the protocol instead of ID's.