### PR TITLE
chain-storage: Pass blocks by reference

### DIFF
--- a/chain-storage-sqlite/examples/import.rs
+++ b/chain-storage-sqlite/examples/import.rs
@@ -50,7 +50,7 @@ fn main() {
         let (_raw_blk, blk) = res.unwrap();
         let hash = blk.id();
         chain_state.verify_block(&hash, &blk).unwrap();
-        store.put_block(blk).unwrap();
+        store.put_block(&blk).unwrap();
         //if n > 49900 { break; }
         if n % 10000 == 0 {
             println!(".");

--- a/chain-storage-sqlite/src/lib.rs
+++ b/chain-storage-sqlite/src/lib.rs
@@ -123,7 +123,7 @@ where
 {
     type Block = B;
 
-    fn put_block_internal(&mut self, block: B, block_info: BlockInfo<B::Id>) -> Result<(), Error> {
+    fn put_block_internal(&mut self, block: &B, block_info: BlockInfo<B::Id>) -> Result<(), Error> {
         self.do_change();
 
         // FIXME: wrap the next two statements in a transaction

--- a/chain-storage/src/memory.rs
+++ b/chain-storage/src/memory.rs
@@ -31,7 +31,7 @@ where
 {
     type Block = B;
 
-    fn put_block_internal(&mut self, block: B, block_info: BlockInfo<B::Id>) -> Result<(), Error> {
+    fn put_block_internal(&mut self, block: &B, block_info: BlockInfo<B::Id>) -> Result<(), Error> {
         self.blocks.insert(
             block_info.block_hash.clone(),
             (block.serialize_as_vec().unwrap(), block_info),

--- a/chain-storage/src/store.rs
+++ b/chain-storage/src/store.rs
@@ -48,7 +48,7 @@ pub trait BlockStore: std::marker::Sized {
     /// back_links set to ensure O(lg n) seek time in
     /// get_nth_ancestor(), and calls put_block_internal() to do the
     /// actual write.
-    fn put_block(&mut self, block: Self::Block) -> Result<(), Error> {
+    fn put_block(&mut self, block: &Self::Block) -> Result<(), Error> {
         let block_hash = block.id();
 
         if self.block_exists(&block_hash)? {
@@ -96,7 +96,7 @@ pub trait BlockStore: std::marker::Sized {
     /// Write a block and associated info to the store.
     fn put_block_internal(
         &mut self,
-        block: Self::Block,
+        block: &Self::Block,
         block_info: BlockInfo<<Self::Block as Block>::Id>,
     ) -> Result<(), Error>;
 


### PR DESCRIPTION
There is no need to move `Block` values into the storage methods in our implementations, and I think this is true in general: a storage implementation would typically serialize blocks for storage, and a direct in-memory storage should be considered a toy corner case.