### PR TITLE
chain-core: Abstract away transaction iterators

### DIFF
--- a/cardano/src/block/block.rs
+++ b/cardano/src/block/block.rs
@@ -361,11 +361,11 @@ impl chain_core::property::Deserialize for Block {
 }
 
 impl chain_core::property::HasTransaction for Block {
-    type Transaction = TxAux;
-    fn transactions<'a>(&'a self) -> std::slice::Iter<'a, Self::Transaction> {
+    type Transactions = Vec<TxAux>;
+    fn transactions(&self) -> Option<&Self::Transactions> {
         match self {
-            &Block::BoundaryBlock(_) => [].iter(),
-            &Block::MainBlock(ref blk) => blk.body.tx.iter(),
+            Block::BoundaryBlock(_) => None,
+            Block::MainBlock(ref blk) => Some(&blk.body.tx),
         }
     }
 }

--- a/cardano/src/tx.rs
+++ b/cardano/src/tx.rs
@@ -688,12 +688,14 @@ impl chain_core::property::Transaction for Tx {
     type Id = TxId;
     type Input = TxoPointer;
     type Output = TxOut;
+    type Inputs = Vec<TxoPointer>;
+    type Outputs = Vec<TxOut>;
 
-    fn inputs<'a>(&'a self) -> std::slice::Iter<'a, Self::Input> {
-        self.inputs.iter()
+    fn inputs(&self) -> &Self::Inputs {
+        &self.inputs
     }
-    fn outputs<'a>(&'a self) -> std::slice::Iter<'a, Self::Output> {
-        self.outputs.iter()
+    fn outputs(&self) -> &Self::Outputs {
+        &self.outputs
     }
     fn id(&self) -> Self::Id {
         Tx::id(self)
@@ -703,12 +705,14 @@ impl chain_core::property::Transaction for TxAux {
     type Id = TxId;
     type Input = TxoPointer;
     type Output = TxOut;
+    type Inputs = Vec<TxoPointer>;
+    type Outputs = Vec<TxOut>;
 
-    fn inputs<'a>(&'a self) -> std::slice::Iter<'a, Self::Input> {
-        self.tx.inputs.iter()
+    fn inputs(&self) -> &Self::Inputs {
+        &self.tx.inputs
     }
-    fn outputs<'a>(&'a self) -> std::slice::Iter<'a, Self::Output> {
-        self.tx.outputs.iter()
+    fn outputs(&self) -> &Self::Outputs {
+        &self.tx.outputs
     }
     fn id(&self) -> Self::Id {
         self.tx.id()

--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -116,22 +116,29 @@ pub trait HasHeader {
 /// the blockchain has (a transaction type to add Stacking Pools and so on...).
 ///
 pub trait Transaction: Serialize + Deserialize {
-    /// the input type of the transaction (if none use `()`).
+    /// The input type of the transaction (if none use `()`).
     type Input;
-    /// the output type of the transaction (if none use `()`).
+    /// The output type of the transaction (if none use `()`).
     type Output;
+    /// The iterable type of transaction inputs (if none use ??).
+    type Inputs;
+    /// The iterable type of transaction outputs (if none use ??).
+    type Outputs;
     /// a unique identifier of the transaction. For 2 different transactions
     /// we must have 2 different `Id` values.
     type Id: TransactionId;
 
-    fn inputs<'a>(&'a self) -> std::slice::Iter<'a, Self::Input>;
-    fn outputs<'a>(&'a self) -> std::slice::Iter<'a, Self::Output>;
+    /// Returns a reference that can be used to iterate over transaction's inputs.
+    fn inputs(&self) -> &Self::Inputs;
+
+    /// Returns a reference that can be used to iterate over transaction's outputs.
+    fn outputs(&self) -> &Self::Outputs;
 
     /// return the Transaction's identifier.
     fn id(&self) -> Self::Id;
 }
 
-/// accessor to transactions within a block
+/// Accessor to transactions within a block
 ///
 /// This trait is generic enough to show there is multiple types
 /// of transaction possibles:
@@ -140,10 +147,15 @@ pub trait Transaction: Serialize + Deserialize {
 /// * certificate registrations
 /// * ...
 pub trait HasTransaction {
-    type Transaction: Transaction;
+    /// An iterable collection of transactions provided by the block.
+    /// A reference to the `Transactions` type must be convertible to an
+    /// iterator returning references to transaction objects.
+    type Transactions;
 
-    /// returns an iterator over the Transactions
-    fn transactions<'a>(&'a self) -> std::slice::Iter<'a, Self::Transaction>;
+    /// Returns a reference that can be used to iterate over transactions in the block.
+    /// If the block does not feature transactions of the given type,
+    /// this method returns `None`.
+    fn transactions(&self) -> Option<&Self::Transactions>;
 }
 
 /// Updates type needs to implement this feature so we can easily
@@ -372,15 +384,23 @@ pub mod testing {
     /// and signatures will compose into a valid transaction, but if such
     /// event would happen it can be treated as error due to lack of the
     /// randomness.
-    pub fn prop_bad_transaction_fails<L>(ledger: L, transaction: L::Transaction) -> TestResult
+    pub fn prop_bad_transaction_fails<'a, L>(
+        ledger: L,
+        transaction: &'a L::Transaction,
+    ) -> TestResult
     where
         L: Ledger + Arbitrary,
-        <L as Ledger>::Transaction: Transaction + Arbitrary,
+        &'a <L::Transaction as Transaction>::Inputs: IntoIterator,
+        <&'a <L::Transaction as Transaction>::Inputs as IntoIterator>::IntoIter: ExactSizeIterator,
+        &'a <L::Transaction as Transaction>::Outputs: IntoIterator,
+        <&'a <L::Transaction as Transaction>::Outputs as IntoIterator>::IntoIter: ExactSizeIterator,
     {
-        if transaction.inputs().len() == 0 && transaction.outputs().len() == 0 {
+        if transaction.inputs().into_iter().len() == 0
+            && transaction.outputs().into_iter().len() == 0
+        {
             return TestResult::discard();
         }
-        TestResult::from_bool(ledger.diff_transaction(&transaction).is_err())
+        TestResult::from_bool(ledger.diff_transaction(transaction).is_err())
     }
 
     /// Pair with a ledger and transaction that is valid in such state.

--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -120,9 +120,9 @@ pub trait Transaction: Serialize + Deserialize {
     type Input;
     /// The output type of the transaction (if none use `()`).
     type Output;
-    /// The iterable type of transaction inputs (if none use ??).
+    /// The iterable type of transaction inputs (if none use `Option<()>` and return `None`).
     type Inputs;
-    /// The iterable type of transaction outputs (if none use ??).
+    /// The iterable type of transaction outputs (if none use `Option<()>` and return `None`).
     type Outputs;
     /// a unique identifier of the transaction. For 2 different transactions
     /// we must have 2 different `Id` values.

--- a/chain-impl-mockchain/src/block.rs
+++ b/chain-impl-mockchain/src/block.rs
@@ -277,14 +277,15 @@ impl property::Deserialize for SignedBlockSummary {
 }
 
 impl property::HasTransaction for Block {
-    type Transaction = SignedTransaction;
-    fn transactions<'a>(&'a self) -> std::slice::Iter<'a, Self::Transaction> {
-        self.transactions.iter()
+    type Transactions = Vec<SignedTransaction>;
+    fn transactions(&self) -> Option<&Self::Transactions> {
+        Some(&self.transactions)
     }
 }
+
 impl property::HasTransaction for SignedBlock {
-    type Transaction = SignedTransaction;
-    fn transactions<'a>(&'a self) -> std::slice::Iter<'a, Self::Transaction> {
+    type Transactions = Vec<SignedTransaction>;
+    fn transactions(&self) -> Option<&Self::Transactions> {
         self.block.transactions()
     }
 }

--- a/chain-impl-mockchain/src/lib.rs
+++ b/chain-impl-mockchain/src/lib.rs
@@ -25,7 +25,7 @@ mod tests {
     quickcheck! {
         /// Randomly generated transaction should fail.
         fn prop_bad_tx_fails(l: Ledger, tx: SignedTransaction) -> TestResult {
-            testing::prop_bad_transaction_fails(l, tx)
+            testing::prop_bad_transaction_fails(l, &tx)
         }
     }
 

--- a/chain-impl-mockchain/src/transaction.rs
+++ b/chain-impl-mockchain/src/transaction.rs
@@ -214,12 +214,15 @@ impl property::Deserialize for SignedTransaction {
 impl property::Transaction for Transaction {
     type Input = UtxoPointer;
     type Output = Output;
+    type Inputs = Vec<UtxoPointer>;
+    type Outputs = Vec<Output>;
     type Id = TransactionId;
-    fn inputs<'a>(&'a self) -> std::slice::Iter<'a, Self::Input> {
-        self.inputs.iter()
+
+    fn inputs(&self) -> &Self::Inputs {
+        &self.inputs
     }
-    fn outputs<'a>(&'a self) -> std::slice::Iter<'a, Self::Output> {
-        self.outputs.iter()
+    fn outputs(&self) -> &Self::Outputs {
+        &self.outputs
     }
     fn id(&self) -> Self::Id {
         use chain_core::property::Serialize;
@@ -232,15 +235,18 @@ impl property::Transaction for Transaction {
         Hash::hash_bytes(&bytes)
     }
 }
-impl property::Transaction for SignedTransaction {
-    type Input = <Transaction as property::Transaction>::Input;
-    type Output = <Transaction as property::Transaction>::Output;
-    type Id = <Transaction as property::Transaction>::Id;
 
-    fn inputs<'a>(&'a self) -> std::slice::Iter<'a, Self::Input> {
+impl property::Transaction for SignedTransaction {
+    type Input = UtxoPointer;
+    type Output = Output;
+    type Inputs = Vec<UtxoPointer>;
+    type Outputs = Vec<Output>;
+    type Id = TransactionId;
+
+    fn inputs(&self) -> &Self::Inputs {
         self.transaction.inputs()
     }
-    fn outputs<'a>(&'a self) -> std::slice::Iter<'a, Self::Output> {
+    fn outputs(&self) -> &Self::Outputs {
         self.transaction.outputs()
     }
     fn id(&self) -> Self::Id {


### PR DESCRIPTION
The chain-core traits provide iterators over various abstract types. Due to lack of generic associated types, it's not trivial to abstract away associated types, so slice iterators were exposed as the only type that can be used to iterate over contents. This change does away with the specific iterator type.