### PR TITLE
network: Added gRPC method SubscribeToBlocks

### DIFF
--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -49,6 +49,16 @@ pub trait BlockService {
     /// implementation to produce a server-streamed response.
     type PullHeadersFuture: Future<Item = Self::PullHeadersStream, Error = BlockError>;
 
+    /// The type of an asynchronous stream that retrieves headers of new
+    /// blocks as they are created.
+    type BlockSubscription: Stream<Item = Self::Header, Error = BlockError>;
+
+    /// The type of asynchronous futures returned by method `subscribe`.
+    ///
+    /// The future resolves to a stream that will be used by the protocol
+    /// implementation to produce a server-streamed response.
+    type BlockSubscriptionFuture: Future<Item = Self::BlockSubscription, Error = BlockError>;
+
     /// Request the current blockchain tip.
     /// The returned future resolves to the tip of the blockchain
     /// accepted by this node.
@@ -77,6 +87,10 @@ pub trait BlockService {
     // Stream block headers from either of the given starting points
     // to the server's tip.
     fn pull_headers_to_tip(&mut self, from: &[Self::BlockId]) -> Self::PullHeadersFuture;
+
+    // Returns a future that resolves to an asynchronous subscription stream
+    // that can be used to notify of newly created blocks.
+    fn subscribe(&mut self) -> Self::BlockSubscriptionFuture;
 }
 
 /// Represents errors that can be returned by the block service.

--- a/network-grpc/src/service.rs
+++ b/network-grpc/src/service.rs
@@ -294,6 +294,14 @@ where
         Self::PullBlocksToTipStream,
         <<T as Node>::BlockService as BlockService>::PullBlocksFuture,
     >;
+    type SubscribeToBlocksStream = ResponseStream<
+        gen::node::Header,
+        <<T as Node>::BlockService as BlockService>::BlockSubscription,
+    >;
+    type SubscribeToBlocksFuture = ResponseFuture<
+        Self::SubscribeToBlocksStream,
+        <<T as Node>::BlockService as BlockService>::BlockSubscriptionFuture,
+    >;
     type ProposeTransactionsFuture = ResponseFuture<
         gen::node::ProposeTransactionsResponse,
         <<T as Node>::TransactionService as TransactionService>::ProposeTransactionsFuture,
@@ -322,6 +330,13 @@ where
         &mut self,
         _request: Request<gen::node::GetBlocksRequest>,
     ) -> Self::GetHeadersFuture {
+        unimplemented!()
+    }
+
+    fn subscribe_to_blocks(
+        &mut self,
+        _req: Request<gen::node::BlockSubscriptionRequest>,
+    ) -> Self::SubscribeToBlocksFuture {
         unimplemented!()
     }
 

--- a/network-proto/node.proto
+++ b/network-proto/node.proto
@@ -46,6 +46,9 @@ message Header {
     bytes content = 1;
 }
 
+// Request message for method SubscribeToBlocks.
+message BlockSubscriptionRequest {}
+
 // Request message for method ProposeTransactions.
 message ProposeTransactionsRequest {
     // Identifiers of transactions to check.
@@ -89,6 +92,11 @@ service Node {
     rpc GetHeaders (GetBlocksRequest) returns (stream Header) {
         option idempotency_level = NO_SIDE_EFFECTS;
     }
+
+    // Establishes a subscription stream to receive information on new
+    // blocks created or accepted by the peer.
+    rpc SubscribeToBlocks (BlockSubscriptionRequest) returns (stream Header);
+
     rpc PullBlocksToTip (PullBlocksToTipRequest) returns (stream Block);
     rpc ProposeTransactions (ProposeTransactionsRequest) returns (ProposeTransactionsResponse);
     rpc RecordTransaction (RecordTransactionRequest) returns (RecordTransactionResponse);


### PR DESCRIPTION
Designed the subscription API for the block service and its
network-core counterpart.