### PR TITLE
Improve trait bounds on blockchain entities

### DIFF
--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -311,6 +311,11 @@ pub trait Deserialize: Sized {
     fn deserialize<R: std::io::BufRead>(reader: R) -> Result<Self, Self::Error>;
 }
 
+/// Defines the way to parse the object from a UTF-8 string.
+///
+/// This is like the standard `FromStr` trait, except that it imposes
+/// additional bounds on the error type to make it more usable for
+/// aggregation to higher level errors and passing between threads.
 pub trait FromStr: Sized {
     type Error: std::error::Error + Send + Sync + 'static;
 

--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -35,8 +35,7 @@
 //! is selected to write a block in the chain.
 //!
 
-use std::fmt::Debug;
-use std::hash::Hash;
+use std::{fmt::Debug, hash::Hash};
 
 /// Trait identifying the block identifier type.
 pub trait BlockId: Eq + Ord + Clone + Debug + Hash + Serialize + Deserialize {}
@@ -307,9 +306,27 @@ pub trait Serialize {
 
 /// Define that an object can be read from a `Read` object.
 pub trait Deserialize: Sized {
-    type Error: std::error::Error + From<std::io::Error>;
+    type Error: std::error::Error + From<std::io::Error> + Send + Sync + 'static;
 
     fn deserialize<R: std::io::BufRead>(reader: R) -> Result<Self, Self::Error>;
+}
+
+pub trait FromStr: Sized {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    fn from_str(s: &str) -> Result<Self, Self::Error>;
+}
+
+impl<T> FromStr for T
+where
+    T: std::str::FromStr,
+    <T as std::str::FromStr>::Err: std::error::Error + Send + Sync + 'static,
+{
+    type Error = <T as std::str::FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Error> {
+        std::str::FromStr::from_str(s)
+    }
 }
 
 impl<T: Serialize> Serialize for &T {

--- a/chain-impl-mockchain/src/block.rs
+++ b/chain-impl-mockchain/src/block.rs
@@ -3,16 +3,7 @@ use crate::key::{Hash, PrivateKey, PublicKey, Signature};
 use crate::transaction::*;
 use chain_core::property;
 
-use std::{error, fmt, num::ParseIntError, str};
-
-/// Non unique identifier of the transaction position in the
-/// blockchain. There may be many transactions related to the same
-/// `SlotId`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct BlockDate {
-    pub epoch: u64,
-    pub slot_id: u64,
-}
+pub use crate::date::{BlockDate, BlockDateParseError};
 
 /// `Block` is an element of the blockchain it contains multiple
 /// transaction and a reference to the parent block. Alongside
@@ -89,66 +80,6 @@ impl SignedBlock {
             public_key: self.public_key.clone(),
             signature: self.signature.clone(),
         }
-    }
-}
-
-impl property::BlockDate for BlockDate {
-    fn from_epoch_slot_id(epoch: u64, slot_id: u64) -> Self {
-        BlockDate {
-            epoch: epoch,
-            slot_id: slot_id,
-        }
-    }
-}
-
-impl fmt::Display for BlockDate {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}.{}", self.epoch, self.slot_id)
-    }
-}
-
-#[derive(Debug)]
-pub enum BlockDateParseError {
-    DotMissing,
-    BadEpochId(ParseIntError),
-    BadSlotId(ParseIntError),
-}
-
-const EXPECT_FORMAT_MESSAGE: &'static str = "expected block date format EPOCH.SLOT";
-
-impl fmt::Display for BlockDateParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use BlockDateParseError::*;
-        match self {
-            DotMissing => write!(f, "{}", EXPECT_FORMAT_MESSAGE),
-            BadEpochId(_) => write!(f, "invalid epoch ID, {}", EXPECT_FORMAT_MESSAGE),
-            BadSlotId(_) => write!(f, "invalid slot ID, {}", EXPECT_FORMAT_MESSAGE),
-        }
-    }
-}
-
-impl error::Error for BlockDateParseError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        use BlockDateParseError::*;
-        match self {
-            DotMissing => None,
-            BadEpochId(e) => Some(e),
-            BadSlotId(e) => Some(e),
-        }
-    }
-}
-
-impl str::FromStr for BlockDate {
-    type Err = BlockDateParseError;
-
-    fn from_str(s: &str) -> Result<BlockDate, BlockDateParseError> {
-        let (ep, sp) = match s.find('.') {
-            None => return Err(BlockDateParseError::DotMissing),
-            Some(pos) => s.split_at(pos),
-        };
-        let epoch = str::parse::<u64>(ep).map_err(BlockDateParseError::BadEpochId)?;
-        let slot_id = str::parse::<u64>(sp).map_err(BlockDateParseError::BadSlotId)?;
-        Ok(BlockDate { epoch, slot_id })
     }
 }
 

--- a/chain-impl-mockchain/src/block.rs
+++ b/chain-impl-mockchain/src/block.rs
@@ -146,8 +146,8 @@ impl str::FromStr for BlockDate {
             None => return Err(BlockDateParseError::DotMissing),
             Some(pos) => s.split_at(pos),
         };
-        let epoch = str::parse::<u64>(ep).map_err(|e| BlockDateParseError::BadEpochId(e))?;
-        let slot_id = str::parse::<u64>(sp).map_err(|e| BlockDateParseError::BadSlotId(e))?;
+        let epoch = str::parse::<u64>(ep).map_err(BlockDateParseError::BadEpochId)?;
+        let slot_id = str::parse::<u64>(sp).map_err(BlockDateParseError::BadSlotId)?;
         Ok(BlockDate { epoch, slot_id })
     }
 }

--- a/chain-impl-mockchain/src/date.rs
+++ b/chain-impl-mockchain/src/date.rs
@@ -26,7 +26,7 @@ impl fmt::Display for BlockDate {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BlockDateParseError {
     DotMissing,
     BadEpochId(ParseIntError),
@@ -68,5 +68,49 @@ impl str::FromStr for BlockDate {
         let epoch = str::parse::<u64>(ep).map_err(BlockDateParseError::BadEpochId)?;
         let slot_id = str::parse::<u64>(sp).map_err(BlockDateParseError::BadSlotId)?;
         Ok(BlockDate { epoch, slot_id })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error;
+
+    #[test]
+    fn parse_no_dot() {
+        let err = "42".parse::<BlockDate>().unwrap_err();
+        assert_eq!(err, BlockDateParseError::DotMissing);
+    }
+
+    #[test]
+    fn parse_epoch_slot_id() {
+        let date = "42.12".parse::<BlockDate>().unwrap();
+        assert_eq!(
+            date,
+            BlockDate {
+                epoch: 42,
+                slot_id: 12
+            }
+        );
+    }
+
+    #[test]
+    fn parse_bad_epoch() {
+        let err = "BAD.12".parse::<BlockDate>().unwrap_err();
+        if let BlockDateParseError::BadEpochId(_) = err {
+            println!("{}: {}", err, err.source().unwrap());
+        } else {
+            panic!("unexpected error {:?}", err);
+        }
+    }
+
+    #[test]
+    fn parse_bad_slotid() {
+        let err = "42.BAD".parse::<BlockDate>().unwrap_err();
+        if let BlockDateParseError::BadSlotId(_) = err {
+            println!("{}: {}", err, err.source().unwrap());
+        } else {
+            panic!("unexpected error {:?}", err);
+        }
     }
 }

--- a/chain-impl-mockchain/src/date.rs
+++ b/chain-impl-mockchain/src/date.rs
@@ -1,0 +1,72 @@
+use chain_core::property;
+
+use std::{error, fmt, num::ParseIntError, str};
+
+/// Non unique identifier of the transaction position in the
+/// blockchain. There may be many transactions related to the same
+/// `SlotId`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BlockDate {
+    pub epoch: u64,
+    pub slot_id: u64,
+}
+
+impl property::BlockDate for BlockDate {
+    fn from_epoch_slot_id(epoch: u64, slot_id: u64) -> Self {
+        BlockDate {
+            epoch: epoch,
+            slot_id: slot_id,
+        }
+    }
+}
+
+impl fmt::Display for BlockDate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}.{}", self.epoch, self.slot_id)
+    }
+}
+
+#[derive(Debug)]
+pub enum BlockDateParseError {
+    DotMissing,
+    BadEpochId(ParseIntError),
+    BadSlotId(ParseIntError),
+}
+
+const EXPECT_FORMAT_MESSAGE: &'static str = "expected block date format EPOCH.SLOT";
+
+impl fmt::Display for BlockDateParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use BlockDateParseError::*;
+        match self {
+            DotMissing => write!(f, "{}", EXPECT_FORMAT_MESSAGE),
+            BadEpochId(_) => write!(f, "invalid epoch ID, {}", EXPECT_FORMAT_MESSAGE),
+            BadSlotId(_) => write!(f, "invalid slot ID, {}", EXPECT_FORMAT_MESSAGE),
+        }
+    }
+}
+
+impl error::Error for BlockDateParseError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        use BlockDateParseError::*;
+        match self {
+            DotMissing => None,
+            BadEpochId(e) => Some(e),
+            BadSlotId(e) => Some(e),
+        }
+    }
+}
+
+impl str::FromStr for BlockDate {
+    type Err = BlockDateParseError;
+
+    fn from_str(s: &str) -> Result<BlockDate, BlockDateParseError> {
+        let (ep, sp) = match s.find('.') {
+            None => return Err(BlockDateParseError::DotMissing),
+            Some(pos) => (&s[..pos], &s[(pos + 1)..]),
+        };
+        let epoch = str::parse::<u64>(ep).map_err(BlockDateParseError::BadEpochId)?;
+        let slot_id = str::parse::<u64>(sp).map_err(BlockDateParseError::BadSlotId)?;
+        Ok(BlockDate { epoch, slot_id })
+    }
+}

--- a/chain-impl-mockchain/src/lib.rs
+++ b/chain-impl-mockchain/src/lib.rs
@@ -4,6 +4,7 @@ extern crate quickcheck;
 extern crate chain_addr;
 
 pub mod block;
+mod date;
 #[cfg(test)]
 pub mod environment;
 pub mod error;


### PR DESCRIPTION
Add `chain-core` property trait `FromStr` to impose extra requirements on parsing values such as block dates from strings.

Require the error types for deserialization and string parsing to be safe for passing between threads, so that they can be boxed and contained in e.g. `client::Error` of `network-core`.

Trait work in gRPC client code to reduce repetitive bound clauses.