### PR TITLE
Fix fee parsing

### DIFF
--- a/chain-storage-sqlite/examples/import.rs
+++ b/chain-storage-sqlite/examples/import.rs
@@ -32,6 +32,9 @@ fn main() {
     )
     .unwrap();
 
+    let mut chain_state = cardano::block::ChainState::new(&exe_common::genesisdata::parse::parse(
+        exe_common::genesis_data::get_genesis_data(&genesis_hash).unwrap().as_bytes()));
+
     let mut store = chain_storage_sqlite::SQLiteBlockStore::new(genesis_hash, db_path);
 
     /* Convert a chain using old-school storage to a SQLiteBlockStore. */
@@ -43,6 +46,7 @@ fn main() {
     {
         let (_raw_blk, blk) = res.unwrap();
         let hash = blk.id();
+        chain_state.verify_block(&hash, &blk).unwrap();
         store.put_block(blk).unwrap();
         //if n > 49900 { break; }
         if n % 10000 == 0 {

--- a/chain-storage-sqlite/examples/import.rs
+++ b/chain-storage-sqlite/examples/import.rs
@@ -33,7 +33,10 @@ fn main() {
     .unwrap();
 
     let mut chain_state = cardano::block::ChainState::new(&exe_common::genesisdata::parse::parse(
-        exe_common::genesisdata::data::get_genesis_data(&genesis_hash).unwrap().as_bytes()));
+        exe_common::genesisdata::data::get_genesis_data(&genesis_hash)
+            .unwrap()
+            .as_bytes(),
+    ));
 
     let mut store = chain_storage_sqlite::SQLiteBlockStore::new(genesis_hash, db_path);
 

--- a/chain-storage-sqlite/examples/import.rs
+++ b/chain-storage-sqlite/examples/import.rs
@@ -33,7 +33,7 @@ fn main() {
     .unwrap();
 
     let mut chain_state = cardano::block::ChainState::new(&exe_common::genesisdata::parse::parse(
-        exe_common::genesis_data::get_genesis_data(&genesis_hash).unwrap().as_bytes()));
+        exe_common::genesisdata::data::get_genesis_data(&genesis_hash).unwrap().as_bytes()));
 
     let mut store = chain_storage_sqlite::SQLiteBlockStore::new(genesis_hash, db_path);
 

--- a/exe-common/src/genesisdata/data.rs
+++ b/exe-common/src/genesisdata/data.rs
@@ -7,21 +7,21 @@ pub fn get_genesis_data(genesis_prev: &HeaderHash) -> Result<&str, HeaderHash> {
             .unwrap()
     {
         Ok(include_str!(
-            "../genesis/5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb.json"
+            "../../genesis/5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb.json"
         ))
     } else if genesis_prev
         == &HeaderHash::from_str("b7f76950bc4866423538ab7764fc1c7020b24a5f717a5bee3109ff2796567214")
             .unwrap()
     {
         Ok(include_str!(
-            "../genesis/b7f76950bc4866423538ab7764fc1c7020b24a5f717a5bee3109ff2796567214.json"
+            "../../genesis/b7f76950bc4866423538ab7764fc1c7020b24a5f717a5bee3109ff2796567214.json"
         ))
     } else if genesis_prev
         == &HeaderHash::from_str("c6a004d3d178f600cd8caa10abbebe1549bef878f0665aea2903472d5abf7323")
             .unwrap()
     {
         Ok(include_str!(
-            "../genesis/c6a004d3d178f600cd8caa10abbebe1549bef878f0665aea2903472d5abf7323.json"
+            "../../genesis/c6a004d3d178f600cd8caa10abbebe1549bef878f0665aea2903472d5abf7323.json"
         ))
     } else {
         Err(genesis_prev.clone())

--- a/exe-common/src/genesisdata/mod.rs
+++ b/exe-common/src/genesisdata/mod.rs
@@ -1,4 +1,4 @@
+pub mod data;
 pub mod parse;
 pub mod print;
 pub mod raw;
-pub mod data;

--- a/exe-common/src/genesisdata/mod.rs
+++ b/exe-common/src/genesisdata/mod.rs
@@ -1,3 +1,4 @@
 pub mod parse;
 pub mod print;
 pub mod raw;
+pub mod data;

--- a/exe-common/src/genesisdata/parse.rs
+++ b/exe-common/src/genesisdata/parse.rs
@@ -19,8 +19,8 @@ pub fn parse<R: Read>(json: R) -> config::GenesisData {
 
     let parse_fee_constant = |s: &str| {
         let n = s.parse::<u64>().unwrap();
-        assert!(n % 1000 == 0);
-        fee::Milli::integral(n / 1000)
+        assert!(n % 1000000 == 0);
+        fee::Milli::new(n / 1000000000, n / 1000000 % 1000)
     };
 
     let mut avvm_distr = BTreeMap::new();

--- a/exe-common/src/genesisdata/parse.rs
+++ b/exe-common/src/genesisdata/parse.rs
@@ -166,7 +166,8 @@ mod test {
             genesis_data
                 .non_avvm_balances
                 .iter()
-                .find(|(n, _)| n.to_string() == "2cWKMJemoBaheSTiK9XEtQDf47Z3My8jwN25o5jjm7s7jaXin2nothhWQrTDd8m433M8K")
+                .find(|(n, _)| n.to_string()
+                    == "2cWKMJemoBaheSTiK9XEtQDf47Z3My8jwN25o5jjm7s7jaXin2nothhWQrTDd8m433M8K")
                 .unwrap()
                 .1,
             &coin::Coin::new(5428571428571429).unwrap()

--- a/exe-common/src/lib.rs
+++ b/exe-common/src/lib.rs
@@ -19,7 +19,6 @@ extern crate hyper;
 extern crate tokio_core;
 
 pub mod config;
-pub mod genesis_data;
 pub mod genesisdata;
 mod mstream;
 pub mod network;


### PR DESCRIPTION
I messed this up in 637ae1efd338ad334a748e93df621ace86e30644. Thanks to @vantuz-subhuman for catching this (see #446). This is a slighly simpler fix that does detect the case where the constant is divisible by 10^9 but not by 10^6.