### PR TITLE
[IOHKCRB-12] Improve error handling for wallet creation

### DIFF
--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -157,8 +157,9 @@ typedef struct cardano_account cardano_account;
 * \param [in] password_size The size of the password string
 * \returns pointer to the constructed wallet that must be freed with `cardano_wallet_delete`
 */
-cardano_wallet *cardano_wallet_new(const uint8_t * const entropy_ptr, unsigned long entropy_size,
-                                   const char * const password_ptr, unsigned long password_size);
+cardano_result cardano_wallet_new(const uint8_t * const entropy_ptr, unsigned long entropy_size,
+                                   const char * const password_ptr, unsigned long password_size,
+                                   cardano_wallet** wallet);
 /*!
 * Free the memory of a wallet allocated with `cardano_wallet_new`
 */

--- a/cardano-c/test/test.c
+++ b/cardano-c/test/test.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include "cardano.h"
+#include "../cardano.h"
 #include "unity/unity.h"
 
 static const uint8_t static_wallet_entropy[16] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
@@ -13,13 +13,15 @@ void test_can_create_address(void)
     static char *address[1];
     size_t NUMBER_OF_ADDRESSES = sizeof(address) / sizeof(char *);
 
-    cardano_wallet *wallet = cardano_wallet_new(
+    cardano_wallet *wallet;
+    cardano_result wallet_rc = cardano_wallet_new(
         static_wallet_entropy,
         sizeof(static_wallet_entropy),
         "abc",
-        strlen("abc"));
+        strlen("abc"),
+        &wallet);
 
-    TEST_ASSERT_MESSAGE(wallet, "The wallet creation failed");
+    TEST_ASSERT_EQUAL_MESSAGE(0, wallet_rc, "The wallet creation failed");
 
     cardano_account *account = cardano_account_create(wallet, alias, 0);
 
@@ -36,9 +38,39 @@ void test_can_create_address(void)
     cardano_wallet_delete(wallet);
 }
 
+void invalid_entropy_size_returns_failure()
+{
+    char *password = "abc";
+    const uint8_t invalid_wallet_entropy[4] = {0};
+
+    cardano_wallet *wallet;
+    cardano_result wallet_rc = cardano_wallet_new(
+        invalid_wallet_entropy, sizeof(invalid_wallet_entropy), password, strlen(password), &wallet);
+
+    TEST_ASSERT_EQUAL(1, wallet_rc);
+}
+
+void valid_entropy_size_returns_success()
+{
+    const size_t valid_sizes[] = {12, 16, 20, 24, 28, 32};
+    const char *password = "abc";
+    for (int i = 0; i < sizeof(valid_sizes) / sizeof(size_t); ++i)
+    {
+        size_t size = valid_sizes[i];
+        uint8_t *valid_wallet_entropy = malloc(size);
+        cardano_wallet *wallet;
+        cardano_result wallet_rc = cardano_wallet_new(
+            valid_wallet_entropy, size, password, strlen(password), &wallet);
+        TEST_ASSERT_EQUAL(0, wallet_rc);
+        free(valid_wallet_entropy);
+    }
+}
+
 int main(void)
 {
     UNITY_BEGIN();
     RUN_TEST(test_can_create_address);
+    RUN_TEST(invalid_entropy_size_returns_failure);
+    RUN_TEST(valid_entropy_size_returns_success);
     return UNITY_END();
 }

--- a/cardano-c/test/test_transaction.c
+++ b/cardano-c/test/test_transaction.c
@@ -20,11 +20,12 @@ static uint8_t txid[32] = {0};
 
 void setUp()
 {
-    wallet = cardano_wallet_new(
+    cardano_result wallet_rc = cardano_wallet_new(
         static_wallet_entropy,
         sizeof(static_wallet_entropy),
         "password",
-        strlen("password"));
+        strlen("password"),
+        &wallet);
 
     account = cardano_account_create(wallet, "main", 0);
 


### PR DESCRIPTION
---
name: [IOHKCRB-12] Add test of transaction creation
---

# Description

## Error handling

- Make `cardano_wallet_new` return the created wallet as an out parameter and use the return value for the error code. This way it no longer returns a null pointer if the size of the entropy array is not valid.
- Add the tests to validate that the error code is consistent
