### PR TITLE
allow creating accounts from the output of a transaction

### DIFF
--- a/chain-impl-mockchain/src/ledger.rs
+++ b/chain-impl-mockchain/src/ledger.rs
@@ -62,11 +62,13 @@ impl Ledger {
     pub fn apply_transaction(
         &mut self,
         signed_tx: &SignedTransaction<Address>,
+        allow_account_creation: bool,
     ) -> Result<Self, Error> {
         let mut ledger = self.clone();
         let transaction_id = signed_tx.transaction.hash();
         ledger = internal_apply_transaction(
             ledger,
+            allow_account_creation,
             &transaction_id,
             &signed_tx.transaction.inputs[..],
             &signed_tx.transaction.outputs[..],
@@ -96,6 +98,7 @@ impl property::Ledger<SignedTransaction<Address>> for Ledger {
 /// Apply the transaction
 fn internal_apply_transaction(
     mut ledger: Ledger,
+    allow_account_creation: bool,
     transaction_id: &TransactionId,
     inputs: &[Input],
     outputs: &[Output<Address>],
@@ -154,7 +157,15 @@ fn internal_apply_transaction(
             Kind::Account(identifier) => {
                 // don't have a way to make a newtype ref from the ref so .clone()
                 let account = identifier.clone().into();
-                ledger.accounts = ledger.accounts.add_value(&account, output.value)?;
+                ledger.accounts = match ledger.accounts.add_value(&account, output.value) {
+                    Ok(accounts) => accounts,
+                    Err(account::LedgerError::NonExistent) if allow_account_creation => {
+                        // if the account was not existent and that we allow creating
+                        // account out of the blue, then fallback on adding the account
+                        ledger.accounts.add_account(&account, output.value)?
+                    }
+                    Err(error) => return Err(error.into()),
+                };
             }
         }
     }

--- a/chain-impl-mockchain/src/state.rs
+++ b/chain-impl-mockchain/src/state.rs
@@ -69,7 +69,10 @@ impl property::State for State {
         for content in contents {
             match content {
                 Message::Transaction(signed_transaction) => {
-                    new_ledger = new_ledger.apply_transaction(signed_transaction)?;
+                    new_ledger = new_ledger.apply_transaction(
+                        signed_transaction,
+                        new_settings.allow_account_creation(),
+                    )?;
                 }
                 Message::Update(update_proposal) => {
                     new_settings = new_settings.apply(update_proposal.clone());


### PR DESCRIPTION
this is allowed if and only if the settings are set to allow it.
Adding this allows creating accounts without publishing a certificate