### PR TITLE
network-code: Common codes for service errors

### DIFF
--- a/network-core/src/error.rs
+++ b/network-core/src/error.rs
@@ -1,0 +1,22 @@
+use std::fmt;
+
+/// Common error codes for network protocol requests.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Code {
+    Canceled,
+    Failed,
+    NotFound,
+    Unimplemented,
+}
+
+impl fmt::Display for Code {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let msg = match self {
+            Code::Canceled => "processing canceled",
+            Code::Failed => "processing error",
+            Code::NotFound => "not found",
+            Code::Unimplemented => "not implemented",
+        };
+        f.write_str(msg)
+    }
+}

--- a/network-core/src/lib.rs
+++ b/network-core/src/lib.rs
@@ -5,6 +5,8 @@
 #[macro_use]
 extern crate prost_derive;
 
+pub mod error;
+
 pub mod client;
 pub mod server;
 

--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -1,10 +1,12 @@
 //! Block service abstraction.
 
+use crate::error::Code as ErrorCode;
+
 use chain_core::property::{Block, BlockDate, BlockId, Deserialize, Header, Serialize};
 
 use futures::prelude::*;
 
-use std::fmt;
+use std::{error, fmt};
 
 /// Interface for the blockchain node service implementation responsible for
 /// providing access to blocks.
@@ -83,14 +85,14 @@ pub trait HeaderService {
     fn block_headers_to_tip(&mut self, from: &[Self::HeaderId]) -> Self::GetHeadersFuture;
 }
 
-/// Represents errors that can be returned by the node service implementation.
+/// Represents errors that can be returned by the block service.
 #[derive(Debug)]
-pub struct BlockError(); // TODO: define specific error variants and details
+pub struct BlockError(pub ErrorCode);
 
-impl std::error::Error for BlockError {}
+impl error::Error for BlockError {}
 
 impl fmt::Display for BlockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "unknown block service error")
+        write!(f, "block service error: {}", self.0)
     }
 }

--- a/network-core/src/server/transaction.rs
+++ b/network-core/src/server/transaction.rs
@@ -1,12 +1,13 @@
 //! Transaction service abstraction.
 
 use crate::codes;
+use crate::error::Code as ErrorCode;
 
 use chain_core::property::{Serialize, TransactionId};
 
 use futures::prelude::*;
 
-use std::fmt;
+use std::{error, fmt};
 
 /// Interface for the blockchain node service implementation responsible for
 /// validating and accepting transactions.
@@ -34,15 +35,15 @@ pub trait TransactionService {
     ) -> Self::ProposeTransactionsFuture;
 }
 
-/// Represents errors that can be returned by the node service implementation.
+/// Represents errors that can be returned by the transaction service.
 #[derive(Debug)]
-pub struct TransactionError(); // TODO: define specific error variants and details
+pub struct TransactionError(pub ErrorCode);
 
-impl std::error::Error for TransactionError {}
+impl error::Error for TransactionError {}
 
 impl fmt::Display for TransactionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "unknown transaction service error")
+        write!(f, "transaction service error: {}", self.0)
     }
 }
 


### PR DESCRIPTION
The enum `error::Code` can be used for general classification of
network protocol errors. Each of the service error types wraps the code
as the simplest workable definition for now; later the errors can be
augmented with service-specific details and variants.