### PR TITLE
network-grpc: Dropped an explicit dependency on tower-service

### DIFF
--- a/network-grpc/Cargo.toml
+++ b/network-grpc/Cargo.toml
@@ -20,7 +20,6 @@ prost = "0.4"
 prost-derive = "0.4"
 tokio = "0.1"
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
-tower-service = "0.2"
 tower-util = { git = "https://github.com/tower-rs/tower" }
 
 [dependencies.tower-grpc]

--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -9,9 +9,8 @@ use network_core::{
 use futures::future::Executor;
 use tokio::io;
 use tokio::prelude::*;
-use tower_grpc::{BoxBody, Code, Request, Status, Streaming};
+use tower_grpc::{codegen::server::tower::Service, BoxBody, Code, Request, Status, Streaming};
 use tower_h2::client::{Background, Connect, ConnectError, Connection};
-use tower_service::Service;
 use tower_util::MakeService;
 
 use std::{error, fmt, marker::PhantomData};

--- a/network-grpc/src/peer.rs
+++ b/network-grpc/src/peer.rs
@@ -2,7 +2,7 @@ use futures::Poll;
 use tokio::net::tcp::{self, TcpStream};
 #[cfg(unix)]
 use tokio::net::unix::{self, UnixStream};
-use tower_service::Service;
+use tower_grpc::codegen::server::tower::Service;
 
 use std::{io, net::SocketAddr};
 


### PR DESCRIPTION
The patch in toplevel `Cargo.toml` has to stay for the time being.