### PR TITLE
Update to latest changes in tower-h2

### DIFF
--- a/network-grpc/Cargo.toml
+++ b/network-grpc/Cargo.toml
@@ -19,14 +19,14 @@ h2 = "0.1.11"
 prost = "0.4"
 prost-derive = "0.4"
 tokio = "0.1"
-tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
+tower-service = { git = "https://github.com/tower-rs/tower" }
 tower-util = { git = "https://github.com/tower-rs/tower" }
 
 [dependencies.tower-grpc]
 git = "https://github.com/tower-rs/tower-grpc"
-rev = "01defa830fc72cc38aba3b2035558e03eed8da4b"
+rev = "d28ba3814e899441252e0b850929e94b7d3ce030"
 
 [build-dependencies.tower-grpc-build]
 git = "https://github.com/tower-rs/tower-grpc"
-rev = "01defa830fc72cc38aba3b2035558e03eed8da4b"
+rev = "d28ba3814e899441252e0b850929e94b7d3ce030"

--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -11,6 +11,7 @@ use tokio::io;
 use tokio::prelude::*;
 use tower_grpc::{BoxBody, Request, Streaming};
 use tower_h2::client::{Background, Connect, ConnectError, Connection};
+use tower_service::Service;
 use tower_util::MakeService;
 
 use std::{
@@ -81,7 +82,7 @@ where
 {
     pub fn connect<P>(peer: P, executor: E) -> impl Future<Item = Self, Error = Error>
     where
-        P: tokio_connect::Connect<Connected = S, Error = io::Error> + 'static,
+        P: Service<(), Response = S, Error = io::Error> + 'static,
     {
         let mut make_client = Connect::new(peer, Default::default(), executor);
         make_client

--- a/network-grpc/src/lib.rs
+++ b/network-grpc/src/lib.rs
@@ -2,7 +2,6 @@ extern crate chain_core;
 extern crate prost;
 #[macro_use]
 extern crate prost_derive;
-extern crate tokio_connect;
 extern crate tower_grpc;
 extern crate tower_h2;
 extern crate tower_util;

--- a/network-grpc/src/peer.rs
+++ b/network-grpc/src/peer.rs
@@ -1,6 +1,8 @@
+use futures::Poll;
 use tokio::net::tcp::{self, TcpStream};
 #[cfg(unix)]
 use tokio::net::unix::{self, UnixStream};
+use tower_service::Service;
 
 use std::{io, net::SocketAddr};
 
@@ -43,23 +45,31 @@ impl UnixPeer {
     }
 }
 
-impl tokio_connect::Connect for TcpPeer {
-    type Connected = TcpStream;
+impl Service<()> for TcpPeer {
+    type Response = TcpStream;
     type Error = io::Error;
     type Future = tcp::ConnectFuture;
 
-    fn connect(&self) -> tcp::ConnectFuture {
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        Ok(().into())
+    }
+
+    fn call(&mut self, _: ()) -> Self::Future {
         TcpStream::connect(self.addr())
     }
 }
 
 #[cfg(unix)]
-impl tokio_connect::Connect for UnixPeer {
-    type Connected = UnixStream;
+impl Service<()> for UnixPeer {
+    type Response = UnixStream;
     type Error = io::Error;
     type Future = unix::ConnectFuture;
 
-    fn connect(&self) -> unix::ConnectFuture {
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        Ok(().into())
+    }
+
+    fn call(&mut self, _: ()) -> Self::Future {
         UnixStream::connect(self.path())
     }
 }


### PR DESCRIPTION
Updated to the latest revision of tower-grpc master as well.
Unfortunately, it's not possible to pin tower-h2 and other tower dependencies to known good revisions in `Cargo.toml` because of issues with transitive dependencies.