### PR TITLE
LeaderSelection: is_leader_at() -> get_leader_at()

### DIFF
--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -253,6 +253,9 @@ pub trait LeaderSelection {
     /// Leader Selection error type
     type Error: std::error::Error;
 
+    /// Identifier of the leader (e.g. a public key).
+    type LeaderId;
+
     /// given a Block, create an Update diff to see what are the changes
     /// that will come with this new block.
     ///
@@ -268,10 +271,9 @@ pub trait LeaderSelection {
     /// apply the Update to the LeaderSelection
     fn apply(&mut self, update: Self::Update) -> Result<(), Self::Error>;
 
-    /// return if this instance of the LeaderSelection is leader of the
-    /// blockchain at the given date.
-    ///
-    fn is_leader_at(&self, date: <Self::Block as Block>::Date) -> Result<bool, Self::Error>;
+    /// return the ID of the leader of the blockchain at the given
+    /// date.
+    fn get_leader_at(&self, date: <Self::Block as Block>::Date) -> Result<Self::LeaderId, Self::Error>;
 }
 
 /// the settings of the blockchain this is something that can be used to maintain
@@ -295,7 +297,7 @@ pub trait Settings {
     fn tip(&self) -> <Self::Block as Block>::Id;
 
     /// the number of transactions in a block
-    fn max_number_of_transactions_per_block(&self) -> usize;
+    fn max_number_of_transactions_per_block(&self) -> u32;
 }
 
 /// Define that an object can be written to a `Write` object.

--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -273,7 +273,10 @@ pub trait LeaderSelection {
 
     /// return the ID of the leader of the blockchain at the given
     /// date.
-    fn get_leader_at(&self, date: <Self::Block as Block>::Date) -> Result<Self::LeaderId, Self::Error>;
+    fn get_leader_at(
+        &self,
+        date: <Self::Block as Block>::Date,
+    ) -> Result<Self::LeaderId, Self::Error>;
 }
 
 /// the settings of the blockchain this is something that can be used to maintain

--- a/chain-impl-mockchain/src/block.rs
+++ b/chain-impl-mockchain/src/block.rs
@@ -356,22 +356,24 @@ impl property::Deserialize for Message {
         let mut codec = Codec::from(reader);
         let tag = codec.get_u8()?;
         match MessageTag::from_u8(tag) {
-            Some(MessageTag::Transaction) => Ok(Message::Transaction(SignedTransaction::deserialize(
-                &mut codec,
-            )?)),
-            Some(MessageTag::StakeKeyRegistration) => Ok(Message::StakeKeyRegistration(Signed::deserialize(
-                &mut codec,
-            )?)),
+            Some(MessageTag::Transaction) => Ok(Message::Transaction(
+                SignedTransaction::deserialize(&mut codec)?,
+            )),
+            Some(MessageTag::StakeKeyRegistration) => Ok(Message::StakeKeyRegistration(
+                Signed::deserialize(&mut codec)?,
+            )),
             Some(MessageTag::StakeKeyDeregistration) => Ok(Message::StakeKeyDeregistration(
                 Signed::deserialize(&mut codec)?,
             )),
-            Some(MessageTag::StakeDelegation) => Ok(Message::StakeDelegation(Signed::deserialize(&mut codec)?)),
-            Some(MessageTag::StakePoolRegistration) => Ok(Message::StakePoolRegistration(Signed::deserialize(
-                &mut codec,
-            )?)),
-            Some(MessageTag::StakePoolRetirement) => Ok(Message::StakePoolRetirement(Signed::deserialize(
-                &mut codec,
-            )?)),
+            Some(MessageTag::StakeDelegation) => {
+                Ok(Message::StakeDelegation(Signed::deserialize(&mut codec)?))
+            }
+            Some(MessageTag::StakePoolRegistration) => Ok(Message::StakePoolRegistration(
+                Signed::deserialize(&mut codec)?,
+            )),
+            Some(MessageTag::StakePoolRetirement) => Ok(Message::StakePoolRetirement(
+                Signed::deserialize(&mut codec)?,
+            )),
             None => panic!("Unrecognized certificate message tag {}.", tag),
         }
     }

--- a/chain-impl-mockchain/src/leadership/mod.rs
+++ b/chain-impl-mockchain/src/leadership/mod.rs
@@ -11,26 +11,11 @@ pub enum LeaderSelection {
     Genesis,
 }
 
-#[derive(PartialEq, Eq)]
-pub enum IsLeading {
-    Yes,
-    No,
-}
-
-impl From<bool> for IsLeading {
-    fn from(b: bool) -> Self {
-        if b {
-            IsLeading::Yes
-        } else {
-            IsLeading::No
-        }
-    }
-}
-
 impl property::LeaderSelection for LeaderSelection {
     type Update = LeaderSelectionDiff;
     type Block = SignedBlock;
     type Error = Error;
+    type LeaderId = PublicKey;
 
     fn diff(&self, input: &Self::Block) -> Result<Self::Update, Self::Error> {
         let mut update = <Self::Update as property::Update>::empty();
@@ -55,13 +40,13 @@ impl property::LeaderSelection for LeaderSelection {
     }
 
     #[inline]
-    fn is_leader_at(
+    fn get_leader_at(
         &self,
         date: <Self::Block as property::Block>::Date,
-    ) -> Result<bool, Self::Error> {
+    ) -> Result<Self::LeaderId, Self::Error> {
         match self {
             LeaderSelection::BFT(ref bft) => {
-                property::LeaderSelection::is_leader_at(bft, date).map_err(Error::Bft)
+                property::LeaderSelection::get_leader_at(bft, date).map_err(Error::Bft)
             }
             LeaderSelection::Genesis => unimplemented!(),
         }

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -14,7 +14,7 @@ pub struct Version {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Settings {
     pub last_block_id: Hash,
-    pub max_number_of_transactions_per_block: usize,
+    pub max_number_of_transactions_per_block: u32,
 }
 
 #[derive(Debug)]
@@ -67,7 +67,7 @@ impl property::Settings for Settings {
         self.last_block_id.clone()
     }
 
-    fn max_number_of_transactions_per_block(&self) -> usize {
+    fn max_number_of_transactions_per_block(&self) -> u32 {
         self.max_number_of_transactions_per_block
     }
 }


### PR DESCRIPTION
(Extracted from the genesis leadership branch.)

This makes the leader selection independent of the identity of the caller. Presumably the caller knows its own leader ID, so checking whether `leadership.get_leader_at(date) == me` is no harder than calling `leadership.is_leader_at(date)`. But it allows the same leadership to be used by multiple leaders (useful in testing), and ensures that we don't have to store a leader ID in diffs.
    
Also, change `max_number_of_transactions_per_block` from `usize` to `u32` in order not to have platform-dependent types in chain configuration parameters.
