### PR TITLE
Merge HeaderService into BlockService

### DIFF
--- a/network-core/src/server.rs
+++ b/network-core/src/server.rs
@@ -12,21 +12,12 @@ pub trait Node {
     /// The implementation of the block service.
     type BlockService: block::BlockService;
 
-    /// The implementation of the header service.
-    type HeaderService: block::HeaderService<
-        HeaderId = <Self::BlockService as block::BlockService>::BlockId,
-    >;
-
     /// The implementation of the transaction service.
     type TransactionService: transaction::TransactionService;
 
     /// Instantiates the block service,
     /// if supported by this node.
     fn block_service(&self) -> Option<Self::BlockService>;
-
-    /// Instantiates the header service,
-    /// if supported by this node.
-    fn header_service(&self) -> Option<Self::HeaderService>;
 
     /// Instantiates the transaction service,
     /// if supported by this node.

--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -2,14 +2,14 @@
 
 use crate::error::Code as ErrorCode;
 
-use chain_core::property::{Block, BlockDate, BlockId, Deserialize, Header, Serialize};
+use chain_core::property::{Block, BlockDate, BlockId, Deserialize, HasHeader, Header, Serialize};
 
 use futures::prelude::*;
 
 use std::{error, fmt};
 
 /// Interface for the blockchain node service implementation responsible for
-/// providing access to blocks.
+/// providing access to block data.
 pub trait BlockService {
     /// The block identifier type for the blockchain.
     type BlockId: BlockId + Serialize + Deserialize;
@@ -18,7 +18,10 @@ pub trait BlockService {
     type BlockDate: BlockDate + ToString;
 
     /// The type representing a block on the blockchain.
-    type Block: Block<Id = Self::BlockId, Date = Self::BlockDate>;
+    type Block: Block<Id = Self::BlockId, Date = Self::BlockDate> + HasHeader<Header = Self::Header>;
+
+    /// The type representing metadata header of a block.
+    type Header: Header<Id = Self::BlockId, Date = Self::BlockDate> + Serialize;
 
     /// The type of asynchronous futures returned by method `tip`.
     ///
@@ -27,62 +30,53 @@ pub trait BlockService {
     type TipFuture: Future<Item = (Self::BlockId, Self::BlockDate), Error = BlockError>;
 
     /// The type of an asynchronous stream that provides blocks in
-    /// response to method `get_blocks`.
-    type GetBlocksStream: Stream<Item = Self::Block, Error = BlockError>;
+    /// response to `pull_blocks_to_*` methods.
+    type PullBlocksStream: Stream<Item = Self::Block, Error = BlockError>;
 
-    /// The type of asynchronous futures returned by method `get_blocks`.
+    /// The type of asynchronous futures returned by `pull_blocks_to_*` methods.
     ///
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a server-streamed response.
-    type GetBlocksFuture: Future<Item = Self::GetBlocksStream, Error = BlockError>;
+    type PullBlocksFuture: Future<Item = Self::PullBlocksStream, Error = BlockError>;
 
-    /// The type of an asynchronous stream that provides blocks in
-    /// response to method `pull_blocks_to_tip`.
-    type PullBlocksToTipStream: Stream<Item = Self::Block, Error = BlockError>;
+    /// The type of an asynchronous stream that provides block headers in
+    /// response to `pull_headers_to_*` methods.
+    type PullHeadersStream: Stream<Item = Self::Header, Error = BlockError>;
 
-    /// The type of asynchronous futures returned by method `pull_blocks_to_tip`.
+    /// The type of asynchronous futures returned by `pull_headers_to*` methods.
     ///
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a server-streamed response.
-    type PullBlocksFuture: Future<Item = Self::PullBlocksToTipStream, Error = BlockError>;
+    type PullHeadersFuture: Future<Item = Self::PullHeadersStream, Error = BlockError>;
 
+    /// Request the current blockchain tip.
+    /// The returned future resolves to the tip of the blockchain
+    /// accepted by this node.
     fn tip(&mut self) -> Self::TipFuture;
-    fn pull_blocks_to_tip(&mut self, from: &[Self::BlockId]) -> Self::PullBlocksFuture;
 
+    /// Get blocks, walking forward in a range between either of the given
+    /// starting points, and the ending point.
     fn pull_blocks_to(
         &mut self,
         from: &[Self::BlockId],
         to: &Self::BlockId,
     ) -> Self::PullBlocksFuture;
-}
 
-/// Interface for the blockchain node service implementation responsible for
-/// providing access to block headers.
-pub trait HeaderService {
-    /// The type representing metadata header of a block.
-    type Header: Header + Serialize;
+    // Stream blocks from either of the given starting points
+    // to the server's tip.
+    fn pull_blocks_to_tip(&mut self, from: &[Self::BlockId]) -> Self::PullBlocksFuture;
 
-    type HeaderId: BlockId;
-
-    /// The type of an asynchronous stream that provides block headers in
-    /// response to method `get_headers`.
-    type GetHeadersStream: Stream<Item = Self::Header, Error = BlockError>;
-
-    /// The type of asynchronous futures returned by method `get_headers`.
-    ///
-    /// The future resolves to a stream that will be used by the protocol
-    /// implementation to produce a server-streamed response.
-    type GetHeadersFuture: Future<Item = Self::GetHeadersStream, Error = BlockError>;
-
-    /// Get block headers between two dates.
-    fn block_headers(
+    /// Get block headers, walking forward in a range between any of the given
+    /// starting points, and the ending point.
+    fn pull_headers_to(
         &mut self,
-        from: &[Self::HeaderId],
-        to: &Self::HeaderId,
-    ) -> Self::GetHeadersFuture;
+        from: &[Self::BlockId],
+        to: &Self::BlockId,
+    ) -> Self::PullHeadersFuture;
 
-    // Stream blocks to the provided tip.
-    fn block_headers_to_tip(&mut self, from: &[Self::HeaderId]) -> Self::GetHeadersFuture;
+    // Stream block headers from either of the given starting points
+    // to the server's tip.
+    fn pull_headers_to_tip(&mut self, from: &[Self::BlockId]) -> Self::PullHeadersFuture;
 }
 
 /// Represents errors that can be returned by the block service.

--- a/network-grpc/src/server.rs
+++ b/network-grpc/src/server.rs
@@ -24,7 +24,6 @@ pub struct Server<T, E>
 where
     T: Node,
     T::BlockService: Clone,
-    T::HeaderService: Clone,
     T::TransactionService: Clone,
 {
     h2: tower_h2::Server<
@@ -40,7 +39,6 @@ where
     S: AsyncRead + AsyncWrite,
     T: Node,
     T::BlockService: Clone,
-    T::HeaderService: Clone,
     T::TransactionService: Clone,
 {
     h2: tower_h2::server::Connection<
@@ -57,7 +55,6 @@ where
     S: AsyncRead + AsyncWrite,
     T: Node + 'static,
     T::BlockService: Clone,
-    T::HeaderService: Clone,
     T::TransactionService: Clone,
     E: Executor<
         tower_h2::server::Background<
@@ -77,7 +74,6 @@ impl<T, E> Server<T, E>
 where
     T: Node + 'static,
     T::BlockService: Clone,
-    T::HeaderService: Clone,
     T::TransactionService: Clone,
     E: Executor<
             tower_h2::server::Background<
@@ -151,7 +147,6 @@ impl<T> From<H2Error<T>> for Error
 where
     T: Node,
     T::BlockService: Clone,
-    T::HeaderService: Clone,
     T::TransactionService: Clone,
 {
     fn from(err: H2Error<T>) -> Self {

--- a/protocol-tokio/src/protocol/inbound_stream.rs
+++ b/protocol-tokio/src/protocol/inbound_stream.rs
@@ -155,8 +155,8 @@ where
     T: AsyncRead,
     B: ProtocolBlock,
     Tx: ProtocolTransactionId,
-    <B as property::Block>::Id: cbor_event::Serialize + cbor_event::Deserialize,
-    <B as property::HasHeader>::Header: cbor_event::Serialize + cbor_event::Deserialize,
+    <B as property::Block>::Id: ProtocolBlockId,
+    <B as property::HasHeader>::Header: ProtocolHeader,
 {
     pub fn new(stream: SplitStream<nt::Connection<T>>, state: Arc<Mutex<ConnectionState>>) -> Self {
         InboundStream {


### PR DESCRIPTION
As all chains we care about are going to provide some sort of block summary for the network protocol, having a separate `HeaderService` only complicates the code. Merge its functionality into `BlockService`.

Renamed methods for walk-forward retrieval of blocks and headers into `pull_blocks_to` and `pull_headers_to` to reflect their similarity to pull-to-tip-methods. Also mandate that the futures and streams of both kinds of methods is the same, because it also simplifies things internally.