### PR TITLE
[IOHKCRB-10] Add functions to generate entropy

### DIFF
--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -15,15 +15,14 @@ typedef int cardano_result;
 /*********/
 
 /* bip39 error definitions */
-enum _bip39_config_error
+typedef enum _bip39_config_error
 {
     SUCCESS = 0,
     INVALID_MNEMONIC = 1,
-    INVALID_CHECKSUM = 2
-};
+    INVALID_CHECKSUM = 2,
+    INVALID_WORD_COUNT = 3
+} cardano_bip39_error_t;
 
-/* type for the API user */
-typedef enum _config_error cardano_bip39_error_t;
 
 /* Error descriptions */
 struct _errordesc {
@@ -33,16 +32,24 @@ struct _errordesc {
     { SUCCESS, "No error" },
     { INVALID_MNEMONIC, "Invalid mnemonic word" },
     { INVALID_CHECKSUM, "Invalid checksum" },
+    { INVALID_WORD_COUNT, "The word count should be one of: 9, 12, 15, 18, 21, 24"}
 };
 
 typedef uint8_t* cardano_entropy;
 
-int cardano_entropy_from_mnemonics(
+cardano_bip39_error_t cardano_entropy_from_english_mnemonics(
     const char *mnemonics,
     cardano_entropy *entropy,
     uint32_t *entropy_size
 );
-void cardano_delete_entropy_array(uint8_t *entropy, size_t bytes);
+cardano_bip39_error_t cardano_generate_random_entropy(
+    uint8_t number_of_words,
+    uint8_t (*random_generator)(),
+    cardano_entropy *entropy,
+    uint32_t *entropy_size
+);
+
+void cardano_delete_entropy_array(uint8_t *entropy, uint32_t bytes);
 
 cardano_result cardano_bip39_encode(const char * const entropy_raw, unsigned long entropy_size, unsigned short *mnemonic_index, unsigned long mnemonic_size);
 

--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -14,6 +14,36 @@ typedef int cardano_result;
 /* BIP39 */
 /*********/
 
+/* bip39 error definitions */
+enum _bip39_config_error
+{
+    SUCCESS = 0,
+    INVALID_MNEMONIC = 1,
+    INVALID_CHECKSUM = 2
+};
+
+/* type for the API user */
+typedef enum _config_error cardano_bip39_error_t;
+
+/* Error descriptions */
+struct _errordesc {
+    int  code;
+    char *message;
+} errordesc[] = {
+    { SUCCESS, "No error" },
+    { INVALID_MNEMONIC, "Invalid mnemonic word" },
+    { INVALID_CHECKSUM, "Invalid checksum" },
+};
+
+typedef uint8_t* cardano_entropy;
+
+int cardano_entropy_from_mnemonics(
+    const char *mnemonics,
+    cardano_entropy *entropy,
+    uint32_t *entropy_size
+);
+void cardano_delete_entropy_array(uint8_t *entropy, size_t bytes);
+
 cardano_result cardano_bip39_encode(const char * const entropy_raw, unsigned long entropy_size, unsigned short *mnemonic_index, unsigned long mnemonic_size);
 
 /*********/

--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -17,39 +17,61 @@ typedef int cardano_result;
 /* bip39 error definitions */
 typedef enum _bip39_config_error
 {
-    SUCCESS = 0,
-    INVALID_MNEMONIC = 1,
-    INVALID_CHECKSUM = 2,
-    INVALID_WORD_COUNT = 3
+    BIP39_SUCCESS = 0,
+    BIP39_INVALID_MNEMONIC = 1,
+    BIP39_INVALID_CHECKSUM = 2,
+    BIP39_INVALID_WORD_COUNT = 3
 } cardano_bip39_error_t;
-
 
 /* Error descriptions */
 struct _errordesc {
     int  code;
     char *message;
 } errordesc[] = {
-    { SUCCESS, "No error" },
-    { INVALID_MNEMONIC, "Invalid mnemonic word" },
-    { INVALID_CHECKSUM, "Invalid checksum" },
-    { INVALID_WORD_COUNT, "The word count should be one of: 9, 12, 15, 18, 21, 24"}
+    { BIP39_SUCCESS, "No error" },
+    { BIP39_INVALID_MNEMONIC, "Invalid mnemonic word" },
+    { BIP39_INVALID_CHECKSUM, "Invalid checksum" },
+    { BIP39_INVALID_WORD_COUNT, "The word count should be one of: 9, 12, 15, 18, 21, 24"}
 };
 
 typedef uint8_t* cardano_entropy;
 
+/*!
+* \brief get entropy array from the given english mnemonics 
+* \param [in] mnemonics a string consisting of 9, 12, 15, 18, 21 or 24 english words
+* \param [out] entropy the returned entropy array
+* \param [out] entropy_size the size of the the returned array
+* \returns BIP39_SUCCESS or either BIP39_INVALID_MNEMONIC or BIP39_INVALID_CHECKSUM 
+*/
 cardano_bip39_error_t cardano_entropy_from_english_mnemonics(
     const char *mnemonics,
     cardano_entropy *entropy,
     uint32_t *entropy_size
 );
-cardano_bip39_error_t cardano_generate_random_entropy(
+
+/*!
+* \brief encode a entropy into its equivalent words represented by their index (0 to 2047) in the BIP39 dictionary
+* \param [in] number_of_words one of 9, 12, 15, 18, 21 or 24 representing the number of words of the equivalent mnemonic
+* \param [in] random_generator a function that generates random bytes  
+* \param [out] entropy the returned entropy array
+* \param [out] entropy_size the size of the the returned array
+* \returns BIP39_SUCCESS or BIP39_INVALID_WORD_COUNT 
+*/
+cardano_bip39_error_t cardano_entropy_from_random(
     uint8_t number_of_words,
     uint8_t (*random_generator)(),
     cardano_entropy *entropy,
     uint32_t *entropy_size
 );
 
-void cardano_delete_entropy_array(uint8_t *entropy, uint32_t bytes);
+/*!
+* delete the allocated memory of entropy byte array
+* \param [in] entropy the entropy array
+* \param [in] entropy_size the length of the entropy array
+* \sa cardano_entropy_from_random()
+* \sa cardano_entropy_from_english_mnemonics()
+*/
+void cardano_delete_entropy_array(uint8_t *entropy, uint32_t entropy_size);
 
 cardano_result cardano_bip39_encode(const char * const entropy_raw, unsigned long entropy_size, unsigned short *mnemonic_index, unsigned long mnemonic_size);
 

--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -23,17 +23,6 @@ typedef enum _bip39_config_error
     BIP39_INVALID_WORD_COUNT = 3
 } cardano_bip39_error_t;
 
-/* Error descriptions */
-struct _errordesc {
-    int  code;
-    char *message;
-} errordesc[] = {
-    { BIP39_SUCCESS, "No error" },
-    { BIP39_INVALID_MNEMONIC, "Invalid mnemonic word" },
-    { BIP39_INVALID_CHECKSUM, "Invalid checksum" },
-    { BIP39_INVALID_WORD_COUNT, "The word count should be one of: 9, 12, 15, 18, 21, 24"}
-};
-
 typedef uint8_t* cardano_entropy;
 
 /*!

--- a/cardano-c/src/bip39.rs
+++ b/cardano-c/src/bip39.rs
@@ -60,7 +60,7 @@ pub extern "C" fn cardano_entropy_from_english_mnemonics(
 
 ///generate entropy from the given random generator
 #[no_mangle]
-pub extern "C" fn cardano_generate_random_entropy(
+pub extern "C" fn cardano_entropy_from_random(
     words: u8,
     gen: extern "C" fn() -> c_uchar,
     entropy_ptr: *mut *const c_uchar,

--- a/cardano-c/src/bip39.rs
+++ b/cardano-c/src/bip39.rs
@@ -3,6 +3,13 @@ use std::slice;
 use cardano::bip::bip39;
 use types::CardanoResult;
 
+use std::{
+    ptr,
+    os::raw::{c_char, c_uchar, c_int, c_uint},
+};
+
+use std::ffi::CStr;
+
 /// encode a entropy into its equivalent words represented by their index (0 to 2047) in the BIP39 dictionary
 #[no_mangle]
 pub extern "C" fn cardano_bip39_encode(
@@ -19,4 +26,65 @@ pub extern "C" fn cardano_bip39_encode(
     };
     out_slice.copy_from_slice(entropy.to_mnemonics().as_ref());
     CardanoResult::success()
+}
+
+///
+/// Error status:
+///     0: Success
+///     1: The words were not in the english dictionary
+///     2: The checksum was invalid
+/// 
+#[no_mangle]
+pub extern "C" fn cardano_entropy_from_mnemonics(
+    mnemonics: *const c_char,
+    entropy_ptr: *mut *const c_uchar,
+    entropy_size: *mut c_uint 
+) -> c_int {
+    let rust_string = unsafe { CStr::from_ptr(mnemonics) }.to_string_lossy(); 
+
+    let dictionary = bip39::dictionary::ENGLISH;
+
+    let mnemonics = match bip39::Mnemonics::from_string(&dictionary, &rust_string)
+    {
+        Ok(m) => m,
+        Err(_) => return 1,
+    };
+
+    let entropy = match bip39::Entropy::from_mnemonics(&mnemonics) {
+        Ok(e) => e,
+        Err(_) => return 2,
+    };
+    
+    let mut entropy_vec = match entropy {
+        bip39::Entropy::Entropy9(arr) => arr.to_vec(),
+        bip39::Entropy::Entropy12(arr) => arr.to_vec(),
+        bip39::Entropy::Entropy15(arr) => arr.to_vec(),
+        bip39::Entropy::Entropy18(arr) => arr.to_vec(),
+        bip39::Entropy::Entropy21(arr) => arr.to_vec(),
+        bip39::Entropy::Entropy24(arr) => arr.to_vec(),
+    };
+
+    //Make sure the capacity is the same as the length to make deallocation simpler
+    entropy_vec.shrink_to_fit();
+
+    let pointer = entropy_vec.as_mut_ptr();
+    let length = entropy_vec.len() as u32;
+
+    //To avoid deallocation
+    std::mem::forget(entropy_vec);
+
+    //Write the array length
+    unsafe { ptr::write(entropy_size, length) }
+
+    //Copy the pointer to the out parameter
+    unsafe { ptr::write(entropy_ptr, pointer) };
+
+    0
+}
+
+//Deallocate the rust-allocated memory for a Entropy array
+#[no_mangle]
+pub extern "C" fn cardano_delete_entropy_array(ptr: *mut c_uchar, size: u32) {
+    let len = size as usize;
+    unsafe { drop(Vec::from_raw_parts(ptr, len, len)) };
 }

--- a/cardano-c/src/types.rs
+++ b/cardano-c/src/types.rs
@@ -18,6 +18,31 @@ impl CardanoResult {
     }
 }
 
+///Struct for representing the possible BIP39 error codes
+#[repr(C)]
+pub struct CardanoBIP39ErrorCode(c_int);
+
+impl CardanoBIP39ErrorCode {
+    pub fn success() -> Self {
+        CardanoBIP39ErrorCode(0)
+    }
+
+    ///Error representing a word not in the dictionary
+    pub fn invalid_word() -> Self {
+        CardanoBIP39ErrorCode(1)
+    }
+
+    ///Error representing that a mnemonic phrase checksum is incorrect
+    pub fn invalid_checksum() -> Self {
+        CardanoBIP39ErrorCode(2)
+    }
+
+    ///Error representing that the word count is not one of the supported ones
+    pub fn invalid_word_count() -> Self {
+        CardanoBIP39ErrorCode(3)
+    }
+}
+
 /// C pointer to an Extended Private Key
 pub type XPrvPtr = *mut hdwallet::XPrv;
 

--- a/cardano-c/test.sh
+++ b/cardano-c/test.sh
@@ -24,3 +24,11 @@ echo "######################################################################"
 echo ""
 echo "######################################################################"
 rm test-cardano-c.$$
+
+
+gcc -o test-cardano-c.$$ -I "${C_ROOT}" "${C_ROOT}test/test_bip39_entropy.c" "${C_ROOT}test/unity/unity.c" "${PROJECT_ROOT}target/debug/libcardano_c.a" -lpthread -lm -ldl
+echo "######################################################################"
+./test-cardano-c.$$
+echo ""
+echo "######################################################################"
+rm test-cardano-c.$$

--- a/cardano-c/test/test_bip39_entropy.c
+++ b/cardano-c/test/test_bip39_entropy.c
@@ -15,13 +15,13 @@ void test_generate_entropy_from_mnemonics(void) {
 }
 
 void test_generate_entropy_from_mnemonics_error_code_invalid_word(void) {
-    static const char *mnemonics =  "termo abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    static const char *mnemonics =  "notaword abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
     cardano_entropy entropy;
     uint32_t bytes;
     int error = cardano_entropy_from_english_mnemonics(mnemonics, &entropy, &bytes);
 
-    TEST_ASSERT_EQUAL_HEX32(INVALID_MNEMONIC, error);
+    TEST_ASSERT_EQUAL_HEX32(BIP39_INVALID_MNEMONIC, error);
 }
 
 void test_generate_entropy_from_mnemonics_invalid_checksum(void) {
@@ -31,7 +31,7 @@ void test_generate_entropy_from_mnemonics_invalid_checksum(void) {
     uint32_t bytes;
     int error = cardano_entropy_from_english_mnemonics(mnemonics, &entropy, &bytes);
 
-    TEST_ASSERT_EQUAL_HEX32(INVALID_CHECKSUM, error);
+    TEST_ASSERT_EQUAL_HEX32(BIP39_INVALID_CHECKSUM, error);
 }
 
 uint8_t gen() {
@@ -42,7 +42,7 @@ void test_generate_entropy_from_random_generator(void) {
     const uint8_t NUMBER_OF_WORDS = 12; 
     cardano_entropy entropy;
     uint32_t bytes;
-    cardano_bip39_error_t error = cardano_generate_random_entropy(NUMBER_OF_WORDS, gen, &entropy, &bytes);
+    cardano_bip39_error_t error = cardano_entropy_from_random(NUMBER_OF_WORDS, gen, &entropy, &bytes);
 
     uint8_t expected[16] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
 
@@ -52,14 +52,13 @@ void test_generate_entropy_from_random_generator(void) {
     cardano_delete_entropy_array(entropy, bytes);
 }
 
-
 void test_generate_entropy_from_random_generator_word_count_error(void) {
     const uint8_t NUMBER_OF_WORDS = 13; 
     cardano_entropy entropy;
     uint32_t bytes;
-    cardano_bip39_error_t error = cardano_generate_random_entropy(NUMBER_OF_WORDS, gen, &entropy, &bytes);
+    cardano_bip39_error_t error = cardano_entropy_from_random(NUMBER_OF_WORDS, gen, &entropy, &bytes);
 
-    TEST_ASSERT_EQUAL_HEX32(INVALID_WORD_COUNT, error);
+    TEST_ASSERT_EQUAL_HEX32(BIP39_INVALID_WORD_COUNT, error);
 }
 
 int main(void) {

--- a/cardano-c/test/test_bip39_entropy.c
+++ b/cardano-c/test/test_bip39_entropy.c
@@ -6,7 +6,7 @@ void test_generate_entropy_from_mnemonics(void) {
 
     cardano_entropy entropy;
     uint32_t bytes;
-    int error = cardano_entropy_from_mnemonics(mnemonics, &entropy, &bytes);
+    int error = cardano_entropy_from_english_mnemonics(mnemonics, &entropy, &bytes);
 
     uint8_t expected[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, entropy, 16);
@@ -19,7 +19,7 @@ void test_generate_entropy_from_mnemonics_error_code_invalid_word(void) {
 
     cardano_entropy entropy;
     uint32_t bytes;
-    int error = cardano_entropy_from_mnemonics(mnemonics, &entropy, &bytes);
+    int error = cardano_entropy_from_english_mnemonics(mnemonics, &entropy, &bytes);
 
     TEST_ASSERT_EQUAL_HEX32(INVALID_MNEMONIC, error);
 }
@@ -29,9 +29,37 @@ void test_generate_entropy_from_mnemonics_invalid_checksum(void) {
 
     cardano_entropy entropy;
     uint32_t bytes;
-    int error = cardano_entropy_from_mnemonics(mnemonics, &entropy, &bytes);
+    int error = cardano_entropy_from_english_mnemonics(mnemonics, &entropy, &bytes);
 
     TEST_ASSERT_EQUAL_HEX32(INVALID_CHECKSUM, error);
+}
+
+uint8_t gen() {
+    return 1;
+}
+
+void test_generate_entropy_from_random_generator(void) {
+    const uint8_t NUMBER_OF_WORDS = 12; 
+    cardano_entropy entropy;
+    uint32_t bytes;
+    cardano_bip39_error_t error = cardano_generate_random_entropy(NUMBER_OF_WORDS, gen, &entropy, &bytes);
+
+    uint8_t expected[16] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+
+    TEST_ASSERT_EQUAL(16, bytes);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, entropy, 16);
+
+    cardano_delete_entropy_array(entropy, bytes);
+}
+
+
+void test_generate_entropy_from_random_generator_word_count_error(void) {
+    const uint8_t NUMBER_OF_WORDS = 13; 
+    cardano_entropy entropy;
+    uint32_t bytes;
+    cardano_bip39_error_t error = cardano_generate_random_entropy(NUMBER_OF_WORDS, gen, &entropy, &bytes);
+
+    TEST_ASSERT_EQUAL_HEX32(INVALID_WORD_COUNT, error);
 }
 
 int main(void) {
@@ -39,5 +67,7 @@ int main(void) {
     RUN_TEST(test_generate_entropy_from_mnemonics);
     RUN_TEST(test_generate_entropy_from_mnemonics_error_code_invalid_word);
     RUN_TEST(test_generate_entropy_from_mnemonics_invalid_checksum);
+    RUN_TEST(test_generate_entropy_from_random_generator);
+    RUN_TEST(test_generate_entropy_from_random_generator_word_count_error);
     return UNITY_END();
 }

--- a/cardano-c/test/test_bip39_entropy.c
+++ b/cardano-c/test/test_bip39_entropy.c
@@ -1,0 +1,43 @@
+#include "../cardano.h"
+#include "unity/unity.h"
+
+void test_generate_entropy_from_mnemonics(void) {
+    static const char *mnemonics =  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    cardano_entropy entropy;
+    uint32_t bytes;
+    int error = cardano_entropy_from_mnemonics(mnemonics, &entropy, &bytes);
+
+    uint8_t expected[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, entropy, 16);
+
+    cardano_delete_entropy_array(entropy, bytes);
+}
+
+void test_generate_entropy_from_mnemonics_error_code_invalid_word(void) {
+    static const char *mnemonics =  "termo abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    cardano_entropy entropy;
+    uint32_t bytes;
+    int error = cardano_entropy_from_mnemonics(mnemonics, &entropy, &bytes);
+
+    TEST_ASSERT_EQUAL_HEX32(INVALID_MNEMONIC, error);
+}
+
+void test_generate_entropy_from_mnemonics_invalid_checksum(void) {
+    static const char *mnemonics =  "about abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    cardano_entropy entropy;
+    uint32_t bytes;
+    int error = cardano_entropy_from_mnemonics(mnemonics, &entropy, &bytes);
+
+    TEST_ASSERT_EQUAL_HEX32(INVALID_CHECKSUM, error);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_generate_entropy_from_mnemonics);
+    RUN_TEST(test_generate_entropy_from_mnemonics_error_code_invalid_word);
+    RUN_TEST(test_generate_entropy_from_mnemonics_invalid_checksum);
+    return UNITY_END();
+}

--- a/cardano-c/test/test_bip39_entropy.c
+++ b/cardano-c/test/test_bip39_entropy.c
@@ -6,7 +6,7 @@ void test_generate_entropy_from_mnemonics(void) {
 
     cardano_entropy entropy;
     uint32_t bytes;
-    int error = cardano_entropy_from_english_mnemonics(mnemonics, &entropy, &bytes);
+    cardano_bip39_error_t error = cardano_entropy_from_english_mnemonics(mnemonics, &entropy, &bytes);
 
     uint8_t expected[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, entropy, 16);
@@ -19,7 +19,7 @@ void test_generate_entropy_from_mnemonics_error_code_invalid_word(void) {
 
     cardano_entropy entropy;
     uint32_t bytes;
-    int error = cardano_entropy_from_english_mnemonics(mnemonics, &entropy, &bytes);
+    cardano_bip39_error_t error = cardano_entropy_from_english_mnemonics(mnemonics, &entropy, &bytes);
 
     TEST_ASSERT_EQUAL_HEX32(BIP39_INVALID_MNEMONIC, error);
 }
@@ -29,7 +29,7 @@ void test_generate_entropy_from_mnemonics_invalid_checksum(void) {
 
     cardano_entropy entropy;
     uint32_t bytes;
-    int error = cardano_entropy_from_english_mnemonics(mnemonics, &entropy, &bytes);
+    cardano_bip39_error_t error = cardano_entropy_from_english_mnemonics(mnemonics, &entropy, &bytes);
 
     TEST_ASSERT_EQUAL_HEX32(BIP39_INVALID_CHECKSUM, error);
 }


### PR DESCRIPTION
---
name: [IOHKCRB-10]Add functions to generate entropy
---

# Summary

Export two functions to work with entropy

- cardano_entropy_from_english_mnemonics
- cardano_entropy_from_random

# Description
---
`cardano_entropy_from_english_mnemonics` can be used to retrieve the entropy as a byte array from the given english mnemonics. It returns a pointer to an array and the respective array size as *out* parameters. The size depends on the number of words of the mnemonic

### Example

```C
static const char *mnemonics =  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";

uint8_t *entropy;
uint32_t *size;
cardano_bip39_error_t rc = cardano_entropy_from_english_mnemonics(mnemonics, &entropy, &size);
```
---
---

`cardano_entropy_from_random` can be used to generate entropy as a byte array given the number of words of a supported mnemonic phrase and a function that generates random numbers. It also returns a pointer to an array and its size as out parameters.

### Example

```C
uint8_t gen() {
    return generate_random_byte();
}
```
```C
...
uint8_t *entropy;
uint32_t *size;
const uint8_t NUMBER_OF_WORDS = 12; 
uint8_t (*gen)() = generate_random_byte;
cardano_bip39_error_t rc = cardano_entropy_from_random(NUMBER_OF_WORDS, gen, &entropy, &size);
```