### PR TITLE
Add Message and MessageId properties

### DIFF
--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -127,6 +127,39 @@ pub trait HasHeader {
     fn header(&self) -> Self::Header;
 }
 
+/// Trait identifying the message identifier type.
+pub trait MessageId: Eq + Hash + Clone + Debug {}
+
+/// A message is some item contained in a block, such as a
+/// transaction, a delegation-related certificate, an update proposal,
+/// and so on. Messages can be serialized (so that they can be
+/// concatenated to form a binary block( and have a unique ID
+/// (typically the hash of their serialization).
+pub trait Message: Serialize + Deserialize {
+    type Id: MessageId;
+
+    /// Return the message's identifier.
+    fn id(&self) -> Self::Id;
+}
+
+/// Accessor to messages within a block
+pub trait HasMessages {
+    /// The type of messages in this block.
+    type Message;
+
+    /// Returns an iterator over the messages in the block.
+    ///
+    /// Note that the iterator is dynamically allocated, and the iterator's
+    /// `next` method is invoked via dynamic dispatch. The method
+    /// `for_each_transaction` provides a statically monomorphised
+    /// alternative.
+    fn messages<'a>(&'a self) -> Box<Iterator<Item = &Self::Message> + 'a>;
+
+    fn for_each_message<F>(&self, f: F)
+    where
+        F: FnMut(&Self::Message);
+}
+
 /// define a transaction within the blockchain. This transaction can be used
 /// for the UTxO model. However it can also be used for any other elements that
 /// the blockchain has (a transaction type to add Stacking Pools and so on...).

--- a/chain-impl-mockchain/src/block/message.rs
+++ b/chain-impl-mockchain/src/block/message.rs
@@ -2,8 +2,14 @@ use chain_core::{packer, property};
 use chain_crypto::Ed25519Extended;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
+use std::mem::size_of;
 
-use crate::{certificate, key::Signed, setting, transaction::SignedTransaction};
+use crate::{
+    certificate,
+    key::{Hash, Signed},
+    setting,
+    transaction::SignedTransaction,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Message {
@@ -32,6 +38,8 @@ enum MessageTag {
     Update = 7,
 }
 
+type MessageSize = u16;
+
 fn serialize_buffered<T, W>(
     codec: packer::Codec<W>,
     tag: MessageTag,
@@ -42,15 +50,19 @@ where
     W: std::io::Write,
 {
     let mut buffered = codec.buffered();
-    let hole = buffered.hole(2)?;
+    let hole = buffered.hole(size_of::<MessageSize>())?;
     buffered.put_u8(tag as u8)?;
     t.serialize(&mut buffered)?;
-    buffered.fill_hole_u16(hole, buffered.buffered_len() as u16 - 2);
+    buffered.fill_hole_u16(
+        hole,
+        (buffered.buffered_len() - size_of::<MessageSize>()) as MessageSize,
+    );
     buffered.into_inner()
 }
 
-impl Message {
-    pub(crate) fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), std::io::Error> {
+impl property::Serialize for Message {
+    type Error = std::io::Error;
+    fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
         use chain_core::packer::*;
         let codec = Codec::from(writer);
         let _codec = match self {
@@ -76,8 +88,10 @@ impl Message {
         };
         Ok(())
     }
+}
 
-    pub(crate) fn deserialize<R: std::io::BufRead>(
+impl Message {
+    pub(crate) fn deserialize_with_size<R: std::io::BufRead>(
         reader: R,
     ) -> Result<(Self, u16), std::io::Error> {
         use chain_core::packer::*;
@@ -104,6 +118,32 @@ impl Message {
                 .map(|msg| (Message::Update(msg), size)),
             None => panic!("Unrecognized certificate message tag {}.", tag),
         }
+    }
+}
+
+impl property::Deserialize for Message {
+    type Error = std::io::Error;
+    fn deserialize<R: std::io::BufRead>(reader: R) -> Result<Self, Self::Error> {
+        Ok(Self::deserialize_with_size(reader)?.0)
+    }
+}
+
+// FIXME: should this be a wrapper type?
+pub type MessageId = Hash;
+
+impl property::Message for Message {
+    type Id = MessageId;
+
+    /// The ID of a message is a hash of its serialization *without* the size.
+    fn id(&self) -> Self::Id {
+        use chain_core::property::Serialize;
+
+        // TODO: we should be able to avoid to serialise the whole message
+        // in memory, using a hasher.
+        let bytes = self
+            .serialize_as_vec()
+            .expect("In memory serialization is expected to work");
+        Hash::hash_bytes(&bytes[size_of::<MessageSize>()..])
     }
 }
 

--- a/chain-impl-mockchain/src/block/mod.rs
+++ b/chain-impl-mockchain/src/block/mod.rs
@@ -6,7 +6,7 @@ use chain_core::property::{self, Serialize};
 use chain_crypto::Verification;
 
 mod header;
-mod message;
+pub mod message;
 
 pub use self::header::{
     BftProof, BftSignature, BlockContentHash, BlockContentSize, BlockId, BlockVersion, Common,

--- a/chain-impl-mockchain/src/key.rs
+++ b/chain-impl-mockchain/src/key.rs
@@ -197,6 +197,7 @@ impl property::BlockId for Hash {
     }
 }
 
+impl property::MessageId for Hash {}
 impl property::TransactionId for Hash {}
 
 impl AsRef<[u8]> for Hash {

--- a/chain-impl-mockchain/src/leadership/genesis.rs
+++ b/chain-impl-mockchain/src/leadership/genesis.rs
@@ -253,6 +253,10 @@ impl GenesisLeaderSelection {
         self.delegation_state
             .get_stake_distribution(&self.ledger.read().unwrap())
     }
+
+    pub fn get_delegation_state(&self) -> &DelegationState {
+        &self.delegation_state
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/chain-impl-mockchain/src/stake.rs
+++ b/chain-impl-mockchain/src/stake.rs
@@ -115,8 +115,8 @@ impl DelegationState {
         }
     }
 
-    pub fn nr_stake_pools(&self) -> usize {
-        self.stake_pools.len()
+    pub fn get_stake_pools(&self) -> &HashMap<StakePoolId, StakePoolInfo> {
+        &self.stake_pools
     }
 
     pub fn stake_pool_exists(&self, pool_id: &StakePoolId) -> bool {

--- a/chain-impl-mockchain/src/transaction.rs
+++ b/chain-impl-mockchain/src/transaction.rs
@@ -60,6 +60,7 @@ impl Witness {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Output(pub Address, pub Value);
 
+// FIXME: should this be a wrapper type?
 pub type TransactionId = Hash;
 
 /// Transaction, transaction maps old unspent tokens into the


### PR DESCRIPTION
This provides traits to model what was already the case in mockchain, namely that blocks consist of a list of "messages", which may be transactions, stake pool registration certificates, and so on.

