### PR TITLE
Implement FromStr for the hash types

### DIFF
--- a/chain-crypto/src/hex.rs
+++ b/chain-crypto/src/hex.rs
@@ -38,17 +38,6 @@ impl fmt::Display for DecodeError {
 
 impl error::Error for DecodeError {}
 
-/// decode the given hexadecimal string
-///
-///  # Example
-///
-/// ```
-/// use cardano::util::hex::{Error, decode};
-///
-/// let example = r"736f6d65206279746573";
-///
-/// assert!(decode(example).is_ok());
-/// ```
 pub fn decode<S: AsRef<[u8]>>(input: S) -> Result<Vec<u8>, DecodeError> {
     decode_bytes(input.as_ref())
 }
@@ -84,3 +73,38 @@ fn decode_bytes(input: &[u8]) -> Result<Vec<u8>, DecodeError> {
     Ok(b)
 }
 
+#[cfg(test)]
+mod tests {
+    fn encode<D: AsRef<[u8]>>(input: D, expected: &str) {
+        let encoded = super::encode(input);
+        assert_eq!(encoded, expected);
+    }
+    fn decode<S: AsRef<[u8]>>(expected: &[u8], input: S) {
+        let decoded = super::decode(input).unwrap();
+        assert_eq!(decoded.as_slice(), expected);
+    }
+
+    #[test]
+    fn test_vector_1() {
+        encode(&[1, 2, 3, 4], "01020304");
+        decode(&[1, 2, 3, 4], "01020304");
+    }
+
+    #[test]
+    fn test_vector_2() {
+        encode(&[0xff, 0x0f, 0xff, 0xff], "ff0fffff");
+        decode(&[0xff, 0x0f, 0xff, 0xff], "ff0fffff");
+    }
+
+    #[test]
+    fn test_bytes() {
+        encode(&[1, 2, 3, 4], "01020304");
+        decode(&[1, 2, 3, 4], b"01020304");
+    }
+
+    #[test]
+    fn test_string() {
+        encode("1234", "31323334");
+        decode(&[1, 2, 3, 4], "01020304");
+    }
+}

--- a/chain-crypto/src/hex.rs
+++ b/chain-crypto/src/hex.rs
@@ -2,7 +2,11 @@
 
 const ALPHABET: &'static [u8] = b"0123456789abcdef";
 
-pub fn encode(input: &[u8]) -> String {
+pub fn encode<D: AsRef<[u8]>>(input: D) -> String {
+    encode_bytes(input.as_ref())
+}
+
+fn encode_bytes(input: &[u8]) -> String {
     let mut v = Vec::with_capacity(input.len() * 2);
     for &byte in input.iter() {
         v.push(ALPHABET[(byte >> 4) as usize]);

--- a/chain-crypto/src/hex.rs
+++ b/chain-crypto/src/hex.rs
@@ -1,5 +1,7 @@
 //! simple implementation of hexadecimal encoding and decoding
 
+use std::{error, fmt};
+
 const ALPHABET: &'static [u8] = b"0123456789abcdef";
 
 pub fn encode<D: AsRef<[u8]>>(input: D) -> String {
@@ -15,3 +17,70 @@ fn encode_bytes(input: &[u8]) -> String {
 
     unsafe { String::from_utf8_unchecked(v) }
 }
+
+/// Errors that may occur during hexadecimal decoding.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum DecodeError {
+    /// A character was encountered is not part of the supported
+    /// hexadecimal alphabet. Contains the index of the faulty byte.
+    InvalidHexChar(usize),
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            DecodeError::InvalidHexChar(idx) => {
+                write!(f, "Non-hexadecimal character at byte index {}", idx)
+            }
+        }
+    }
+}
+
+impl error::Error for DecodeError {}
+
+/// decode the given hexadecimal string
+///
+///  # Example
+///
+/// ```
+/// use cardano::util::hex::{Error, decode};
+///
+/// let example = r"736f6d65206279746573";
+///
+/// assert!(decode(example).is_ok());
+/// ```
+pub fn decode<S: AsRef<[u8]>>(input: S) -> Result<Vec<u8>, DecodeError> {
+    decode_bytes(input.as_ref())
+}
+
+fn decode_bytes(input: &[u8]) -> Result<Vec<u8>, DecodeError> {
+    let mut b = Vec::with_capacity(input.len() / 2);
+    let mut modulus = 0;
+    let mut buf = 0;
+
+    for (idx, byte) in input.iter().enumerate() {
+        buf <<= 4;
+
+        match byte {
+            b'A'...b'F' => buf |= byte - b'A' + 10,
+            b'a'...b'f' => buf |= byte - b'a' + 10,
+            b'0'...b'9' => buf |= byte - b'0',
+            b' ' | b'\r' | b'\n' | b'\t' => {
+                buf >>= 4;
+                continue;
+            }
+            _ => {
+                return Err(DecodeError::InvalidHexChar(idx));
+            }
+        }
+
+        modulus += 1;
+        if modulus == 2 {
+            modulus = 0;
+            b.push(buf);
+        }
+    }
+
+    Ok(b)
+}
+

--- a/chain-crypto/src/lib.rs
+++ b/chain-crypto/src/lib.rs
@@ -13,7 +13,7 @@ extern crate ed25519_bip32;
 extern crate rand_core;
 
 pub mod algorithms;
-mod hash;
+pub mod hash;
 mod hex;
 mod kes;
 mod key;

--- a/chain-impl-mockchain/src/key.rs
+++ b/chain-impl-mockchain/src/key.rs
@@ -7,6 +7,8 @@ use chain_crypto::{
     AsymmetricKey, KeyEvolvingSignatureAlgorithm, SigningAlgorithm, VerificationAlgorithm,
 };
 
+use std::str::FromStr;
+
 pub type SpendingPublicKey = crypto::PublicKey<crypto::Ed25519Extended>;
 pub type SpendingSecretKey = crypto::SecretKey<crypto::Ed25519Extended>;
 pub type SpendingSignature<T> = crypto::Signature<T, crypto::Ed25519Extended>;
@@ -214,6 +216,13 @@ impl From<crypto::Blake2b256> for Hash {
 impl std::fmt::Display for Hash {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for Hash {
+    type Err = crypto::hash::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Hash(crypto::Blake2b256::from_str(s)?))
     }
 }
 


### PR DESCRIPTION
Reinstate the ability to parse hash values from hexadecimal strings, now in chain-crypto.