### PR TITLE
Make BlockStore usable as a trait object

### DIFF
--- a/chain-storage-sqlite/examples/import.rs
+++ b/chain-storage-sqlite/examples/import.rs
@@ -38,7 +38,9 @@ fn main() {
             .as_bytes(),
     ));
 
-    let mut store = chain_storage_sqlite::SQLiteBlockStore::new(db_path);
+    // Test whether using BlockStore as a trait object works.
+    let mut store: Box<dyn BlockStore<Block = cardano::block::Block>> =
+        Box::new(chain_storage_sqlite::SQLiteBlockStore::new(db_path));
 
     /* Convert a chain using old-school storage to a SQLiteBlockStore. */
     let now = Instant::now();

--- a/chain-storage-sqlite/src/lib.rs
+++ b/chain-storage-sqlite/src/lib.rs
@@ -209,4 +209,8 @@ where
             Err(err) => panic!(err),
         }
     }
+
+    fn as_trait(&self) -> &BlockStore<Block = Self::Block> {
+        self as &BlockStore<Block = Self::Block>
+    }
 }

--- a/chain-storage/src/memory.rs
+++ b/chain-storage/src/memory.rs
@@ -66,4 +66,8 @@ where
             Ok(None)
         }
     }
+
+    fn as_trait(&self) -> &BlockStore<Block = Self::Block> {
+        self as &BlockStore<Block = Self::Block>
+    }
 }

--- a/chain-storage/src/store.rs
+++ b/chain-storage/src/store.rs
@@ -36,7 +36,7 @@ pub struct BackLink<Id: BlockId> {
     pub block_hash: Id,
 }
 
-pub trait BlockStore: std::marker::Sized {
+pub trait BlockStore {
     type Block: Block;
 
     /// Write a block to the store. The parent of the block must exist
@@ -135,17 +135,17 @@ pub trait BlockStore: std::marker::Sized {
         block_hash: &<Self::Block as Block>::Id,
         distance: u64,
     ) -> Result<BlockInfo<<Self::Block as Block>::Id>, Error> {
-        self.get_path_to_nth_ancestor(block_hash, distance, |_| {})
+        self.get_path_to_nth_ancestor(block_hash, distance, Box::new(|_| {}))
     }
 
     /// Like get_nth_ancestor(), but calls the closure 'callback' with
     /// each intermediate block encountered while travelling from
     /// 'block_hash' to its n'th ancestor.
-    fn get_path_to_nth_ancestor<F: FnMut(&BlockInfo<<Self::Block as Block>::Id>)>(
-        &self,
+    fn get_path_to_nth_ancestor<'a>(
+        &'a self,
         block_hash: &<Self::Block as Block>::Id,
         distance: u64,
-        mut callback: F,
+        mut callback: Box<'a + FnMut(&BlockInfo<<Self::Block as Block>::Id>)>,
     ) -> Result<BlockInfo<<Self::Block as Block>::Id>, Error> {
         let mut cur_block_info = self.get_block_info(block_hash)?;
 
@@ -222,18 +222,18 @@ pub trait BlockStore: std::marker::Sized {
     /// Return an iterator that yields block info for the blocks in
     /// the half-open range `(from, to]`. `from` must be an ancestor
     /// of `to` and may be the zero hash.
-    fn iterate_range(
-        &self,
+    fn iterate_range<'store>(
+        &'store self,
         from: &<Self::Block as Block>::Id,
         to: &<Self::Block as Block>::Id,
-    ) -> Result<BlockIterator<Self>, Error> {
+    ) -> Result<BlockIterator<'store, Self::Block>, Error> {
         // FIXME: put blocks loaded by is_ancestor into pending_infos.
         match self.is_ancestor(from, to)? {
             None => panic!(), // FIXME: return error
             Some(distance) => {
                 let to_info = self.get_block_info(&to)?;
                 Ok(BlockIterator {
-                    store: &self,
+                    store: self.as_trait(),
                     to_depth: to_info.depth,
                     cur_depth: to_info.depth - distance,
                     pending_infos: vec![to_info],
@@ -241,23 +241,20 @@ pub trait BlockStore: std::marker::Sized {
             }
         }
     }
+
+    // See https://stackoverflow.com/questions/42121299/provided-method-casting-self-to-trait-object
+    fn as_trait(&self) -> &BlockStore<Block = Self::Block>;
 }
 
-pub struct BlockIterator<'store, S>
-where
-    S: BlockStore + 'store,
-{
-    store: &'store S,
+pub struct BlockIterator<'store, B: Block> {
+    store: &'store BlockStore<Block = B>,
     to_depth: u64,
     cur_depth: u64,
-    pending_infos: Vec<BlockInfo<<S::Block as Block>::Id>>,
+    pending_infos: Vec<BlockInfo<B::Id>>,
 }
 
-impl<'store, S> Iterator for BlockIterator<'store, S>
-where
-    S: BlockStore + 'store,
-{
-    type Item = Result<BlockInfo<<S::Block as Block>::Id>, Error>;
+impl<'store, B: Block> Iterator for BlockIterator<'store, B> {
+    type Item = Result<BlockInfo<B::Id>, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.cur_depth >= self.to_depth {
@@ -280,9 +277,9 @@ where
                 Some(self.store.get_path_to_nth_ancestor(
                     &parent,
                     depth - self.cur_depth - 1,
-                    |new_info| {
+                    Box::new(|new_info| {
                         self.pending_infos.push(new_info.clone());
-                    },
+                    }),
                 ))
             }
         }


### PR DESCRIPTION
This requires getting rid of the generic type parameter in `get_path_to_nth_ancestor()`, dropping the `Self` return type in `iterate_range()` and dropping `Sized`.