### PR TITLE
Add error cause information to BlockError and TransactionError

### DIFF
--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -120,6 +120,10 @@ impl BlockError {
             cause: Some(cause.into()),
         }
     }
+
+    pub fn code(&self) -> ErrorCode {
+        self.code
+    }
 }
 
 impl error::Error for BlockError {

--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -95,12 +95,45 @@ pub trait BlockService {
 
 /// Represents errors that can be returned by the block service.
 #[derive(Debug)]
-pub struct BlockError(pub ErrorCode);
+pub struct BlockError {
+    code: ErrorCode,
+    cause: Option<Box<dyn error::Error + Send + Sync>>,
+}
 
-impl error::Error for BlockError {}
+impl BlockError {
+    pub fn failed<E>(cause: E) -> Self
+    where
+        E: Into<Box<dyn error::Error + Send + Sync>>,
+    {
+        BlockError {
+            code: ErrorCode::Failed,
+            cause: Some(cause.into()),
+        }
+    }
+
+    pub fn with_code_and_cause<E>(code: ErrorCode, cause: E) -> Self
+    where
+        E: Into<Box<dyn error::Error + Send + Sync>>,
+    {
+        BlockError {
+            code,
+            cause: Some(cause.into()),
+        }
+    }
+}
+
+impl error::Error for BlockError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        if let Some(err) = &self.cause {
+            Some(&**err)
+        } else {
+            None
+        }
+    }
+}
 
 impl fmt::Display for BlockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "block service error: {}", self.0)
+        write!(f, "block service error: {}", self.code)
     }
 }


### PR DESCRIPTION
The errors in many cases should chain source errors from the implementation.