### PR TITLE
ChainStore: Eliminate genesis data

### DIFF
--- a/cardano/src/block/types.rs
+++ b/cardano/src/block/types.rs
@@ -103,7 +103,11 @@ impl chain_core::property::Deserialize for HeaderHash {
     }
 }
 
-impl chain_core::property::BlockId for HeaderHash {}
+impl chain_core::property::BlockId for HeaderHash {
+    fn zero() -> HeaderHash {
+        HeaderHash(Blake2b256::from([0; Blake2b256::HASH_SIZE]))
+    }
+}
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
 pub struct BlockVersion {

--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -38,7 +38,11 @@
 use std::{fmt::Debug, hash::Hash};
 
 /// Trait identifying the block identifier type.
-pub trait BlockId: Eq + Ord + Clone + Debug + Hash + Serialize + Deserialize {}
+pub trait BlockId: Eq + Ord + Clone + Debug + Hash + Serialize + Deserialize {
+    /// A special ID used to denote a non-existent block (e.g. the
+    /// parent of the first block).
+    fn zero() -> Self;
+}
 
 /// A trait representing block dates.
 pub trait BlockDate: Eq + Ord + Clone {

--- a/chain-impl-mockchain/src/key.rs
+++ b/chain-impl-mockchain/src/key.rs
@@ -181,7 +181,12 @@ impl property::Deserialize for Hash {
     }
 }
 
-impl property::BlockId for Hash {}
+impl property::BlockId for Hash {
+    fn zero() -> Hash {
+        Hash(hash::Blake2b256::from([0; hash::Blake2b256::HASH_SIZE]))
+    }
+}
+
 impl property::TransactionId for Hash {}
 
 impl AsRef<[u8]> for PrivateKey {

--- a/chain-impl-mockchain/src/leadership/genesis.rs
+++ b/chain-impl-mockchain/src/leadership/genesis.rs
@@ -524,7 +524,7 @@ mod test {
     use chain_core::property::Ledger as L;
     use chain_core::property::Settings as S;
     use chain_core::property::Transaction as T;
-    use chain_core::property::{Deserialize, HasTransaction, Serialize};
+    use chain_core::property::{BlockId, Deserialize, HasTransaction, Serialize};
     use quickcheck::{Arbitrary, StdGen};
     use rand::rngs::{StdRng, ThreadRng};
 
@@ -556,8 +556,6 @@ mod test {
     ) -> TestState {
         let mut g = StdGen::new(rand::thread_rng(), 10);
 
-        let genesis_hash = Hash::hash_bytes("abc".as_bytes());
-
         let bft_leaders: Vec<PrivateKey> =
             (0..10_i32).map(|_| PrivateKey::arbitrary(&mut g)).collect();
 
@@ -572,7 +570,7 @@ mod test {
 
         let ledger = Arc::new(RwLock::new(Ledger::new(initial_utxos)));
 
-        let settings = Arc::new(RwLock::new(Settings::new(genesis_hash)));
+        let settings = Arc::new(RwLock::new(Settings::new()));
         settings.write().unwrap().bootstrap_key_slots_percentage =
             initial_bootstrap_key_slots_percentage;
 
@@ -593,7 +591,7 @@ mod test {
             ledger,
             settings,
             cur_date: BlockDate::first(),
-            prev_hash: genesis_hash.clone(),
+            prev_hash: Hash::zero(),
             faucet_utxo,
             faucet_private_key,
             selected_leaders: HashMap::new(),

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -4,7 +4,7 @@
 use crate::block::Message;
 use crate::key::Hash;
 use crate::update::ValueDiff;
-use chain_core::property;
+use chain_core::property::{self, BlockId};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -95,9 +95,9 @@ pub struct Settings {
 pub const SLOTS_PERCENTAGE_RANGE: u8 = 100;
 
 impl Settings {
-    pub fn new(genesis_hash: Hash) -> Self {
+    pub fn new() -> Self {
         Self {
-            last_block_id: genesis_hash,
+            last_block_id: Hash::zero(),
             max_number_of_transactions_per_block: 100,
             bootstrap_key_slots_percentage: SLOTS_PERCENTAGE_RANGE,
         }

--- a/chain-storage-sqlite/examples/import.rs
+++ b/chain-storage-sqlite/examples/import.rs
@@ -3,7 +3,7 @@ extern crate cardano_storage;
 extern crate chain_storage;
 
 use cardano_storage::StorageConfig;
-use chain_core::property::Block;
+use chain_core::property::{Block, BlockId};
 use chain_storage::store::BlockStore;
 use std::env;
 use std::str::FromStr;
@@ -38,7 +38,7 @@ fn main() {
             .as_bytes(),
     ));
 
-    let mut store = chain_storage_sqlite::SQLiteBlockStore::new(genesis_hash, db_path);
+    let mut store = chain_storage_sqlite::SQLiteBlockStore::new(db_path);
 
     /* Convert a chain using old-school storage to a SQLiteBlockStore. */
     let now = Instant::now();
@@ -116,7 +116,7 @@ fn main() {
     let now = Instant::now();
     let mut n = 0;
     for info in store
-        .iterate_range(&store.get_genesis_hash(), &tip_info.block_hash)
+        .iterate_range(&cardano::block::HeaderHash::zero(), &tip_info.block_hash)
         .unwrap()
     {
         n += 1;
@@ -132,7 +132,7 @@ fn main() {
     let now = Instant::now();
     let mut n = 0;
     for info in store
-        .iterate_range(&store.get_genesis_hash(), &tip_info.block_hash)
+        .iterate_range(&cardano::block::HeaderHash::zero(), &tip_info.block_hash)
         .unwrap()
     {
         let info = info.unwrap();

--- a/chain-storage-sqlite/src/lib.rs
+++ b/chain-storage-sqlite/src/lib.rs
@@ -13,7 +13,6 @@ pub struct SQLiteBlockStore<B>
 where
     B: Block,
 {
-    genesis_hash: B::Id,
     connection: Box<sqlite::Connection>,
 
     // Prepared statements. Note: we currently give these a fake
@@ -35,7 +34,7 @@ impl<B> SQLiteBlockStore<B>
 where
     B: Block,
 {
-    pub fn new(genesis_hash: B::Id, path: &str) -> Self {
+    pub fn new(path: &str) -> Self {
         let connection = Box::new(sqlite::open(path).unwrap());
 
         connection
@@ -69,7 +68,6 @@ where
         };
 
         SQLiteBlockStore {
-            genesis_hash,
             stmt_insert_block: make_statement(&connection, "insert into Blocks (hash, block) values(?, ?)"),
             stmt_insert_block_info: make_statement(&connection, "insert into BlockInfo (hash, depth, parent, fast_distance, fast_hash) values(?, ?, ?, ?, ?)"),
             stmt_get_block: make_statement(&connection, "select block from Blocks where hash = ?"),
@@ -244,9 +242,5 @@ where
             sqlite::State::Done => Ok(None),
             sqlite::State::Row => Ok(Some(blob_to_hash(statement.read::<Vec<u8>>(0).unwrap()))),
         }
-    }
-
-    fn get_genesis_hash(&self) -> B::Id {
-        self.genesis_hash.clone()
     }
 }

--- a/chain-storage/src/memory.rs
+++ b/chain-storage/src/memory.rs
@@ -7,7 +7,6 @@ pub struct MemoryBlockStore<B>
 where
     B: Block,
 {
-    genesis_hash: B::Id,
     blocks: HashMap<B::Id, (Vec<u8>, BlockInfo<B::Id>)>,
     tags: HashMap<String, B::Id>,
 }
@@ -16,9 +15,8 @@ impl<B> MemoryBlockStore<B>
 where
     B: Block,
 {
-    pub fn new(genesis_hash: B::Id) -> Self {
+    pub fn new() -> Self {
         MemoryBlockStore {
-            genesis_hash,
             blocks: HashMap::new(),
             tags: HashMap::new(),
         }
@@ -67,9 +65,5 @@ where
         } else {
             Ok(None)
         }
-    }
-
-    fn get_genesis_hash(&self) -> B::Id {
-        self.genesis_hash.clone()
     }
 }


### PR DESCRIPTION
The first block of the chain must now have a zero parent hash. That is, genesis data (like initial UTXOs) must be stored in the first block, rather than in some external file (like the canonical JSON data used by the current Cardano chain). 

Of course, this requires some special rules for validating the first block (for example that transactions don't need inputs and don't need to be balanced), but that's easier than having a completely different source for genesis data. It also makes fetching a chain self-contained - there is no need to hard-code the genesis data in clients or have them fetch it in some other way.