### PR TITLE
Store chain length in header

### DIFF
--- a/chain-impl-mockchain/FORMAT.md
+++ b/chain-impl-mockchain/FORMAT.md
@@ -10,12 +10,13 @@ Format is:
 
 The header is a small piece of data, containing enough informations for validation and network deduplication and a strong signed cryptographic link to the content.
 
-Common (2 * 64 bits + 2 * 256 bits = 80 bytes):
+Common (2 * 64 bits + 1 * 32 bits + 2 * 256 bits = 84 bytes):
 
 * Size of Header: 16 bits: Maximum header is thus 64K not including the block content
 * Version of block: 16 bits
 * Size of Content: 32 bits
 * Block Date: Epoch (32 bits) + Slot-id (32 bits)
+* Chain length (number of ancestor blocks; first block has chain length 0): 32 bits
 * Hash of content `H(Content)` (256 bits)
 * Parent Header hash : 256 bits (with the special value of 0 to represent the lack of parent for the first block)
 

--- a/chain-impl-mockchain/src/block/header.rs
+++ b/chain-impl-mockchain/src/block/header.rs
@@ -29,7 +29,10 @@ pub struct Common {
     pub block_content_size: BlockContentSize,
     pub block_content_hash: BlockContentHash,
     pub block_parent_hash: BlockId,
+    pub chain_length: ChainLength,
 }
+
+pub type ChainLength = u32;
 
 pub type HeaderToSign = Common;
 
@@ -193,6 +196,7 @@ impl property::Serialize for Common {
         codec.put_u32(self.block_content_size)?;
         codec.put_u32(self.block_date.epoch)?;
         codec.put_u32(self.block_date.slot_id)?;
+        codec.put_u32(self.chain_length)?;
         codec.write_all(self.block_content_hash.as_ref())?;
         codec.write_all(self.block_parent_hash.as_ref())?;
 
@@ -257,6 +261,7 @@ impl property::Deserialize for Header {
         let epoch = codec.get_u32()?;
         let slot_id = codec.get_u32()?;
         let block_date = BlockDate { epoch, slot_id };
+        let chain_length = codec.get_u32()?;
 
         let mut hash = [0; 32];
         codec.read_exact(&mut hash)?;
@@ -287,6 +292,7 @@ impl property::Deserialize for Header {
                 block_content_size,
                 block_content_hash,
                 block_parent_hash,
+                chain_length,
             },
             proof,
         })
@@ -319,6 +325,7 @@ mod test {
                 block_content_size: Arbitrary::arbitrary(g),
                 block_content_hash: Arbitrary::arbitrary(g),
                 block_parent_hash: Arbitrary::arbitrary(g),
+                chain_length: Arbitrary::arbitrary(g),
             }
         }
     }

--- a/chain-impl-mockchain/src/block/mod.rs
+++ b/chain-impl-mockchain/src/block/mod.rs
@@ -11,8 +11,8 @@ pub mod message;
 pub use self::builder::BlockBuilder;
 
 pub use self::header::{
-    BftProof, BftSignature, BlockContentHash, BlockContentSize, BlockId, BlockVersion, Common,
-    GenesisPraosProof, Header, KESSignature, Proof, BLOCK_VERSION_CONSENSUS_BFT,
+    BftProof, BftSignature, BlockContentHash, BlockContentSize, BlockId, BlockVersion, ChainLength,
+    Common, GenesisPraosProof, Header, KESSignature, Proof, BLOCK_VERSION_CONSENSUS_BFT,
     BLOCK_VERSION_CONSENSUS_GENESIS_PRAOS, BLOCK_VERSION_CONSENSUS_NONE,
 };
 pub use self::message::Message;


### PR DESCRIPTION
This adds the chain length (i.e. number of ancestors of a block) to the block header. Note that the chain length is not currently verified anywhere.