### PR TITLE
Further refine abstract iteration API in chain-core

### DIFF
--- a/cardano/src/block/block.rs
+++ b/cardano/src/block/block.rs
@@ -364,7 +364,7 @@ impl chain_core::property::HasTransaction for Block {
     type Transactions = [TxAux];
     fn transactions(&self) -> &Self::Transactions {
         match self {
-            Block::BoundaryBlock(blk) => &blk.body.no_transactions,
+            Block::BoundaryBlock(_) => &[],
             Block::MainBlock(blk) => &blk.body.tx,
         }
     }

--- a/cardano/src/block/block.rs
+++ b/cardano/src/block/block.rs
@@ -361,11 +361,11 @@ impl chain_core::property::Deserialize for Block {
 }
 
 impl chain_core::property::HasTransaction for Block {
-    type Transactions = Vec<TxAux>;
-    fn transactions(&self) -> Option<&Self::Transactions> {
+    type Transactions = [TxAux];
+    fn transactions(&self) -> &Self::Transactions {
         match self {
-            Block::BoundaryBlock(_) => None,
-            Block::MainBlock(ref blk) => Some(&blk.body.tx),
+            Block::BoundaryBlock(blk) => &blk.body.no_transactions,
+            Block::MainBlock(blk) => &blk.body.tx,
         }
     }
 }

--- a/cardano/src/block/boundary.rs
+++ b/cardano/src/block/boundary.rs
@@ -1,5 +1,5 @@
-use crate::{address, config::ProtocolMagic, hash::Blake2b256, tx};
 use super::types::{self, ChainDifficulty, HeaderHash};
+use crate::{address, config::ProtocolMagic, hash::Blake2b256};
 
 use std::{
     fmt,
@@ -33,7 +33,6 @@ impl cbor_event::de::Deserialize for BodyProof {
 #[derive(Debug, Clone)]
 pub struct Body {
     pub slot_leaders: Vec<address::StakeholderId>,
-    pub no_transactions: [tx::TxAux; 0], // A placeholder for the HasTransaction impl
 }
 impl cbor_event::se::Serialize for Body {
     fn serialize<'se, W: Write>(
@@ -59,7 +58,7 @@ impl cbor_event::de::Deserialize for Body {
                 true
             }
         } {}
-        Ok(Body { slot_leaders, no_transactions: [] })
+        Ok(Body { slot_leaders })
     }
 }
 

--- a/cardano/src/block/boundary.rs
+++ b/cardano/src/block/boundary.rs
@@ -1,12 +1,11 @@
-use config::ProtocolMagic;
+use crate::{address, config::ProtocolMagic, hash::Blake2b256, tx};
+use super::types::{self, ChainDifficulty, HeaderHash};
+
 use std::{
     fmt,
     io::{BufRead, Write},
 };
-use {address, hash::Blake2b256};
 
-use super::types;
-use super::types::{ChainDifficulty, HeaderHash};
 use cbor_event::{self, de::Deserializer, se::Serializer};
 
 #[derive(Debug, Clone)]
@@ -34,6 +33,7 @@ impl cbor_event::de::Deserialize for BodyProof {
 #[derive(Debug, Clone)]
 pub struct Body {
     pub slot_leaders: Vec<address::StakeholderId>,
+    pub no_transactions: [tx::TxAux; 0], // A placeholder for the HasTransaction impl
 }
 impl cbor_event::se::Serialize for Body {
     fn serialize<'se, W: Write>(
@@ -59,7 +59,7 @@ impl cbor_event::de::Deserialize for Body {
                 true
             }
         } {}
-        Ok(Body { slot_leaders })
+        Ok(Body { slot_leaders, no_transactions: [] })
     }
 }
 

--- a/cardano/src/tx.rs
+++ b/cardano/src/tx.rs
@@ -688,8 +688,8 @@ impl chain_core::property::Transaction for Tx {
     type Id = TxId;
     type Input = TxoPointer;
     type Output = TxOut;
-    type Inputs = Vec<TxoPointer>;
-    type Outputs = Vec<TxOut>;
+    type Inputs = [TxoPointer];
+    type Outputs = [TxOut];
 
     fn inputs(&self) -> &Self::Inputs {
         &self.inputs
@@ -705,8 +705,8 @@ impl chain_core::property::Transaction for TxAux {
     type Id = TxId;
     type Input = TxoPointer;
     type Output = TxOut;
-    type Inputs = Vec<TxoPointer>;
-    type Outputs = Vec<TxOut>;
+    type Inputs = [TxoPointer];
+    type Outputs = [TxOut];
 
     fn inputs(&self) -> &Self::Inputs {
         &self.tx.inputs

--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -121,9 +121,9 @@ pub trait Transaction: Serialize + Deserialize {
     /// The output type of the transaction (if none use `()`).
     type Output;
     /// The iterable type of transaction inputs (if none use `Option<()>` and return `None`).
-    type Inputs;
+    type Inputs: ?Sized;
     /// The iterable type of transaction outputs (if none use `Option<()>` and return `None`).
-    type Outputs;
+    type Outputs: ?Sized;
     /// a unique identifier of the transaction. For 2 different transactions
     /// we must have 2 different `Id` values.
     type Id: TransactionId;
@@ -150,12 +150,10 @@ pub trait HasTransaction {
     /// An iterable collection of transactions provided by the block.
     /// A reference to the `Transactions` type must be convertible to an
     /// iterator returning references to transaction objects.
-    type Transactions;
+    type Transactions: ?Sized;
 
     /// Returns a reference that can be used to iterate over transactions in the block.
-    /// If the block does not feature transactions of the given type,
-    /// this method returns `None`.
-    fn transactions(&self) -> Option<&Self::Transactions>;
+    fn transactions(&self) -> &Self::Transactions;
 }
 
 /// Updates type needs to implement this feature so we can easily

--- a/chain-impl-mockchain/src/block.rs
+++ b/chain-impl-mockchain/src/block.rs
@@ -277,15 +277,15 @@ impl property::Deserialize for SignedBlockSummary {
 }
 
 impl property::HasTransaction for Block {
-    type Transactions = Vec<SignedTransaction>;
-    fn transactions(&self) -> Option<&Self::Transactions> {
-        Some(&self.transactions)
+    type Transactions = [SignedTransaction];
+    fn transactions(&self) -> &Self::Transactions {
+        &self.transactions
     }
 }
 
 impl property::HasTransaction for SignedBlock {
-    type Transactions = Vec<SignedTransaction>;
-    fn transactions(&self) -> Option<&Self::Transactions> {
+    type Transactions = [SignedTransaction];
+    fn transactions(&self) -> &Self::Transactions {
         self.block.transactions()
     }
 }

--- a/chain-impl-mockchain/src/transaction.rs
+++ b/chain-impl-mockchain/src/transaction.rs
@@ -214,8 +214,8 @@ impl property::Deserialize for SignedTransaction {
 impl property::Transaction for Transaction {
     type Input = UtxoPointer;
     type Output = Output;
-    type Inputs = Vec<UtxoPointer>;
-    type Outputs = Vec<Output>;
+    type Inputs = [UtxoPointer];
+    type Outputs = [Output];
     type Id = TransactionId;
 
     fn inputs(&self) -> &Self::Inputs {
@@ -239,8 +239,8 @@ impl property::Transaction for Transaction {
 impl property::Transaction for SignedTransaction {
     type Input = UtxoPointer;
     type Output = Output;
-    type Inputs = Vec<UtxoPointer>;
-    type Outputs = Vec<Output>;
+    type Inputs = [UtxoPointer];
+    type Outputs = [Output];
     type Id = TransactionId;
 
     fn inputs(&self) -> &Self::Inputs {


### PR DESCRIPTION
The `Option` return of `HasTransaction::transactions()` is unwieldy.
It's better to have an empty array in the implementation type that does
not have transactions, and iterate over the slice reference.

The iterable accessor types do not have to be sized, so lift the sized
bound from these associated types.