### PR TITLE
Mockchain delegation certificates

### DIFF
--- a/cardano/src/block/block.rs
+++ b/cardano/src/block/block.rs
@@ -361,11 +361,11 @@ impl chain_core::property::Deserialize for Block {
 }
 
 impl chain_core::property::HasTransaction for Block {
-    type Transactions = [TxAux];
-    fn transactions(&self) -> &Self::Transactions {
+    type Transaction = TxAux;
+    fn transactions<'a>(&'a self) -> Box<Iterator<Item = &Self::Transaction> + 'a> {
         match self {
-            Block::BoundaryBlock(_) => &[],
-            Block::MainBlock(blk) => &blk.body.tx,
+            Block::BoundaryBlock(_) => Box::new([].iter()),
+            Block::MainBlock(blk) => Box::new(blk.body.tx.iter()),
         }
     }
 }

--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -147,13 +147,11 @@ pub trait Transaction: Serialize + Deserialize {
 /// * certificate registrations
 /// * ...
 pub trait HasTransaction {
-    /// An iterable collection of transactions provided by the block.
-    /// A reference to the `Transactions` type must be convertible to an
-    /// iterator returning references to transaction objects.
-    type Transactions: ?Sized;
+    /// The type of transactions in this block.
+    type Transaction;
 
-    /// Returns a reference that can be used to iterate over transactions in the block.
-    fn transactions(&self) -> &Self::Transactions;
+    /// Returns an iterator over the transactions in the block.
+    fn transactions<'a>(&'a self) -> Box<Iterator<Item = &Self::Transaction> + 'a>;
 }
 
 /// Updates type needs to implement this feature so we can easily

--- a/chain-impl-mockchain/Cargo.toml
+++ b/chain-impl-mockchain/Cargo.toml
@@ -17,6 +17,8 @@ quickcheck = { version = "0.8" }
 chain-core = { path = "../chain-core" }
 chain-addr = { path = "../chain-addr" }
 rand = "0.6"
+num-traits = "0.2"
+num-derive = "0.2"
 
 [dependencies.cardano]
 path = "../cardano"

--- a/chain-impl-mockchain/src/block.rs
+++ b/chain-impl-mockchain/src/block.rs
@@ -1,7 +1,7 @@
 //! Representation of the block in the mockchain.
+use crate::certificate;
 use crate::key::{Hash, PrivateKey, PublicKey, Signature, Signed};
 use crate::transaction::*;
-use crate::certificate;
 use chain_core::property;
 
 pub use crate::date::{BlockDate, BlockDateParseError};
@@ -231,9 +231,7 @@ impl property::Deserialize for Block {
             contents: Vec::with_capacity(num_messages),
         };
         for _ in 0..num_messages {
-            block
-                .contents
-                .push(Message::deserialize(&mut codec)?);
+            block.contents.push(Message::deserialize(&mut codec)?);
         }
 
         Ok(block)
@@ -292,7 +290,7 @@ impl property::HasTransaction for Block {
     fn transactions<'a>(&'a self) -> Box<Iterator<Item = &SignedTransaction> + 'a> {
         Box::new(self.contents.iter().filter_map(|msg| match msg {
             Message::Transaction(tx) => Some(tx),
-            _ => None
+            _ => None,
         }))
     }
 }
@@ -352,21 +350,19 @@ impl property::Deserialize for Message {
         use chain_core::packer::*;
         let mut codec = Codec::from(reader);
         match codec.get_u8()? {
-            TAG_TRANSACTION => Ok(Message::Transaction(
-                SignedTransaction::deserialize(&mut codec)?,
-            )),
-            TAG_STAKE_KEY_REGISTRATION => Ok(Message::StakeKeyRegistration(
-                Signed::deserialize(&mut codec)?,
-            )),
+            TAG_TRANSACTION => Ok(Message::Transaction(SignedTransaction::deserialize(
+                &mut codec,
+            )?)),
+            TAG_STAKE_KEY_REGISTRATION => Ok(Message::StakeKeyRegistration(Signed::deserialize(
+                &mut codec,
+            )?)),
             TAG_STAKE_KEY_DEREGISTRATION => Ok(Message::StakeKeyDeregistration(
                 Signed::deserialize(&mut codec)?,
             )),
-            TAG_STAKE_DELEGATION => Ok(Message::StakeDelegation(Signed::deserialize(
+            TAG_STAKE_DELEGATION => Ok(Message::StakeDelegation(Signed::deserialize(&mut codec)?)),
+            TAG_STAKE_POOL_REGISTRATION => Ok(Message::StakePoolRegistration(Signed::deserialize(
                 &mut codec,
             )?)),
-            TAG_STAKE_POOL_REGISTRATION => Ok(Message::StakePoolRegistration(
-                Signed::deserialize(&mut codec)?,
-            )),
             TAG_STAKE_POOL_RETIREMENT => Ok(Message::StakePoolRetirement(Signed::deserialize(
                 &mut codec,
             )?)),

--- a/chain-impl-mockchain/src/block.rs
+++ b/chain-impl-mockchain/src/block.rs
@@ -14,7 +14,7 @@ pub struct Block {
     pub slot_id: BlockDate,
     pub parent_hash: Hash,
 
-    pub messages: Vec<Message>,
+    pub contents: Vec<Message>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -159,8 +159,8 @@ impl property::Serialize for Block {
         codec.put_u64(self.slot_id.epoch)?;
         codec.put_u64(self.slot_id.slot_id)?;
         codec.write_all(self.parent_hash.as_ref())?;
-        codec.put_u16(self.messages.len() as u16)?;
-        for t in self.messages.iter() {
+        codec.put_u16(self.contents.len() as u16)?;
+        for t in self.contents.iter() {
             t.serialize(&mut codec)?;
         }
 
@@ -228,11 +228,11 @@ impl property::Deserialize for Block {
         let mut block = Block {
             slot_id: date,
             parent_hash: hash,
-            messages: Vec::with_capacity(num_messages),
+            contents: Vec::with_capacity(num_messages),
         };
         for _ in 0..num_messages {
             block
-                .messages
+                .contents
                 .push(Message::deserialize(&mut codec)?);
         }
 
@@ -290,7 +290,7 @@ impl property::Deserialize for SignedBlockSummary {
 impl property::HasTransaction for Block {
     type Transaction = SignedTransaction;
     fn transactions<'a>(&'a self) -> Box<Iterator<Item = &SignedTransaction> + 'a> {
-        Box::new(self.messages.iter().filter_map(|msg| match msg {
+        Box::new(self.contents.iter().filter_map(|msg| match msg {
             Message::Transaction(tx) => Some(tx),
             _ => None
         }))
@@ -424,7 +424,7 @@ mod test {
             Block {
                 slot_id: Arbitrary::arbitrary(g),
                 parent_hash: Arbitrary::arbitrary(g),
-                messages: Arbitrary::arbitrary(g),
+                contents: Arbitrary::arbitrary(g),
             }
         }
     }

--- a/chain-impl-mockchain/src/certificate.rs
+++ b/chain-impl-mockchain/src/certificate.rs
@@ -1,5 +1,5 @@
-use crate::key::*;
 use crate::block::Message;
+use crate::key::*;
 use chain_core::property;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/chain-impl-mockchain/src/certificate.rs
+++ b/chain-impl-mockchain/src/certificate.rs
@@ -1,0 +1,321 @@
+use crate::key::*;
+use chain_core::property;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Certificate {
+    StakeKeyRegistration(SignedStakeKeyRegistration),
+    //StakeKeyDeregistration(...),
+    StakePoolRegistration(SignedStakePoolRegistration),
+    StakePoolRetirement(SignedStakePoolRetirement),
+}
+
+pub const TAG_STAKE_KEY_REGISTRATION: u8 = 1;
+pub const TAG_STAKE_POOL_REGISTRATION: u8 = 3;
+pub const TAG_STAKE_POOL_RETIREMENT: u8 = 5;
+
+impl property::Serialize for Certificate {
+    type Error = std::io::Error;
+    fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
+        use chain_core::packer::*;
+        let mut codec = Codec::from(writer);
+        match self {
+            Certificate::StakeKeyRegistration(signed_reg) => {
+                codec.put_u8(TAG_STAKE_KEY_REGISTRATION)?;
+                signed_reg.serialize(&mut codec)
+            }
+            Certificate::StakePoolRegistration(signed_reg) => {
+                codec.put_u8(TAG_STAKE_POOL_REGISTRATION)?;
+                signed_reg.serialize(&mut codec)
+            }
+            Certificate::StakePoolRetirement(signed_ret) => {
+                codec.put_u8(TAG_STAKE_POOL_RETIREMENT)?;
+                signed_ret.serialize(&mut codec)
+            }
+        }
+    }
+}
+
+impl property::Deserialize for Certificate {
+    type Error = std::io::Error;
+
+    fn deserialize<R: std::io::BufRead>(reader: R) -> Result<Self, Self::Error> {
+        use chain_core::packer::*;
+        let mut codec = Codec::from(reader);
+        match codec.get_u8()? {
+            TAG_STAKE_POOL_REGISTRATION => {
+                Ok(Certificate::StakePoolRegistration(SignedStakePoolRegistration::deserialize(&mut codec)?))
+            }
+            n => panic!("Unrecognized certificate tag {}.", n) // FIXME: return Error
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignedStakeKeyRegistration {
+    pub data: StakeKeyRegistration,
+    pub sig: Signature,
+}
+
+impl property::Serialize for SignedStakeKeyRegistration {
+    type Error = std::io::Error;
+    fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
+        use chain_core::packer::*;
+        let mut codec = Codec::from(writer);
+        self.data.serialize(&mut codec)?;
+        self.sig.serialize(&mut codec)?;
+        Ok(())
+    }
+}
+
+impl property::Deserialize for SignedStakeKeyRegistration {
+    type Error = std::io::Error;
+
+    fn deserialize<R: std::io::BufRead>(reader: R) -> Result<Self, Self::Error> {
+        use chain_core::packer::*;
+        let mut codec = Codec::from(reader);
+        let data = StakeKeyRegistration::deserialize(&mut codec)?;
+        let sig = Signature::deserialize(&mut codec)?;
+        Ok(SignedStakeKeyRegistration {
+            data,
+            sig,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StakeKeyRegistration {
+    pub stake_public_key: PublicKey,
+}
+
+impl StakeKeyRegistration {
+    pub fn make_certificate(self, private_stake_key: &PrivateKey) -> Certificate {
+        Certificate::StakeKeyRegistration(SignedStakeKeyRegistration {
+            sig: private_stake_key.serialize_and_sign(&self),
+            data: self
+        })
+    }
+}
+
+impl property::Serialize for StakeKeyRegistration {
+    type Error = std::io::Error;
+    fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
+        use chain_core::packer::*;
+        let mut codec = Codec::from(writer);
+        self.stake_public_key.serialize(&mut codec)?;
+        Ok(())
+    }
+}
+
+impl property::Deserialize for StakeKeyRegistration {
+    type Error = std::io::Error;
+
+    fn deserialize<R: std::io::BufRead>(reader: R) -> Result<Self, Self::Error> {
+        use chain_core::packer::*;
+        let mut codec = Codec::from(reader);
+        let stake_public_key = PublicKey::deserialize(&mut codec)?;
+        Ok(StakeKeyRegistration {
+            stake_public_key,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignedStakePoolRegistration {
+    pub data: StakePoolRegistration,
+    //pub owner_sig: Signature,
+    pub pool_sig: Signature,
+}
+
+impl property::Serialize for SignedStakePoolRegistration {
+    type Error = std::io::Error;
+    fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
+        use chain_core::packer::*;
+        let mut codec = Codec::from(writer);
+        self.data.serialize(&mut codec)?;
+        //self.owner_sig.serialize(&mut codec)?;
+        self.pool_sig.serialize(&mut codec)?;
+        Ok(())
+    }
+}
+
+impl property::Deserialize for SignedStakePoolRegistration {
+    type Error = std::io::Error;
+
+    fn deserialize<R: std::io::BufRead>(reader: R) -> Result<Self, Self::Error> {
+        use chain_core::packer::*;
+        let mut codec = Codec::from(reader);
+        let data = StakePoolRegistration::deserialize(&mut codec)?;
+        //let owner_sig = Signature::deserialize(&mut codec)?;
+        let pool_sig = Signature::deserialize(&mut codec)?;
+        Ok(SignedStakePoolRegistration {
+            data,
+            //owner_sig,
+            pool_sig,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StakePoolRegistration {
+    pub pool_public_key: PublicKey,
+    //pub owner: PublicKey, // FIXME: support list of owners
+    // reward sharing params: cost, margin, pledged amount of stake
+    // alternative stake key reward account
+}
+
+impl StakePoolRegistration {
+    /// Create a certificate for this stake pool registration, signed
+    /// by the pool's staking key and the owners.
+    pub fn make_certificate(self, pool_private_key: &PrivateKey) -> Certificate {
+        Certificate::StakePoolRegistration(SignedStakePoolRegistration {
+            pool_sig: pool_private_key.serialize_and_sign(&self),
+            data: self
+        })
+    }
+}
+
+impl property::Serialize for StakePoolRegistration {
+    type Error = std::io::Error;
+    fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
+        use chain_core::packer::*;
+        let mut codec = Codec::from(writer);
+        self.pool_public_key.serialize(&mut codec)?;
+        //self.owner.serialize(&mut codec)?;
+        Ok(())
+    }
+}
+
+impl property::Deserialize for StakePoolRegistration {
+    type Error = std::io::Error;
+
+    fn deserialize<R: std::io::BufRead>(reader: R) -> Result<Self, Self::Error> {
+        use chain_core::packer::*;
+        let mut codec = Codec::from(reader);
+        let pool_public_key = PublicKey::deserialize(&mut codec)?;
+        //let owner = PublicKey::deserialize(&mut codec)?;
+        Ok(StakePoolRegistration {
+            pool_public_key,
+            //owner,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignedStakePoolRetirement {
+    pub data: StakePoolRetirement,
+    pub pool_sig: Signature,
+}
+
+impl property::Serialize for SignedStakePoolRetirement {
+    type Error = std::io::Error;
+    fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
+        use chain_core::packer::*;
+        let mut codec = Codec::from(writer);
+        self.data.serialize(&mut codec)?;
+        self.pool_sig.serialize(&mut codec)?;
+        Ok(())
+    }
+}
+
+impl property::Deserialize for SignedStakePoolRetirement {
+    type Error = std::io::Error;
+
+    fn deserialize<R: std::io::BufRead>(reader: R) -> Result<Self, Self::Error> {
+        use chain_core::packer::*;
+        let mut codec = Codec::from(reader);
+        let data = StakePoolRetirement::deserialize(&mut codec)?;
+        let pool_sig = Signature::deserialize(&mut codec)?;
+        Ok(SignedStakePoolRetirement {
+            data,
+            pool_sig,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StakePoolRetirement {
+    pub pool_public_key: PublicKey,
+    // TODO: add epoch when the retirement will take effect
+}
+
+impl StakePoolRetirement {
+    /// Create a certificate for this stake pool retirement, signed
+    /// by the pool's staking key.
+    pub fn make_certificate(self, pool_private_key: &PrivateKey) -> Certificate {
+        Certificate::StakePoolRetirement(SignedStakePoolRetirement {
+            pool_sig: pool_private_key.serialize_and_sign(&self),
+            data: self
+        })
+    }
+}
+
+impl property::Serialize for StakePoolRetirement {
+    type Error = std::io::Error;
+    fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
+        use chain_core::packer::*;
+        let mut codec = Codec::from(writer);
+        self.pool_public_key.serialize(&mut codec)?;
+        Ok(())
+    }
+}
+
+impl property::Deserialize for StakePoolRetirement {
+    type Error = std::io::Error;
+
+    fn deserialize<R: std::io::BufRead>(reader: R) -> Result<Self, Self::Error> {
+        use chain_core::packer::*;
+        let mut codec = Codec::from(reader);
+        let pool_public_key = PublicKey::deserialize(&mut codec)?;
+        Ok(StakePoolRetirement {
+            pool_public_key,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use quickcheck::{Arbitrary, Gen};
+
+    impl Arbitrary for Certificate {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            Certificate::StakePoolRegistration(Arbitrary::arbitrary(g))
+        }
+    }
+
+    impl Arbitrary for StakePoolRegistration {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            StakePoolRegistration {
+                pool_public_key: Arbitrary::arbitrary(g),
+                //owner: Arbitrary::arbitrary(g),
+            }
+        }
+    }
+
+    impl Arbitrary for SignedStakePoolRegistration {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            SignedStakePoolRegistration {
+                data: Arbitrary::arbitrary(g),
+                //owner_sig: Arbitrary::arbitrary(g),
+                pool_sig: Arbitrary::arbitrary(g),
+            }
+        }
+    }
+
+    impl Arbitrary for StakePoolRetirement {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            StakePoolRetirement {
+                pool_public_key: Arbitrary::arbitrary(g),
+            }
+        }
+    }
+
+    impl Arbitrary for SignedStakePoolRetirement {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            SignedStakePoolRetirement {
+                data: Arbitrary::arbitrary(g),
+                pool_sig: Arbitrary::arbitrary(g),
+            }
+        }
+    }
+}

--- a/chain-impl-mockchain/src/certificate.rs
+++ b/chain-impl-mockchain/src/certificate.rs
@@ -53,22 +53,22 @@ impl property::Deserialize for Certificate {
         use chain_core::packer::*;
         let mut codec = Codec::from(reader);
         match codec.get_u8()? {
-            TAG_STAKE_KEY_REGISTRATION => {
-                Ok(Certificate::StakeKeyRegistration(Signed::deserialize(&mut codec)?))
-            }
-            TAG_STAKE_KEY_DEREGISTRATION => {
-                Ok(Certificate::StakeKeyDeregistration(Signed::deserialize(&mut codec)?))
-            }
-            TAG_STAKE_DELEGATION => {
-                Ok(Certificate::StakeDelegation(Signed::deserialize(&mut codec)?))
-            }
-            TAG_STAKE_POOL_REGISTRATION => {
-                Ok(Certificate::StakePoolRegistration(Signed::deserialize(&mut codec)?))
-            }
-            TAG_STAKE_POOL_RETIREMENT => {
-                Ok(Certificate::StakePoolRetirement(Signed::deserialize(&mut codec)?))
-            }
-            n => panic!("Unrecognized certificate tag {}.", n) // FIXME: return Error
+            TAG_STAKE_KEY_REGISTRATION => Ok(Certificate::StakeKeyRegistration(
+                Signed::deserialize(&mut codec)?,
+            )),
+            TAG_STAKE_KEY_DEREGISTRATION => Ok(Certificate::StakeKeyDeregistration(
+                Signed::deserialize(&mut codec)?,
+            )),
+            TAG_STAKE_DELEGATION => Ok(Certificate::StakeDelegation(Signed::deserialize(
+                &mut codec,
+            )?)),
+            TAG_STAKE_POOL_REGISTRATION => Ok(Certificate::StakePoolRegistration(
+                Signed::deserialize(&mut codec)?,
+            )),
+            TAG_STAKE_POOL_RETIREMENT => Ok(Certificate::StakePoolRetirement(Signed::deserialize(
+                &mut codec,
+            )?)),
+            n => panic!("Unrecognized certificate tag {}.", n), // FIXME: return Error
         }
     }
 }
@@ -79,7 +79,10 @@ pub struct Signed<T> {
     pub sig: Signature,
 }
 
-impl<T: property::Serialize> property::Serialize for Signed<T> where std::io::Error: From<T::Error> {
+impl<T: property::Serialize> property::Serialize for Signed<T>
+where
+    std::io::Error: From<T::Error>,
+{
     type Error = std::io::Error;
     fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
         use chain_core::packer::*;
@@ -90,7 +93,10 @@ impl<T: property::Serialize> property::Serialize for Signed<T> where std::io::Er
     }
 }
 
-impl<T: property::Deserialize> property::Deserialize for Signed<T> where std::io::Error: From<T::Error> {
+impl<T: property::Deserialize> property::Deserialize for Signed<T>
+where
+    std::io::Error: From<T::Error>,
+{
     type Error = std::io::Error;
 
     fn deserialize<R: std::io::BufRead>(reader: R) -> Result<Self, Self::Error> {
@@ -112,7 +118,7 @@ impl StakeKeyRegistration {
     pub fn make_certificate(self, stake_private_key: &PrivateKey) -> Certificate {
         Certificate::StakeKeyRegistration(Signed {
             sig: stake_private_key.serialize_and_sign(&self),
-            data: self
+            data: self,
         })
     }
 }
@@ -148,7 +154,7 @@ impl StakeKeyDeregistration {
     pub fn make_certificate(self, stake_private_key: &PrivateKey) -> Certificate {
         Certificate::StakeKeyDeregistration(Signed {
             sig: stake_private_key.serialize_and_sign(&self),
-            data: self
+            data: self,
         })
     }
 }
@@ -187,7 +193,7 @@ impl StakeDelegation {
         // be included in the witness." - why?
         Certificate::StakeDelegation(Signed {
             sig: stake_private_key.serialize_and_sign(&self),
-            data: self
+            data: self,
         })
     }
 }
@@ -230,7 +236,7 @@ impl StakePoolRegistration {
     pub fn make_certificate(self, pool_private_key: &PrivateKey) -> Certificate {
         Certificate::StakePoolRegistration(Signed {
             sig: pool_private_key.serialize_and_sign(&self),
-            data: self
+            data: self,
         })
     }
 }
@@ -271,7 +277,7 @@ impl StakePoolRetirement {
     pub fn make_certificate(self, pool_private_key: &PrivateKey) -> Certificate {
         Certificate::StakePoolRetirement(Signed {
             sig: pool_private_key.serialize_and_sign(&self),
-            data: self
+            data: self,
         })
     }
 }

--- a/chain-impl-mockchain/src/certificate.rs
+++ b/chain-impl-mockchain/src/certificate.rs
@@ -74,42 +74,6 @@ impl property::Deserialize for Certificate {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Signed<T> {
-    pub data: T,
-    pub sig: Signature,
-}
-
-impl<T: property::Serialize> property::Serialize for Signed<T>
-where
-    std::io::Error: From<T::Error>,
-{
-    type Error = std::io::Error;
-    fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
-        use chain_core::packer::*;
-        let mut codec = Codec::from(writer);
-        self.data.serialize(&mut codec)?;
-        self.sig.serialize(&mut codec)?;
-        Ok(())
-    }
-}
-
-impl<T: property::Deserialize> property::Deserialize for Signed<T>
-where
-    std::io::Error: From<T::Error>,
-{
-    type Error = std::io::Error;
-
-    fn deserialize<R: std::io::BufRead>(reader: R) -> Result<Self, Self::Error> {
-        use chain_core::packer::*;
-        let mut codec = Codec::from(reader);
-        Ok(Signed {
-            data: T::deserialize(&mut codec)?,
-            sig: Signature::deserialize(&mut codec)?,
-        })
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StakeKeyRegistration {
     pub stake_public_key: PublicKey,
 }

--- a/chain-impl-mockchain/src/date.rs
+++ b/chain-impl-mockchain/src/date.rs
@@ -15,7 +15,10 @@ pub const EPOCH_DURATION: u64 = 100; // FIXME: support dynamic epoch durations?
 
 impl BlockDate {
     pub fn first() -> BlockDate {
-        BlockDate { epoch: 0, slot_id: 0 }
+        BlockDate {
+            epoch: 0,
+            slot_id: 0,
+        }
     }
 
     /// Get the slot following this one.

--- a/chain-impl-mockchain/src/date.rs
+++ b/chain-impl-mockchain/src/date.rs
@@ -11,6 +11,30 @@ pub struct BlockDate {
     pub slot_id: u64,
 }
 
+pub const EPOCH_DURATION: u64 = 100; // FIXME: support dynamic epoch durations?
+
+impl BlockDate {
+    pub fn first() -> BlockDate {
+        BlockDate { epoch: 0, slot_id: 0 }
+    }
+
+    /// Get the slot following this one.
+    pub fn next(&self) -> BlockDate {
+        assert!(self.slot_id < EPOCH_DURATION);
+        if self.slot_id + 1 == EPOCH_DURATION {
+            BlockDate {
+                epoch: self.epoch + 1,
+                slot_id: 0,
+            }
+        } else {
+            BlockDate {
+                epoch: self.epoch,
+                slot_id: self.slot_id + 1,
+            }
+        }
+    }
+}
+
 impl property::BlockDate for BlockDate {
     fn from_epoch_slot_id(epoch: u64, slot_id: u64) -> Self {
         BlockDate {

--- a/chain-impl-mockchain/src/environment.rs
+++ b/chain-impl-mockchain/src/environment.rs
@@ -14,9 +14,9 @@ use crate::update::TransactionsDiff;
 
 /// Helper structure that keeps the ledger together with key-pairs
 /// that participate in communication. By having such type it's
-/// possible to perform and genarate new cryptographically signed
-/// operations and verify them, without requiring user to mess with
-/// keys on it's own.
+/// possible to perform and generate new cryptographically signed
+/// operations and verify them, without requiring users to mess with
+/// keys on their own.
 pub struct Environment {
     ledger: Ledger,
     gen: StdGen<rand::rngs::ThreadRng>,
@@ -162,6 +162,7 @@ impl testing::GenerateTransaction<SignedTransaction> for Environment {
                 .map(|(i, _)| i.clone())
                 .collect(),
             outputs: outputs,
+            certificates: vec![],
         };
         let tx_id = tx.id();
         let mut witnesses = Vec::with_capacity(tx.inputs.len());

--- a/chain-impl-mockchain/src/environment.rs
+++ b/chain-impl-mockchain/src/environment.rs
@@ -162,7 +162,6 @@ impl testing::GenerateTransaction<SignedTransaction> for Environment {
                 .map(|(i, _)| i.clone())
                 .collect(),
             outputs: outputs,
-            certificates: vec![],
         };
         let tx_id = tx.id();
         let mut witnesses = Vec::with_capacity(tx.inputs.len());

--- a/chain-impl-mockchain/src/key.rs
+++ b/chain-impl-mockchain/src/key.rs
@@ -22,7 +22,11 @@ impl PublicKey {
     }
 
     /// Convenience function to verify a serialize object.
-    pub fn serialize_and_verify<T: property::Serialize>(&self, t: &T, signature: &Signature) -> bool {
+    pub fn serialize_and_verify<T: property::Serialize>(
+        &self,
+        t: &T,
+        signature: &Signature,
+    ) -> bool {
         let mut codec = chain_core::packer::Codec::from(vec![]);
         t.serialize(&mut codec).unwrap();
         self.verify(&codec.into_inner(), signature)

--- a/chain-impl-mockchain/src/key.rs
+++ b/chain-impl-mockchain/src/key.rs
@@ -16,8 +16,16 @@ impl PublicKey {
     pub fn from_bytes(bytes: [u8; crypto::PUBLICKEY_SIZE]) -> Self {
         PublicKey(crypto::PublicKey::from_bytes(bytes))
     }
+
     pub fn from_hex(string: &str) -> Result<Self, cardano::redeem::Error> {
         Ok(PublicKey(crypto::PublicKey::from_hex(string)?))
+    }
+
+    /// Convenience function to verify a serialize object.
+    pub fn serialize_and_verify<T: property::Serialize>(&self, t: &T, signature: &Signature) -> bool {
+        let mut codec = chain_core::packer::Codec::from(vec![]);
+        t.serialize(&mut codec).unwrap();
+        self.verify(&codec.into_inner(), signature)
     }
 }
 
@@ -34,8 +42,16 @@ impl PrivateKey {
     pub fn normalize_bytes(xprv: [u8; crypto::PRIVATEKEY_SIZE]) -> Self {
         PrivateKey(crypto::PrivateKey::normalize_bytes(xprv))
     }
+
     pub fn from_hex(input: &str) -> Result<Self, cardano::redeem::Error> {
         Ok(PrivateKey(crypto::PrivateKey::from_hex(&input)?))
+    }
+
+    /// Convenience function to sign a serialize object.
+    pub fn serialize_and_sign<T: property::Serialize>(&self, t: &T) -> Signature {
+        let mut codec = chain_core::packer::Codec::from(vec![]);
+        t.serialize(&mut codec).unwrap();
+        self.sign(&codec.into_inner())
     }
 }
 

--- a/chain-impl-mockchain/src/key.rs
+++ b/chain-impl-mockchain/src/key.rs
@@ -83,6 +83,43 @@ impl Signature {
     }
 }
 
+/// A serializable type T with a signature.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Signed<T> {
+    pub data: T,
+    pub sig: Signature,
+}
+
+impl<T: property::Serialize> property::Serialize for Signed<T>
+where
+    std::io::Error: From<T::Error>,
+{
+    type Error = std::io::Error;
+    fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
+        use chain_core::packer::*;
+        let mut codec = Codec::from(writer);
+        self.data.serialize(&mut codec)?;
+        self.sig.serialize(&mut codec)?;
+        Ok(())
+    }
+}
+
+impl<T: property::Deserialize> property::Deserialize for Signed<T>
+where
+    std::io::Error: From<T::Error>,
+{
+    type Error = std::io::Error;
+
+    fn deserialize<R: std::io::BufRead>(reader: R) -> Result<Self, Self::Error> {
+        use chain_core::packer::*;
+        let mut codec = Codec::from(reader);
+        Ok(Signed {
+            data: T::deserialize(&mut codec)?,
+            sig: Signature::deserialize(&mut codec)?,
+        })
+    }
+}
+
 /// Hash that is used as an address of the various components.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Hash(hash::Blake2b256);

--- a/chain-impl-mockchain/src/ledger.rs
+++ b/chain-impl-mockchain/src/ledger.rs
@@ -163,7 +163,6 @@ pub mod test {
         let tx = Transaction {
             inputs: vec![utxo0],
             outputs: vec![Output(user1_address, Value(1))],
-            certificates: vec![],
         };
         let signed_tx = SignedTransaction {
             transaction: tx,
@@ -197,7 +196,6 @@ pub mod test {
         let tx = crate::transaction::Transaction {
             inputs: vec![utxo0],
             outputs: vec![output0.clone()],
-            certificates: vec![],
         };
         let (pk1, _) = make_key(1);
         let witness = Witness::new(&tx.id(), &pk1);
@@ -233,7 +231,6 @@ pub mod test {
         let tx = crate::transaction::Transaction {
             inputs: vec![utxo0],
             outputs: vec![output0],
-            certificates: vec![],
         };
         let witness = Witness::new(&tx.id(), &pk1);
         let signed_tx = SignedTransaction {
@@ -246,5 +243,4 @@ pub mod test {
         )
     }
 
-    // FIXME: add certificate tests
 }

--- a/chain-impl-mockchain/src/ledger.rs
+++ b/chain-impl-mockchain/src/ledger.rs
@@ -45,6 +45,9 @@ impl property::Ledger for Ledger {
 
         let mut diff = <Self::Update as property::Update>::empty();
         let id = transaction.id();
+
+        // FIXME: check that inputs is non-empty?
+
         // 0. verify that number of signatures matches number of
         // transactions
         if transaction.transaction.inputs.len() > transaction.witnesses.len() {
@@ -117,7 +120,7 @@ impl property::Ledger for Ledger {
 }
 
 #[cfg(test)]
-mod test {
+pub mod test {
 
     use super::*;
     use crate::key::PrivateKey;
@@ -133,7 +136,7 @@ mod test {
         }
     }
 
-    fn make_key(u: u8) -> (PrivateKey, Address) {
+    pub fn make_key(u: u8) -> (PrivateKey, Address) {
         let sk1 = PrivateKey::normalize_bytes([u; crypto::PRIVATEKEY_SIZE]);
         let pk1 = sk1.public();
         let user_address = Address(Discrimination::Production, Kind::Single(pk1.0));
@@ -160,6 +163,7 @@ mod test {
         let tx = Transaction {
             inputs: vec![utxo0],
             outputs: vec![Output(user1_address, Value(1))],
+            certificates: vec![],
         };
         let signed_tx = SignedTransaction {
             transaction: tx,
@@ -193,6 +197,7 @@ mod test {
         let tx = crate::transaction::Transaction {
             inputs: vec![utxo0],
             outputs: vec![output0.clone()],
+            certificates: vec![],
         };
         let (pk1, _) = make_key(1);
         let witness = Witness::new(&tx.id(), &pk1);
@@ -228,6 +233,7 @@ mod test {
         let tx = crate::transaction::Transaction {
             inputs: vec![utxo0],
             outputs: vec![output0],
+            certificates: vec![],
         };
         let witness = Witness::new(&tx.id(), &pk1);
         let signed_tx = SignedTransaction {
@@ -239,4 +245,6 @@ mod test {
             ledger.diff_transaction(&signed_tx)
         )
     }
+
+    // FIXME: add certificate tests
 }

--- a/chain-impl-mockchain/src/lib.rs
+++ b/chain-impl-mockchain/src/lib.rs
@@ -12,6 +12,7 @@ pub mod key;
 pub mod leadership;
 pub mod ledger;
 pub mod setting;
+pub mod certificate;
 pub mod transaction;
 pub mod update;
 

--- a/chain-impl-mockchain/src/lib.rs
+++ b/chain-impl-mockchain/src/lib.rs
@@ -4,6 +4,7 @@ extern crate quickcheck;
 extern crate chain_addr;
 
 pub mod block;
+pub mod certificate;
 mod date;
 #[cfg(test)]
 pub mod environment;
@@ -12,7 +13,6 @@ pub mod key;
 pub mod leadership;
 pub mod ledger;
 pub mod setting;
-pub mod certificate;
 pub mod transaction;
 pub mod update;
 

--- a/chain-impl-mockchain/src/transaction.rs
+++ b/chain-impl-mockchain/src/transaction.rs
@@ -1,7 +1,7 @@
+use super::certificate::Certificate;
 use crate::key::*;
 use chain_addr::Address;
 use chain_core::property;
-use super::certificate::{Certificate};
 
 /// Unspent transaction value.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/chain-impl-mockchain/src/transaction.rs
+++ b/chain-impl-mockchain/src/transaction.rs
@@ -131,6 +131,8 @@ impl property::Serialize for SignedTransaction {
         let mut codec = Codec::from(writer);
         codec.put_u8(0x01)?;
 
+        assert_eq!(self.transaction.inputs.len(), self.witnesses.len());
+
         // encode the transaction body
         self.transaction.serialize(&mut codec)?;
 

--- a/chain-impl-mockchain/src/update.rs
+++ b/chain-impl-mockchain/src/update.rs
@@ -36,12 +36,14 @@ pub enum ValueDiff<T> {
     Replace(T, T),
 }
 
-impl<T> ValueDiff<T> where T: Eq {
-
+impl<T> ValueDiff<T>
+where
+    T: Eq,
+{
     pub fn check(&self, dest: &T) -> bool {
         match &self {
             ValueDiff::None => true,
-            ValueDiff::Replace(old, _) => dest == old
+            ValueDiff::Replace(old, _) => dest == old,
         }
     }
 

--- a/chain-impl-mockchain/src/update.rs
+++ b/chain-impl-mockchain/src/update.rs
@@ -79,27 +79,28 @@ pub struct LeaderSelectionDiff {
 }
 
 impl<T: PartialEq> ValueDiff<T> {
-    fn inverse(self) -> Self {
+    pub fn inverse(self) -> Self {
         match self {
             ValueDiff::None => ValueDiff::None,
             ValueDiff::Replace(a, b) => ValueDiff::Replace(b, a),
         }
     }
 
-    fn union(&mut self, other: Self) -> &mut Self {
+    pub fn union(&mut self, other: Self) -> &mut Self {
         match (std::mem::replace(self, ValueDiff::None), other) {
             (ValueDiff::None, ValueDiff::None) => {}
             (ValueDiff::None, ValueDiff::Replace(c, d)) => {
-                std::mem::replace(self, ValueDiff::Replace(c, d));
+                *self = ValueDiff::Replace(c, d);
             }
             (ValueDiff::Replace(a, b), ValueDiff::None) => {
-                std::mem::replace(self, ValueDiff::Replace(a, b));
+                *self = ValueDiff::Replace(a, b);
             }
             (ValueDiff::Replace(a, _b), ValueDiff::Replace(_c, d)) => {
+                //assert!(b == c); // FIXME
                 if a == d {
-                    std::mem::replace(self, ValueDiff::None);
+                    *self = ValueDiff::None;
                 } else {
-                    std::mem::replace(self, ValueDiff::Replace(a, d));
+                    *self = ValueDiff::Replace(a, d);
                 }
             }
         }

--- a/chain-impl-mockchain/src/update.rs
+++ b/chain-impl-mockchain/src/update.rs
@@ -36,6 +36,32 @@ pub enum ValueDiff<T> {
     Replace(T, T),
 }
 
+impl<T> ValueDiff<T> where T: Eq {
+
+    pub fn check(&self, dest: &T) -> bool {
+        match &self {
+            ValueDiff::None => true,
+            ValueDiff::Replace(old, _) => dest == old
+        }
+    }
+
+    /// Apply this diff to a destination, overwriting it with the new
+    /// value if it is equal to the expected old value. Panic if the
+    /// old value is unexpected. (The caller is expected to use
+    /// `check` first to validate the expected state of all values in
+    /// an update first. We panic to ensure that we don't end up in a
+    /// half-update state.)
+    pub fn apply_to(self, dest: &mut T) {
+        match self {
+            ValueDiff::None => {}
+            ValueDiff::Replace(old, new) => {
+                assert!(dest == &old);
+                *dest = new;
+            }
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct SettingsDiff {
     pub block_id: ValueDiff<Hash>,

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ nixpkgs ? fetchTarball channel:nixos-unstable
+{ nixpkgs ? fetchTarball https://github.com/NixOS/nixpkgs/archive/7fff567ee99c1f343ecdd82fef2e35fb6f50e423.tar.gz
 , pkgs ? import nixpkgs {}
 }:
 


### PR DESCRIPTION
This extends the mockchain's `Transaction` type with a vector of `Certificate`s, which are signed messages for registering/deregistering a stake key, registering/retiring a stake pool, and delegating from a stake key to a stake pool. They're in `Transaction` to ensure UTxO-based protection against replays and to allow fees/deposits if needed.

Handling of these messages to update the ledger/leadership will be a subsequent PR.