### PR TITLE
[IOHKCRB-7] Add test of transaction creation

### DIFF
--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -1,7 +1,7 @@
 /*! \file cardano.h
 */
 #ifndef CARDANO_RUST_H
-# define CARDANO_RUST_H
+#define CARDANO_RUST_H
 /* Basic Types */
 
 #ifdef __cplusplus
@@ -198,7 +198,7 @@ void cardano_account_delete(cardano_account *account);
 * \sa cardano_address_delete() 
 */
 unsigned long cardano_account_generate_addresses(cardano_account *account, int internal, unsigned int from_index, unsigned long num_indices, char *addresses_ptr[]);
-void cardano_account_delete_addresses(char *addresses_ptr[], size_t length);
+void cardano_account_delete_addresses(char *addresses_ptr[], unsigned long length);
 
 /****************/
 /* Transactions */

--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -13,7 +13,10 @@ extern "C" {
 /*!
 * Type used to represent failure and success
 */
-typedef int cardano_result;
+typedef enum _cardano_result {
+    CARDANO_RESULT_SUCCESS = 0,
+    CARDANO_RESULT_ERROR = 1
+} cardano_result;
 
 /*********/
 /* BIP39 */
@@ -195,6 +198,7 @@ void cardano_account_delete(cardano_account *account);
 * \sa cardano_address_delete() 
 */
 unsigned long cardano_account_generate_addresses(cardano_account *account, int internal, unsigned int from_index, unsigned long num_indices, char *addresses_ptr[]);
+void cardano_account_delete_addresses(char *addresses_ptr[], size_t length);
 
 /****************/
 /* Transactions */
@@ -256,14 +260,13 @@ cardano_transaction_builder * cardano_transaction_builder_new(void);
 */
 void cardano_transaction_builder_delete(cardano_transaction_builder *tb);
 
-
 /*!
 * \brief Add output to transaction
 * \param [in] tb the builder for the transaction
 * \param [in] txo created with `cardano_transaction_output_new`
 * \sa cardano_transaction_output_new()
 */
-void cardano_transaction_builder_add_output(cardano_transaction_builder *tb, cardano_txoptr *txo);
+void cardano_transaction_builder_add_output(cardano_transaction_builder *tb, cardano_txoutput *txo);
 
 /*!
 * \brief Add input to the transaction
@@ -303,11 +306,13 @@ uint64_t cardano_transaction_builder_fee(cardano_transaction_builder *tb);
 * \brief Get a transaction object
 */
 cardano_transaction *cardano_transaction_builder_finalize(cardano_transaction_builder *tb);
+void cardano_transaction_delete(cardano_transaction *c_tx);
 
 /*!
 * \brief Take a transaction and create a working area for adding witnesses
 */
 cardano_transaction_finalized * cardano_transaction_finalized_new(cardano_transaction *c_tx);
+void cardano_transaction_finalized_delete(cardano_transaction_finalized *tf);
 
 /*!
 * Add a witness associated with the next input.

--- a/cardano-c/src/transaction.rs
+++ b/cardano-c/src/transaction.rs
@@ -127,6 +127,11 @@ pub extern "C" fn cardano_transaction_builder_finalize(
 }
 
 #[no_mangle]
+pub extern "C" fn cardano_transaction_delete(tx: TransactionPtr) {
+    unsafe { Box::from_raw(tx) };
+}
+
+#[no_mangle]
 pub extern "C" fn cardano_transaction_finalized_new(
     c_tx: TransactionPtr,
 ) -> TransactionFinalizedPtr {
@@ -134,6 +139,11 @@ pub extern "C" fn cardano_transaction_finalized_new(
     let finalized = TxFinalized::new(tx.clone());
     let b = Box::new(finalized);
     Box::into_raw(b)
+}
+
+#[no_mangle]
+pub extern "C" fn cardano_transaction_finalized_delete(c_txf: TransactionFinalizedPtr) {
+    unsafe { Box::from_raw(c_txf) };
 }
 
 #[no_mangle]

--- a/cardano-c/src/wallet.rs
+++ b/cardano-c/src/wallet.rs
@@ -124,3 +124,13 @@ pub extern "C" fn cardano_account_generate_addresses(
         })
         .count()
 }
+
+#[no_mangle]
+pub extern "C" fn cardano_account_delete_addresses(addresses_ptr: *mut *mut c_char, size: usize) {
+    for i in 0..size {
+        unsafe {
+            let ptr = addresses_ptr.offset(i as isize);
+            ffi::CString::from_raw(*ptr);
+        };
+    }
+}

--- a/cardano-c/test.sh
+++ b/cardano-c/test.sh
@@ -18,9 +18,9 @@ if [ ! -f "${C_LIB_A}" ]; then
 	exit 2
 fi
 
-gcc -o test-cardano-c.$$ -I "${C_ROOT}" "${C_ROOT}test/test.c" "${C_ROOT}test/unity/unity.c" "${PROJECT_ROOT}target/debug/libcardano_c.a" -lpthread -lm -ldl
+gcc -o test-cardano-c.$$ -I "${C_ROOT}" "${C_ROOT}test/test_transaction.c" "${C_ROOT}test/unity/unity.c" "${PROJECT_ROOT}target/debug/libcardano_c.a" -lpthread -lm -ldl
 echo "######################################################################"
-./test-cardano-c.$$
+valgrind ./test-cardano-c.$$
 echo ""
 echo "######################################################################"
 rm test-cardano-c.$$

--- a/cardano-c/test.sh
+++ b/cardano-c/test.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-
+# Run tests
+# Set the VALGRIND variable to true to check for memory leaks
 if [ -d target/debug ]; then
 	PROJECT_ROOT="./"
 elif [ -d ../target/debug ]; then
@@ -9,7 +10,6 @@ else
 	exit 1
 fi
 
-
 C_ROOT="${PROJECT_ROOT}cardano-c/"
 C_LIB_A="${PROJECT_ROOT}target/debug/libcardano_c.a"
 
@@ -18,17 +18,23 @@ if [ ! -f "${C_LIB_A}" ]; then
 	exit 2
 fi
 
-gcc -o test-cardano-c.$$ -I "${C_ROOT}" "${C_ROOT}test/test_transaction.c" "${C_ROOT}test/unity/unity.c" "${PROJECT_ROOT}target/debug/libcardano_c.a" -lpthread -lm -ldl
-echo "######################################################################"
-valgrind ./test-cardano-c.$$
-echo ""
-echo "######################################################################"
-rm test-cardano-c.$$
+if [ -t 1 ]; then
+	UNITY_COLOR="-D UNITY_OUTPUT_COLOR"
+fi
 
+: "${VALGRIND:-false}"
 
-gcc -o test-cardano-c.$$ -I "${C_ROOT}" "${C_ROOT}test/test_bip39_entropy.c" "${C_ROOT}test/unity/unity.c" "${PROJECT_ROOT}target/debug/libcardano_c.a" -lpthread -lm -ldl
-echo "######################################################################"
-./test-cardano-c.$$
-echo ""
-echo "######################################################################"
-rm test-cardano-c.$$
+for FILENAME in ${C_ROOT}test/*.c; do
+    [ -e "$FILENAME" ] || continue
+	gcc -o test-cardano-c.$$ -I "${C_ROOT}" "${FILENAME}" "${C_ROOT}test/unity/unity.c" "${PROJECT_ROOT}target/debug/libcardano_c.a" -lpthread -lm -ldl ${UNITY_COLOR} 
+	echo "######################################################################"
+	if [ "$VALGRIND" = true ] ; then
+		valgrind ./test-cardano-c.$$
+		else
+		./test-cardano-c.$$
+	fi
+	echo ""
+	echo "######################################################################"
+	rm test-cardano-c.$$
+done
+

--- a/cardano-c/test/test.c
+++ b/cardano-c/test/test.c
@@ -5,13 +5,19 @@
 #include "cardano.h"
 #include "unity/unity.h"
 
-static const uint8_t static_wallet_entropy[16] = { 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15 };
+static const uint8_t static_wallet_entropy[16] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
 
-void test_can_create_address(void) {
-	static const char* alias = "Test Wallet";
-	static char *address;
+void test_can_create_address(void)
+{
+    static const char *alias = "Test Wallet";
+    static char *address[1];
+    size_t NUMBER_OF_ADDRESSES = sizeof(address) / sizeof(char *);
 
-	cardano_wallet *wallet = cardano_wallet_new(static_wallet_entropy, 16, "abc", 3);
+    cardano_wallet *wallet = cardano_wallet_new(
+        static_wallet_entropy,
+        sizeof(static_wallet_entropy),
+        "abc",
+        strlen("abc"));
 
     TEST_ASSERT_MESSAGE(wallet, "The wallet creation failed");
 
@@ -19,13 +25,15 @@ void test_can_create_address(void) {
 
     TEST_ASSERT_MESSAGE(account, "The account creation failed");
 
-	cardano_account_generate_addresses(account, 0, 0, 1, &address);
+    cardano_account_generate_addresses(account, 0, 0, NUMBER_OF_ADDRESSES, address);
 
-    TEST_ASSERT_MESSAGE(!cardano_address_is_valid(address) , "The generated address is invalid");
+    TEST_ASSERT_MESSAGE(!cardano_address_is_valid(address[0]), "The generated address is invalid");
 
-	cardano_account_delete(account);
+    cardano_account_delete_addresses(address, NUMBER_OF_ADDRESSES);
 
-	cardano_wallet_delete(wallet);
+    cardano_account_delete(account);
+
+    cardano_wallet_delete(wallet);
 }
 
 int main(void)

--- a/cardano-c/test/test_transaction.c
+++ b/cardano-c/test/test_transaction.c
@@ -1,0 +1,110 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include "../cardano.h"
+#include "unity/unity.h"
+
+//Variables for the setUp function
+cardano_wallet *wallet;
+cardano_account *account;
+cardano_address *input_address;
+cardano_address *output_address;
+cardano_transaction_builder *txbuilder;
+
+//Constants
+static uint32_t PROTOCOL_MAGIC = 1;
+static uint8_t input_xprv[XPRV_SIZE] = {0};
+static const uint8_t static_wallet_entropy[16] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+static uint8_t txid[32] = {0};
+
+void setUp()
+{
+    wallet = cardano_wallet_new(
+        static_wallet_entropy,
+        sizeof(static_wallet_entropy),
+        "password",
+        strlen("password"));
+
+    account = cardano_account_create(wallet, "main", 0);
+
+    char *addresses[2];
+    size_t NUMBER_OF_ADDRESSES = sizeof(addresses) / sizeof(char *);
+
+    int rc = cardano_account_generate_addresses(account, 0, 0, NUMBER_OF_ADDRESSES, addresses);
+
+    input_address = cardano_address_import_base58(addresses[0]);
+    output_address = cardano_address_import_base58(addresses[1]);
+
+    cardano_account_delete_addresses(addresses, sizeof(addresses) / sizeof(char *));
+
+    txbuilder = cardano_transaction_builder_new();
+}
+
+void tearDown()
+{
+    cardano_account_delete(account);
+
+    cardano_wallet_delete(wallet);
+
+    cardano_address_delete(input_address);
+
+    cardano_address_delete(output_address);
+
+    cardano_transaction_builder_delete(txbuilder);
+}
+
+void test_add_input_returns_success_with_valid_value()
+{
+    cardano_txoptr *input = cardano_transaction_output_ptr_new(txid, 1);
+    cardano_result irc = cardano_transaction_builder_add_input(txbuilder, input, 1000);
+
+    TEST_ASSERT_EQUAL(CARDANO_RESULT_SUCCESS, irc);
+    cardano_transaction_output_ptr_delete(input);
+}
+
+void test_add_input_returns_error_with_big_value()
+{
+    const uint64_t MAX_COIN = 45000000000000000;
+    cardano_txoptr *input = cardano_transaction_output_ptr_new(txid, 1);
+    cardano_result irc = cardano_transaction_builder_add_input(txbuilder, input, MAX_COIN + 1);
+
+    TEST_ASSERT_EQUAL(CARDANO_RESULT_ERROR, irc);
+    cardano_transaction_output_ptr_delete(input);
+}
+
+void test_add_witness_returns_error_with_less_inputs()
+{
+    cardano_txoptr *input = cardano_transaction_output_ptr_new(txid, 1);
+    cardano_result irc = cardano_transaction_builder_add_input(txbuilder, input, 1000);
+
+    /* the builder finalize fails without outputs*/
+    cardano_txoutput *output = cardano_transaction_output_new(output_address, 1000);
+    cardano_transaction_builder_add_output(txbuilder, output);
+
+    cardano_transaction *tx = cardano_transaction_builder_finalize(txbuilder);
+    cardano_transaction_finalized *tf = cardano_transaction_finalized_new(tx);
+
+    cardano_result rc1 = cardano_transaction_finalized_add_witness(tf, input_xprv, PROTOCOL_MAGIC, txid);
+
+    TEST_ASSERT_EQUAL(CARDANO_RESULT_SUCCESS, rc1);
+
+    cardano_result rc2 = cardano_transaction_finalized_add_witness(tf, input_xprv, PROTOCOL_MAGIC, txid);
+
+    //#witnesses > #inputs
+    TEST_ASSERT_EQUAL(CARDANO_RESULT_ERROR, rc2);
+
+    cardano_transaction_output_ptr_delete(input);
+    cardano_transaction_output_delete(output);
+    cardano_transaction_delete(tx);
+    cardano_transaction_finalized_delete(tf);
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_add_input_returns_success_with_valid_value);
+    RUN_TEST(test_add_input_returns_error_with_big_value);
+    RUN_TEST(test_add_witness_returns_error_with_less_inputs);
+    return UNITY_END();
+}


### PR DESCRIPTION
---
name: [IOHKCRB-7] Add test of transaction creation
---

# Description
## Add 3 tests to transaction building functionality
To the return status of the builder functions that return `cardano_result`, to assert that they report errors correctly.

**Note**: As there is no way to check the balance of the builder it is not possible to make assertions over the effects of the functions that add inputs and outputs. 

## Add 3 missing deallocation functions

### Problem
Currently, there are a few functions that allocate data structures that cannot be deallocated.
- `cardano_account_generate_addresses`
- `cardano_transaction_builder_finalize`
- `cardano_transaction_finalized_new`

### Solution
- `cardano_account_delete_addresses`
- `cardano_transaction_delete`
- `cardano_transaction_finalized_delete`

## Add valgrind to the test runner (_script.sh_)

To be able to check for memory leaks in the tests and detect possible deallocation issues, set the environment variable VALGRIND to true to use it.
### Example:
`VALGRIND=true ./cardano-c/test.sh`