### PR TITLE
Rework the network-ntt client connection as an explicit state machine

### DIFF
--- a/exe-common/src/network/ntt.rs
+++ b/exe-common/src/network/ntt.rs
@@ -30,9 +30,15 @@ impl NetworkCore {
                 // FIXME: use default executor, or take
                 // executor argument before merge.
                 let mut rt = Runtime::new().unwrap();
-                rt.spawn(connection.map(|_| {
-                    println!("Exited");
-                }));
+                rt.spawn(
+                    connection
+                        .map(|_| {
+                            debug!("Exited");
+                        })
+                        .map_err(|e| {
+                            error!("NTT connection error: {:?}", e);
+                        }),
+                );
                 Ok(NetworkCore { handle, rt })
             }
             Err(_err) => unimplemented!(),

--- a/network-ntt/src/client.rs
+++ b/network-ntt/src/client.rs
@@ -231,10 +231,10 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Error::Connect(e) => write!(f, "connection error"),
-            Error::Handshake(e) => write!(f, "failed to set up the protocol connection"),
-            Error::Inbound(e) => write!(f, "network input error"),
-            Error::Outbound(e) => write!(f, "network output error"),
+            Error::Connect(_) => write!(f, "connection error"),
+            Error::Handshake(_) => write!(f, "failed to set up the protocol connection"),
+            Error::Inbound(_) => write!(f, "network input error"),
+            Error::Outbound(_) => write!(f, "network output error"),
         }
     }
 }
@@ -368,6 +368,8 @@ where
     }
 }
 
+// To be used when UnaryRequest and StreamRequest are extended with more variants.
+#[allow(dead_code)]
 fn unexpected_response_error() -> core_client::Error {
     core_client::Error::new(core_client::ErrorKind::Rpc, "unexpected response")
 }
@@ -398,6 +400,7 @@ where
             Inbound::NothingExciting => {}
             Inbound::BlockHeaders(lwcid, response) => {
                 let request = self.unary_requests.remove(&lwcid);
+                #[allow(unreachable_patterns)]
                 match request {
                     None => {
                         // TODO: log the bogus response
@@ -417,6 +420,7 @@ where
             Inbound::Block(lwcid, response) => {
                 use hash_map::Entry::*;
 
+                #[allow(unreachable_patterns)]
                 match self.stream_requests.entry(lwcid) {
                     Vacant(_) => {
                         // TODO: log the bogus response
@@ -443,7 +447,6 @@ where
                     Some(StreamRequest::Blocks(mut chan, ..)) => {
                         chan.close().unwrap();
                     }
-                    _ => (),
                 };
             }
             _ => {}

--- a/network-ntt/src/lib.rs
+++ b/network-ntt/src/lib.rs
@@ -6,5 +6,8 @@
 
 extern crate protocol_tokio as protocol;
 
+#[macro_use]
+extern crate futures;
+
 pub mod client;
 pub mod server;

--- a/protocol-tokio/src/lib.rs
+++ b/protocol-tokio/src/lib.rs
@@ -19,5 +19,6 @@ pub mod protocol;
 
 pub use self::protocol::{
     Accepting, AcceptingError, Connecting, ConnectingError, Connection, Inbound, InboundError,
-    InboundStream, Message, MessageType, Outbound, OutboundError, OutboundSink, Response,
+    InboundStream, Message, MessageType, Outbound, OutboundError, OutboundSink, ProtocolBlock,
+    ProtocolBlockDate, ProtocolBlockId, ProtocolHeader, ProtocolTransactionId, Response,
 };

--- a/protocol-tokio/src/lib.rs
+++ b/protocol-tokio/src/lib.rs
@@ -18,7 +18,8 @@ pub mod network_transport;
 pub mod protocol;
 
 pub use self::protocol::{
-    Accepting, AcceptingError, Connecting, ConnectingError, Connection, Inbound, InboundError,
-    InboundStream, Message, MessageType, Outbound, OutboundError, OutboundSink, ProtocolBlock,
-    ProtocolBlockDate, ProtocolBlockId, ProtocolHeader, ProtocolTransactionId, Response,
+    Accepting, AcceptingError, CloseLightConnection, Connecting, ConnectingError, Connection,
+    Inbound, InboundError, InboundStream, Message, MessageType, NewLightConnection, Outbound,
+    OutboundError, OutboundSink, ProtocolBlock, ProtocolBlockDate, ProtocolBlockId, ProtocolHeader,
+    ProtocolTransactionId, Response,
 };

--- a/protocol-tokio/src/network_transport/event.rs
+++ b/protocol-tokio/src/network_transport/event.rs
@@ -28,6 +28,12 @@ impl LightWeightConnectionId {
     }
 }
 
+impl fmt::Display for LightWeightConnectionId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 ///
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
 pub enum ControlHeader {

--- a/protocol-tokio/src/protocol/accepting.rs
+++ b/protocol-tokio/src/protocol/accepting.rs
@@ -10,7 +10,10 @@ use cbor_event::de::Deserializer;
 use chain_core::property;
 use std::{self, fmt, io::Cursor, vec};
 
-use super::{nt, Connection, Handshake, Message, NodeId};
+use super::{
+    chain_bounds::{ProtocolBlock, ProtocolBlockId, ProtocolHeader, ProtocolTransactionId},
+    nt, Connection, Handshake, Message, NodeId,
+};
 
 enum AcceptingState<T, B: property::Block, Tx: property::TransactionId> {
     NtAccepting(nt::Accepting<T>),
@@ -43,20 +46,13 @@ impl<T: AsyncRead + AsyncWrite, B: property::Block, Tx: property::TransactionId>
     }
 }
 
-impl<
-        T: AsyncRead + AsyncWrite,
-        B: property::Block + property::HasHeader,
-        Tx: property::TransactionId,
-    > Future for Accepting<T, B, Tx>
+impl<T, B, Tx> Future for Accepting<T, B, Tx>
 where
-    B: cbor_event::Deserialize,
-    B: cbor_event::Serialize,
-    <B as property::Block>::Id: cbor_event::Deserialize,
-    <B as property::Block>::Id: cbor_event::Serialize,
-    B::Header: cbor_event::Deserialize,
-    B::Header: cbor_event::Serialize,
-    Tx: cbor_event::Deserialize,
-    Tx: cbor_event::Serialize,
+    T: AsyncRead + AsyncWrite,
+    B: ProtocolBlock,
+    Tx: ProtocolTransactionId,
+    <B as property::Block>::Id: ProtocolBlockId,
+    <B as property::HasHeader>::Header: ProtocolHeader,
 {
     type Item = Connection<T, B, Tx>;
     type Error = AcceptingError;

--- a/protocol-tokio/src/protocol/chain_bounds.rs
+++ b/protocol-tokio/src/protocol/chain_bounds.rs
@@ -22,12 +22,13 @@ where
 
 /// Traits required for the blockchain header payloads used by the protocol.
 pub trait ProtocolHeader:
-    property::Header + cbor_event::Deserialize + cbor_event::Serialize
+    property::Header + cbor_event::Deserialize + cbor_event::Serialize + Debug
 {
 }
 
 impl<T> ProtocolHeader for T
 where
+    T: Debug,
     T: property::Header,
     T: cbor_event::Deserialize + cbor_event::Serialize,
     <T as property::Header>::Id: ProtocolBlockId,

--- a/protocol-tokio/src/protocol/chain_bounds.rs
+++ b/protocol-tokio/src/protocol/chain_bounds.rs
@@ -1,0 +1,67 @@
+use chain_core::property;
+
+use std::fmt::Debug;
+
+/// Traits required for the blockchain block payloads used by the protocol.
+pub trait ProtocolBlock:
+    property::Block + property::HasHeader + cbor_event::Deserialize + cbor_event::Serialize + Debug
+{
+}
+
+impl<T> ProtocolBlock for T
+where
+    T: Debug,
+    T: property::Block,
+    T: property::HasHeader,
+    T: cbor_event::Deserialize + cbor_event::Serialize,
+    <T as property::Block>::Id: ProtocolBlockId,
+    <T as property::Block>::Date: ProtocolBlockDate,
+    <T as property::HasHeader>::Header: ProtocolHeader,
+{
+}
+
+/// Traits required for the blockchain header payloads used by the protocol.
+pub trait ProtocolHeader:
+    property::Header + cbor_event::Deserialize + cbor_event::Serialize
+{
+}
+
+impl<T> ProtocolHeader for T
+where
+    T: property::Header,
+    T: cbor_event::Deserialize + cbor_event::Serialize,
+    <T as property::Header>::Id: ProtocolBlockId,
+    <T as property::Header>::Date: ProtocolBlockDate,
+{
+}
+
+/// Traits required for the block id values used by the protocol.
+pub trait ProtocolBlockId:
+    property::BlockId + cbor_event::Deserialize + cbor_event::Serialize + Debug
+{
+}
+
+impl<T> ProtocolBlockId for T
+where
+    T: property::BlockId + Debug,
+    T: cbor_event::Deserialize + cbor_event::Serialize,
+{
+}
+
+/// Traits required for the block date values used by the protocol.
+pub trait ProtocolBlockDate: property::BlockDate + Debug {}
+
+impl<T> ProtocolBlockDate for T where T: property::BlockDate + Debug {}
+
+/// Traits required for the transaction id values used by the protocol.
+pub trait ProtocolTransactionId:
+    property::TransactionId + cbor_event::Deserialize + cbor_event::Serialize + Debug
+{
+}
+
+impl<T> ProtocolTransactionId for T
+where
+    T: property::TransactionId + Debug,
+    T: cbor_event::Deserialize + cbor_event::Serialize,
+{
+}

--- a/protocol-tokio/src/protocol/codec/message.rs
+++ b/protocol-tokio/src/protocol/codec/message.rs
@@ -8,8 +8,8 @@ use cbor_event::{
 };
 
 use super::super::{
-    nt,
     chain_bounds::{ProtocolBlock, ProtocolTransactionId},
+    nt,
 };
 use super::NodeId;
 use chain_core::property;

--- a/protocol-tokio/src/protocol/codec/message.rs
+++ b/protocol-tokio/src/protocol/codec/message.rs
@@ -7,7 +7,10 @@ use cbor_event::{
     se::{self, Serializer},
 };
 
-use super::super::nt;
+use super::super::{
+    nt,
+    chain_bounds::{ProtocolBlock, ProtocolTransactionId},
+};
 use super::NodeId;
 use chain_core::property;
 
@@ -73,7 +76,7 @@ impl de::Deserialize for MessageType {
 pub type KeepAlive = bool;
 
 #[derive(Clone, Debug)]
-pub enum Message<B: property::Block + property::HasHeader, Tx: property::TransactionId> {
+pub enum Message<B: ProtocolBlock, Tx: ProtocolTransactionId> {
     CreateLightWeightConnectionId(nt::LightWeightConnectionId),
     CloseConnection(nt::LightWeightConnectionId),
     CloseEndPoint(nt::LightWeightConnectionId),
@@ -102,16 +105,12 @@ pub enum Message<B: property::Block + property::HasHeader, Tx: property::Transac
     Subscribe(nt::LightWeightConnectionId, KeepAlive),
 }
 
-impl<B: property::Block + property::HasHeader, Tx: property::TransactionId> Message<B, Tx>
+impl<B, Tx> Message<B, Tx>
 where
-    <B as property::Block>::Id: cbor_event::Deserialize,
-    <B as property::Block>::Id: cbor_event::Serialize,
-    B: cbor_event::Deserialize,
-    B: cbor_event::Serialize,
-    B::Header: cbor_event::Deserialize,
-    B::Header: cbor_event::Serialize,
-    Tx: cbor_event::Serialize,
-    Tx: cbor_event::Deserialize,
+    B: ProtocolBlock,
+    <B as property::Block>::Id: se::Serialize + de::Deserialize,
+    <B as property::HasHeader>::Header: se::Serialize + de::Deserialize,
+    Tx: ProtocolTransactionId,
 {
     pub fn to_nt_event(self) -> nt::Event {
         use self::nt::{ControlHeader::*, Event::*};
@@ -181,7 +180,7 @@ where
     }
 }
 
-fn decode_node_ack_or_syn<B: property::Block + property::HasHeader, Tx: property::TransactionId>(
+fn decode_node_ack_or_syn<B: ProtocolBlock, Tx: ProtocolTransactionId>(
     lwcid: nt::LightWeightConnectionId,
     bytes: &Bytes,
 ) -> Option<Message<B, Tx>> {

--- a/protocol-tokio/src/protocol/codec/node_id.rs
+++ b/protocol-tokio/src/protocol/codec/node_id.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{fmt, ops::Deref};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NodeId(u64);
@@ -23,5 +23,11 @@ impl Deref for NodeId {
     type Target = u64;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl fmt::Display for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
     }
 }

--- a/protocol-tokio/src/protocol/connecting.rs
+++ b/protocol-tokio/src/protocol/connecting.rs
@@ -12,7 +12,10 @@ use tokio_io::{AsyncRead, AsyncWrite};
 
 use cbor_event::{self, de::Deserializer};
 
-use super::{nt, Connection, Handshake, Message, NodeId, ProtocolMagic};
+use super::{
+    chain_bounds::{ProtocolBlock, ProtocolBlockId, ProtocolHeader, ProtocolTransactionId},
+    nt, Connection, Handshake, Message, NodeId, ProtocolMagic,
+};
 
 use std::fmt;
 
@@ -49,20 +52,13 @@ impl<T: AsyncRead + AsyncWrite, B: property::Block, Tx: property::TransactionId>
     }
 }
 
-impl<
-        T: AsyncRead + AsyncWrite,
-        B: property::Block + property::HasHeader,
-        Tx: property::TransactionId,
-    > Future for Connecting<T, B, Tx>
+impl<T, B, Tx> Future for Connecting<T, B, Tx>
 where
-    B: cbor_event::Deserialize,
-    B: cbor_event::Serialize,
-    <B as property::Block>::Id: cbor_event::Deserialize,
-    <B as property::Block>::Id: cbor_event::Serialize,
-    B::Header: cbor_event::Deserialize,
-    B::Header: cbor_event::Serialize,
-    Tx: cbor_event::Deserialize,
-    Tx: cbor_event::Serialize,
+    T: AsyncRead + AsyncWrite,
+    B: ProtocolBlock,
+    Tx: ProtocolTransactionId,
+    <B as property::Block>::Id: ProtocolBlockId,
+    <B as property::HasHeader>::Header: ProtocolHeader,
 {
     type Item = Connection<T, B, Tx>;
     type Error = ConnectingError;

--- a/protocol-tokio/src/protocol/inbound_stream.rs
+++ b/protocol-tokio/src/protocol/inbound_stream.rs
@@ -1,5 +1,5 @@
 use super::{
-    chain_bounds::{ProtocolBlock, ProtocolTransactionId},
+    chain_bounds::{ProtocolBlock, ProtocolBlockId, ProtocolHeader, ProtocolTransactionId},
     nt, ConnectionState, KeepAlive, LightWeightConnectionState, Message, NodeId, Response,
 };
 use super::{BlockHeaders, GetBlockHeaders, GetBlocks};
@@ -134,8 +134,8 @@ where
     T: AsyncRead,
     B: ProtocolBlock,
     Tx: ProtocolTransactionId,
-    <B as property::Block>::Id: cbor_event::Serialize + cbor_event::Deserialize,
-    <B as property::HasHeader>::Header: cbor_event::Serialize + cbor_event::Deserialize,
+    <B as property::Block>::Id: ProtocolBlockId,
+    <B as property::HasHeader>::Header: ProtocolHeader,
 {
     type Item = Inbound<B, Tx>;
     type Error = InboundError;

--- a/protocol-tokio/src/protocol/mod.rs
+++ b/protocol-tokio/src/protocol/mod.rs
@@ -25,7 +25,9 @@ pub use self::codec::{
 };
 pub use self::connecting::{Connecting, ConnectingError};
 pub use self::inbound_stream::{Inbound, InboundError, InboundStream};
-pub use self::outbound_sink::{Outbound, OutboundError, OutboundSink};
+pub use self::outbound_sink::{
+    CloseLightConnection, NewLightConnection, Outbound, OutboundError, OutboundSink,
+};
 
 use std::marker::PhantomData;
 
@@ -82,8 +84,8 @@ where
     T: AsyncRead + AsyncWrite,
     B: ProtocolBlock,
     Tx: ProtocolTransactionId,
-    <B as property::Block>::Id: cbor_event::Serialize + cbor_event::Deserialize,
-    <B as property::HasHeader>::Header: cbor_event::Serialize + cbor_event::Deserialize,
+    <B as property::Block>::Id: ProtocolBlockId,
+    <B as property::HasHeader>::Header: ProtocolHeader,
 {
     fn new(connection: nt::Connection<T>) -> Self {
         Connection {

--- a/protocol-tokio/src/protocol/mod.rs
+++ b/protocol-tokio/src/protocol/mod.rs
@@ -1,4 +1,5 @@
 mod accepting;
+mod chain_bounds;
 mod codec;
 mod connecting;
 mod inbound_stream;
@@ -17,6 +18,7 @@ use std::{
 use tokio_io::{AsyncRead, AsyncWrite};
 
 pub use self::accepting::{Accepting, AcceptingError};
+pub use self::chain_bounds::*;
 pub use self::codec::{
     BlockHeaders, GetBlockHeaders, GetBlocks, HandlerSpec, HandlerSpecs, Handshake, KeepAlive,
     Message, MessageType, NodeId, ProtocolMagic, Response,
@@ -24,6 +26,7 @@ pub use self::codec::{
 pub use self::connecting::{Connecting, ConnectingError};
 pub use self::inbound_stream::{Inbound, InboundError, InboundStream};
 pub use self::outbound_sink::{Outbound, OutboundError, OutboundSink};
+
 use std::marker::PhantomData;
 
 /// the connection state, shared between the `ConnectionStream` and the `ConnectionSink`.
@@ -68,17 +71,19 @@ impl ConnectionState {
 ///
 /// Once established call `split` to get the inbound stream
 /// and the outbound sink and starts processing queries
-pub struct Connection<T, B: property::Block, Tx: property::TransactionId> {
+pub struct Connection<T, B, Tx> {
     connection: nt::Connection<T>,
     state: Arc<Mutex<ConnectionState>>,
     phantoms: PhantomData<(B, Tx)>,
 }
 
-impl<
-        T: AsyncRead + AsyncWrite,
-        B: property::Block + property::HasHeader,
-        Tx: property::TransactionId,
-    > Connection<T, B, Tx>
+impl<T, B, Tx> Connection<T, B, Tx>
+where
+    T: AsyncRead + AsyncWrite,
+    B: ProtocolBlock,
+    Tx: ProtocolTransactionId,
+    <B as property::Block>::Id: cbor_event::Serialize + cbor_event::Deserialize,
+    <B as property::HasHeader>::Header: cbor_event::Serialize + cbor_event::Deserialize,
 {
     fn new(connection: nt::Connection<T>) -> Self {
         Connection {
@@ -107,17 +112,7 @@ impl<
         Accepting::new(inner)
     }
 
-    pub fn split(self) -> (OutboundSink<T, B, Tx>, InboundStream<T, B, Tx>)
-    where
-        B::Header: cbor_event::Serialize,
-        B::Header: cbor_event::Deserialize,
-        <B as property::Block>::Id: cbor_event::Serialize,
-        <B as property::Block>::Id: cbor_event::Deserialize,
-        B: cbor_event::Serialize,
-        B: cbor_event::Deserialize,
-        Tx: cbor_event::Serialize,
-        Tx: cbor_event::Deserialize,
-    {
+    pub fn split(self) -> (OutboundSink<T, B, Tx>, InboundStream<T, B, Tx>) {
         let state = self.state;
         let (sink, stream) = self.connection.split();
 

--- a/protocol-tokio/src/protocol/outbound_sink.rs
+++ b/protocol-tokio/src/protocol/outbound_sink.rs
@@ -202,6 +202,18 @@ where
             state,
         }
     }
+
+    pub fn connection_id(&self) -> nt::LightWeightConnectionId {
+        self.lwcid
+    }
+
+    pub fn get_mut(&mut self) -> &mut OutboundSink<T, B, Tx> {
+        use self::CreationState::*;
+        match &mut self.state {
+            CreatingConnectionId(send) => send.get_mut(),
+            CreatingNodeId(send) => send.get_mut(),
+        }
+    }
 }
 
 enum CreationState<T, B, Tx>
@@ -274,6 +286,10 @@ where
     fn new(sink: OutboundSink<T, B, Tx>, lwcid: nt::LightWeightConnectionId) -> Self {
         let send = sink.send(Message::CloseConnection(lwcid));
         CloseLightConnection { lwcid, send }
+    }
+
+    pub fn get_mut(&mut self) -> &mut OutboundSink<T, B, Tx> {
+        self.send.get_mut()
     }
 }
 

--- a/protocol-tokio/src/protocol/outbound_sink.rs
+++ b/protocol-tokio/src/protocol/outbound_sink.rs
@@ -10,7 +10,7 @@ use futures::{sink, stream::SplitSink};
 use tokio_io::AsyncWrite;
 
 use std::{
-    io,
+    error, fmt, io,
     marker::PhantomData,
     sync::{Arc, Mutex},
 };
@@ -30,6 +30,28 @@ impl From<()> for OutboundError {
 impl From<io::Error> for OutboundError {
     fn from(e: io::Error) -> Self {
         OutboundError::IoError(e)
+    }
+}
+
+impl fmt::Display for OutboundError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use OutboundError::*;
+
+        match self {
+            IoError(_) => write!(f, "I/O error"),
+            Unknown => write!(f, "unknown error"),
+        }
+    }
+}
+
+impl error::Error for OutboundError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        use OutboundError::*;
+
+        match self {
+            IoError(e) => Some(e),
+            Unknown => None,
+        }
     }
 }
 


### PR DESCRIPTION
A client connection is represented by an explicit `Connection` type that implements `Future`.

Get rid of a monster generic future type and combinators holding together the asynchronous parts of a client connection. It should be easier to debug and maintain the protocol interactions in the explicitly coded state machine.