### PR TITLE
[IOHKCRB-16] Unimplemented functions in XPrv module

### DIFF
--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -114,8 +114,23 @@ cardano_xpub *cardano_xprv_delete(cardano_xprv *privkey);
 */
 cardano_xpub *cardano_xprv_to_xpub(cardano_xprv *privkey);
 
+/*!
+* Get the bytes representation of cardano_xprv
+* \sa cardano_xprv_bytes_delete
+*/
 uint8_t *cardano_xprv_to_bytes(cardano_xprv *privkey);
-cardano_xprv *cardano_xprv_from_bytes(uint8_t bytes[XPRV_SIZE]);
+
+/*!
+* Free the memory allocated with `cardano_xprv_to_bytes`
+*/
+void cardano_xprv_bytes_delete(uint8_t  *bytes);
+
+/*!
+* \brief Construct cardano_xprv from the given bytes
+* \returns 1 if the representation is invalid 0 otherwise
+* \sa cardano_xprv_delete
+*/
+cardano_result cardano_xprv_from_bytes(uint8_t *bytes, cardano_xprv **xprv_out);
 
 /*!
 * Free the associated memory

--- a/cardano-c/src/key.rs
+++ b/cardano-c/src/key.rs
@@ -1,10 +1,10 @@
 use cardano::hdwallet;
 use std::{
     ffi,
-    ptr,
     os::raw::{c_char, c_int},
+    ptr, slice,
 };
-use types::{XPrvPtr, XPubPtr};
+use types::{CardanoResult, XPrvPtr, XPubPtr};
 
 #[no_mangle]
 pub extern "C" fn cardano_xprv_derive(c_xprv: XPrvPtr, index: u32) -> XPrvPtr {
@@ -15,22 +15,47 @@ pub extern "C" fn cardano_xprv_derive(c_xprv: XPrvPtr, index: u32) -> XPrvPtr {
 }
 
 #[no_mangle]
-pub extern "C" fn cardano_xprv_from_bytes(c_xprv: *const u8) -> XPrvPtr {
+pub extern "C" fn cardano_xprv_from_bytes(
+    c_xprv: *const u8,
+    xprv_out: *mut XPrvPtr,
+) -> CardanoResult {
     let xprv_data = unsafe { slice::from_raw_parts(c_xprv, hdwallet::XPRV_SIZE) };
-    match hdwallet::XPrv::from_slice(xprv_data) {
+    let array = {
+        let mut array = [0u8; 96];
+        array.copy_from_slice(xprv_data);
+        array
+    };
+    match hdwallet::XPrv::from_bytes_verified(array) {
         Ok(r) => {
+            println!("ok");
             let xprv = Box::new(r);
-            Box::into_raw(xprv)
-        },
-        Err(_) => {
-            ptr::null_mut()
+            unsafe { ptr::write(xprv_out, Box::into_raw(xprv)) };
+            CardanoResult::success()
         }
+        Err(_) => CardanoResult::failure(),
     }
 }
 
 #[no_mangle]
 pub extern "C" fn cardano_xprv_to_bytes(c_xprv: XPrvPtr) -> *const u8 {
-    unimplemented!()
+    //Get the inner byte array without taking ownership
+    let slice: &[u8] = unsafe { (*c_xprv).as_ref() };
+
+    let mut vector: Vec<u8> = Vec::with_capacity(hdwallet::XPRV_SIZE);
+    vector.extend_from_slice(slice);
+
+    //Get pointer to the inner value
+    let ptr = vector.as_ptr();
+
+    //Avoid running the destructor
+    std::mem::forget(vector);
+    ptr
+}
+
+#[no_mangle]
+pub extern "C" fn cardano_xprv_bytes_delete(bytes: *mut u8) {
+    let vector = unsafe { Vec::from_raw_parts(bytes, hdwallet::XPRV_SIZE, hdwallet::XPRV_SIZE) };
+    std::mem::drop(vector)
 }
 
 #[no_mangle]
@@ -41,21 +66,19 @@ pub extern "C" fn cardano_xprv_to_xpub(c_xprv: XPrvPtr) -> XPubPtr {
 }
 
 #[no_mangle]
-pub extern "C" fn cardano_xprv_delete(c_xpub: XPrvPtr) {
+pub extern "C" fn cardano_xprv_delete(c_xprv: XPrvPtr) {
     unsafe { Box::from_raw(c_xprv) };
 }
 
 #[no_mangle]
-pub extern "C" fn cardano_xpub_derive(c_xprv: XPubPtr, index: u32) -> XPubPtr {
+pub extern "C" fn cardano_xpub_derive(c_xpub: XPubPtr, index: u32) -> XPubPtr {
     let xpub = unsafe { c_xpub.as_mut() }.expect("Not a NULL PTR");
     match xpub.derive(hdwallet::DerivationScheme::V2, index) {
         Ok(r) => {
             let child = Box::new(r);
             Box::into_raw(child)
-        },
-        Err(_) => {
-            ptr::null_mut()
         }
+        Err(_) => ptr::null_mut(),
     }
 }
 

--- a/cardano-c/src/key.rs
+++ b/cardano-c/src/key.rs
@@ -54,7 +54,9 @@ pub extern "C" fn cardano_xprv_to_bytes(c_xprv: XPrvPtr) -> *const u8 {
 
 #[no_mangle]
 pub extern "C" fn cardano_xprv_bytes_delete(bytes: *mut u8) {
-    let vector = unsafe { Vec::from_raw_parts(bytes, hdwallet::XPRV_SIZE, hdwallet::XPRV_SIZE) };
+    let mut vector =
+        unsafe { Vec::from_raw_parts(bytes, hdwallet::XPRV_SIZE, hdwallet::XPRV_SIZE) };
+    cardano::util::securemem::zero(&mut vector);
     std::mem::drop(vector)
 }
 

--- a/cardano-c/src/lib.rs
+++ b/cardano-c/src/lib.rs
@@ -2,12 +2,14 @@ extern crate cardano;
 
 pub mod address;
 pub mod bip39;
+pub mod key;
 pub mod transaction;
 pub mod types;
 pub mod wallet;
 
 pub use address::*;
 pub use bip39::*;
+pub use key::*;
 pub use transaction::*;
 pub use types::*;
 pub use wallet::*;

--- a/cardano-c/test/test_xprv.c
+++ b/cardano-c/test/test_xprv.c
@@ -1,0 +1,52 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include "../cardano.h"
+#include "unity/unity.h"
+
+void can_serialize_xprv(void)
+{
+    uint8_t bytes[XPRV_SIZE] = {0};
+    bytes[0] = 0b00000000;
+    bytes[31] = 0b01000000;
+
+    cardano_xprv *xprv;
+    cardano_result rc = cardano_xprv_from_bytes(bytes, &xprv);
+
+    uint8_t *new_bytes = cardano_xprv_to_bytes(xprv);
+
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(bytes, new_bytes, XPRV_SIZE);
+    cardano_xprv_bytes_delete(new_bytes);
+    cardano_xprv_delete(xprv);
+}
+
+void xprv_from_invalid_bytes_returns_failure()
+{
+    uint8_t bytes[XPRV_SIZE] = {0};
+    cardano_xprv *xprv;
+    cardano_result rc = cardano_xprv_from_bytes(bytes, &xprv);
+    TEST_ASSERT_EQUAL(1, rc);
+}
+
+void xprv_from_valid_bytes_returns_success()
+{
+    uint8_t bytes[XPRV_SIZE] = {0};
+    bytes[0] = 0b00000000;
+    bytes[31] = 0b01000000;
+
+    cardano_xprv *xprv;
+    cardano_result rc = cardano_xprv_from_bytes(bytes, &xprv);
+
+    TEST_ASSERT_EQUAL(0, rc);
+    cardano_xprv_delete(xprv);
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(can_serialize_xprv);
+    RUN_TEST(xprv_from_invalid_bytes_returns_failure);
+    RUN_TEST(xprv_from_valid_bytes_returns_success);
+    return UNITY_END();
+}


### PR DESCRIPTION
---
name: [IOHKCRB-16] Unimplemented functions in XPrv module
---
# Description

- Fix compilation issues in *key.rs* and export it.
- Implemented `cardano_xprv_to_bytes`.
- Associated function `cardano_xprv_bytes_delete` to free the allocated memory.
- Return `cardano_error` in `cardano_xprv_from_bytes` to contemplate failure. <sup>1</sup>

<sup>1</sup> _The error can happen because I used `from_bytes_verified` (instead of `from_bytes`), previously it was using `from_slice` but I didn't compile because it is  a private method._