### PR TITLE
chain-core: Add method for_each_transaction to property::HasTransaction

### DIFF
--- a/cardano/src/block/block.rs
+++ b/cardano/src/block/block.rs
@@ -368,6 +368,16 @@ impl chain_core::property::HasTransaction for Block {
             Block::MainBlock(blk) => Box::new(blk.body.tx.iter()),
         }
     }
+
+    fn for_each_transaction<F>(&self, f: F)
+    where
+        F: FnMut(&Self::Transaction),
+    {
+        match self {
+            Block::BoundaryBlock(_) => {}
+            Block::MainBlock(blk) => blk.body.tx.iter().for_each(f),
+        }
+    }
 }
 
 // **************************************************************************

--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -151,7 +151,16 @@ pub trait HasTransaction {
     type Transaction;
 
     /// Returns an iterator over the transactions in the block.
+    ///
+    /// Note that the iterator is dynamically allocated, and the iterator's
+    /// `next` method is invoked via dynamic dispatch. The method
+    /// `for_each_transaction` provides a statically monomorphised
+    /// alternative.
     fn transactions<'a>(&'a self) -> Box<Iterator<Item = &Self::Transaction> + 'a>;
+
+    fn for_each_transaction<F>(&self, f: F)
+    where
+        F: FnMut(&Self::Transaction);
 }
 
 /// Updates type needs to implement this feature so we can easily

--- a/chain-impl-mockchain/src/block.rs
+++ b/chain-impl-mockchain/src/block.rs
@@ -295,12 +295,29 @@ impl property::HasTransaction for Block {
             _ => None,
         }))
     }
+
+    fn for_each_transaction<F>(&self, mut f: F)
+    where
+        F: FnMut(&Self::Transaction),
+    {
+        self.contents.iter().for_each(|msg| match msg {
+            Message::Transaction(tx) => f(tx),
+            _ => {}
+        })
+    }
 }
 
 impl property::HasTransaction for SignedBlock {
     type Transaction = SignedTransaction;
     fn transactions<'a>(&'a self) -> Box<Iterator<Item = &SignedTransaction> + 'a> {
         self.block.transactions()
+    }
+
+    fn for_each_transaction<F>(&self, f: F)
+    where
+        F: FnMut(&Self::Transaction),
+    {
+        self.block.for_each_transaction(f)
     }
 }
 


### PR DESCRIPTION
A statically dispatched alternative to the transactions iterator.