### PR TITLE
Add bech32 prefixes to crypto keys 

### DIFF
--- a/chain-crypto/Cargo.toml
+++ b/chain-crypto/Cargo.toml
@@ -8,7 +8,6 @@ keywords = [ "Crypto", "VRF", "Ed25519", "MMM" ]
 
 [dependencies]
 cryptoxide = "0.1"
-rand_core = { version = "0.3.0", default-features = false }
 curve25519-dalek = "1"
 sha2 = "^0.8"
 digest = "^0.8"

--- a/chain-crypto/src/algorithms/ed25519.rs
+++ b/chain-crypto/src/algorithms/ed25519.rs
@@ -1,7 +1,7 @@
 use crate::key::{AsymmetricKey, PublicKeyError, SecretKeyError};
 use crate::sign::{SignatureError, SigningAlgorithm, Verification, VerificationAlgorithm};
 use cryptoxide::ed25519;
-use rand_core::{CryptoRng, RngCore};
+use rand::{CryptoRng, RngCore};
 
 use ed25519_bip32::XPub;
 

--- a/chain-crypto/src/algorithms/ed25519.rs
+++ b/chain-crypto/src/algorithms/ed25519.rs
@@ -47,6 +47,9 @@ impl AsymmetricKey for Ed25519 {
     type Secret = Priv;
     type Public = Pub;
 
+    const SECRET_BECH32_HRP: &'static str = "ed25519_secret";
+    const PUBLIC_BECH32_HRP: &'static str = "ed25519_public";
+
     fn generate<T: RngCore + CryptoRng>(mut rng: T) -> Self::Secret {
         let mut priv_bytes = [0u8; ed25519::SEED_LENGTH];
         rng.fill_bytes(&mut priv_bytes);

--- a/chain-crypto/src/algorithms/ed25519_derive.rs
+++ b/chain-crypto/src/algorithms/ed25519_derive.rs
@@ -30,6 +30,9 @@ impl AsymmetricKey for Ed25519Bip32 {
     type Secret = XPrv;
     type Public = XPub;
 
+    const SECRET_BECH32_HRP: &'static str = "ed25519bip32_secret";
+    const PUBLIC_BECH32_HRP: &'static str = "ed25519bip32_public";
+
     fn generate<T: RngCore + CryptoRng>(mut rng: T) -> Self::Secret {
         let mut priv_bytes = [0u8; XPRV_SIZE];
         rng.fill_bytes(&mut priv_bytes);

--- a/chain-crypto/src/algorithms/ed25519_derive.rs
+++ b/chain-crypto/src/algorithms/ed25519_derive.rs
@@ -3,7 +3,7 @@ use crate::sign::{SignatureError, SigningAlgorithm, Verification, VerificationAl
 
 use ed25519_bip32 as i;
 use ed25519_bip32::{XPrv, XPub, XPRV_SIZE};
-use rand_core::{CryptoRng, RngCore};
+use rand::{CryptoRng, RngCore};
 
 /// Ed25519 BIP32 Signature algorithm
 pub struct Ed25519Bip32;

--- a/chain-crypto/src/algorithms/ed25519_extended.rs
+++ b/chain-crypto/src/algorithms/ed25519_extended.rs
@@ -32,6 +32,9 @@ impl AsymmetricKey for Ed25519Extended {
     type Secret = ExtendedPriv;
     type Public = ei::Pub;
 
+    const SECRET_BECH32_HRP: &'static str = "ed25519extended_secret";
+    const PUBLIC_BECH32_HRP: &'static str = "ed25519extended_public";
+
     fn generate<T: RngCore + CryptoRng>(mut rng: T) -> Self::Secret {
         let mut priv_bytes = [0u8; XPRV_SIZE];
         rng.fill_bytes(&mut priv_bytes);

--- a/chain-crypto/src/algorithms/ed25519_extended.rs
+++ b/chain-crypto/src/algorithms/ed25519_extended.rs
@@ -4,7 +4,7 @@ use crate::sign::{SignatureError, SigningAlgorithm, Verification, VerificationAl
 use super::ed25519 as ei;
 
 use cryptoxide::ed25519;
-use rand_core::{CryptoRng, RngCore};
+use rand::{CryptoRng, RngCore};
 
 use ed25519_bip32::{XPrv, XPRV_SIZE};
 

--- a/chain-crypto/src/algorithms/fakemmm.rs
+++ b/chain-crypto/src/algorithms/fakemmm.rs
@@ -38,6 +38,9 @@ impl AsymmetricKey for FakeMMM {
     type Secret = Priv;
     type Public = Pub;
 
+    const SECRET_BECH32_HRP: &'static str = "fakemmm_secret";
+    const PUBLIC_BECH32_HRP: &'static str = "fakemmm_public";
+
     fn generate<T: RngCore + CryptoRng>(mut rng: T) -> Priv {
         let mut priv_bytes = [0u8; ed25519::PRIVATE_KEY_LENGTH];
         rng.fill_bytes(&mut priv_bytes);

--- a/chain-crypto/src/algorithms/fakemmm.rs
+++ b/chain-crypto/src/algorithms/fakemmm.rs
@@ -2,7 +2,7 @@ use crate::kes::KeyEvolvingSignatureAlgorithm;
 use crate::key::{AsymmetricKey, PublicKeyError, SecretKeyError};
 use crate::sign::{SignatureError, Verification, VerificationAlgorithm};
 use cryptoxide::ed25519;
-use rand_core::{CryptoRng, RngCore};
+use rand::{CryptoRng, RngCore};
 
 /// Fake MMM Signing Algorithm
 pub struct FakeMMM;

--- a/chain-crypto/src/algorithms/vrf/mod.rs
+++ b/chain-crypto/src/algorithms/vrf/mod.rs
@@ -2,7 +2,7 @@ mod dleq;
 pub mod vrf;
 
 use crate::key::{AsymmetricKey, PublicKeyError, SecretKeyError};
-use rand_core::{CryptoRng, RngCore};
+use rand::{CryptoRng, RngCore};
 
 /// VRF
 pub struct Curve25519_2HashDH;

--- a/chain-crypto/src/algorithms/vrf/mod.rs
+++ b/chain-crypto/src/algorithms/vrf/mod.rs
@@ -11,6 +11,9 @@ impl AsymmetricKey for Curve25519_2HashDH {
     type Secret = vrf::SecretKey;
     type Public = vrf::PublicKey;
 
+    const SECRET_BECH32_HRP: &'static str = "curve25519_2hashdh_secret";
+    const PUBLIC_BECH32_HRP: &'static str = "curve25519_2hashdh_public";
+
     fn generate<T: RngCore + CryptoRng>(rng: T) -> Self::Secret {
         Self::Secret::random(rng)
     }

--- a/chain-crypto/src/key.rs
+++ b/chain-crypto/src/key.rs
@@ -1,5 +1,5 @@
 use crate::hex;
-use rand_core::{CryptoRng, RngCore};
+use rand::{CryptoRng, RngCore};
 use std::fmt;
 use std::hash::Hash;
 
@@ -174,8 +174,8 @@ mod test {
     use super::*;
 
     use quickcheck::{Arbitrary, Gen};
+    use rand::SeedableRng;
     use rand_chacha::ChaChaRng;
-    use rand_core::SeedableRng;
 
     pub fn arbitrary_public_key<A: AsymmetricKey, G: Gen>(g: &mut G) -> PublicKey<A> {
         arbitrary_secret_key(g).to_public()

--- a/chain-crypto/src/key.rs
+++ b/chain-crypto/src/key.rs
@@ -19,6 +19,9 @@ pub trait AsymmetricKey {
     type Secret: AsRef<[u8]> + Clone;
     type Public: AsRef<[u8]> + Clone + PartialEq + Eq + Hash;
 
+    const SECRET_BECH32_HRP: &'static str;
+    const PUBLIC_BECH32_HRP: &'static str;
+
     fn generate<T: RngCore + CryptoRng>(rng: T) -> Self::Secret;
 
     fn compute_public(secret: &Self::Secret) -> Self::Public;

--- a/chain-crypto/src/lib.rs
+++ b/chain-crypto/src/lib.rs
@@ -8,10 +8,6 @@ extern crate test;
 #[macro_use]
 extern crate quickcheck;
 
-extern crate cryptoxide;
-extern crate ed25519_bip32;
-extern crate rand_core;
-
 pub mod algorithms;
 pub mod hash;
 mod hex;


### PR DESCRIPTION
This is needed for exporting and importing bech32-encoded keys. Currently only utilized during generation of private and public keys in CLI, may have more uses.