### PR TITLE
Rework the node gossip protocol

### DIFF
--- a/network-core/src/client/block.rs
+++ b/network-core/src/client/block.rs
@@ -53,7 +53,7 @@ pub trait BlockService {
     // implementation to produce a server-streamed response.
     //type GetHeadersFuture: Future<Item = Self::GetHeadersStream, Error = Error>;
 
-    /// The type of asynchronous futures returned by method `subscribe`.
+    /// The type of asynchronous futures returned by method `block_subscription`.
     ///
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a subscription stream.

--- a/network-core/src/client/gossip.rs
+++ b/network-core/src/client/gossip.rs
@@ -1,13 +1,16 @@
-use crate::{error::Error, gossip::NodeGossip};
+use crate::{
+    error::Error,
+    gossip::{Gossip, Node},
+};
 
 use futures::prelude::*;
 
 pub trait GossipService {
-    type NodeGossip: NodeGossip;
+    type Node: Node;
 
     /// The type of an asynchronous stream that provides node gossip messages
     /// sent by the peer.
-    type GossipSubscription: Stream<Item = Self::NodeGossip, Error = Error>;
+    type GossipSubscription: Stream<Item = Gossip<Self::Node>, Error = Error>;
 
     /// The type of asynchronous futures returned by method `gossip_subscription`.
     ///
@@ -22,5 +25,5 @@ pub trait GossipService {
     /// as a long-lived subscription handle.
     fn gossip_subscription<S>(&mut self, outbound: S) -> Self::GossipSubscriptionFuture
     where
-        S: Stream<Item = Self::NodeGossip> + Send + 'static;
+        S: Stream<Item = Gossip<Self::Node>> + Send + 'static;
 }

--- a/network-core/src/client/gossip.rs
+++ b/network-core/src/client/gossip.rs
@@ -1,16 +1,26 @@
-use crate::{
-    error::Error,
-    gossip::{self, Gossip},
-};
+use crate::{error::Error, gossip::NodeGossip};
 
 use futures::prelude::*;
 
 pub trait GossipService {
-    type Gossip: Gossip;
+    type NodeGossip: NodeGossip;
 
-    /// Future that represent an asynchronous gossip request.
-    type GossipFuture: Future<Item = (gossip::NodeId, Self::Gossip), Error = Error>;
+    /// The type of an asynchronous stream that provides node gossip messages
+    /// sent by the peer.
+    type GossipSubscription: Stream<Item = Self::NodeGossip, Error = Error>;
 
-    /// Request to announce our own gossip and bring back result.
-    fn gossip(&mut self, node_id: &gossip::NodeId, gossip: &Self::Gossip) -> Self::GossipFuture;
+    /// The type of asynchronous futures returned by method `subscription`.
+    ///
+    /// The future resolves to a stream that will be used by the protocol
+    /// implementation to produce a subscription stream.
+    type GossipSubscriptionFuture: Future<Item = Self::GossipSubscription, Error = Error>;
+
+    /// Establishes a bidirectional stream of notifications for gossip
+    /// messages.
+    ///
+    /// The client can use the stream that the returned future resolves to
+    /// as a long-lived subscription handle.
+    fn subscription<S>(&mut self, outbound: S) -> Self::GossipSubscriptionFuture
+    where
+        S: Stream<Item = Self::NodeGossip> + Send + 'static;
 }

--- a/network-core/src/client/gossip.rs
+++ b/network-core/src/client/gossip.rs
@@ -9,7 +9,7 @@ pub trait GossipService {
     /// sent by the peer.
     type GossipSubscription: Stream<Item = Self::NodeGossip, Error = Error>;
 
-    /// The type of asynchronous futures returned by method `subscription`.
+    /// The type of asynchronous futures returned by method `gossip_subscription`.
     ///
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a subscription stream.
@@ -20,7 +20,7 @@ pub trait GossipService {
     ///
     /// The client can use the stream that the returned future resolves to
     /// as a long-lived subscription handle.
-    fn subscription<S>(&mut self, outbound: S) -> Self::GossipSubscriptionFuture
+    fn gossip_subscription<S>(&mut self, outbound: S) -> Self::GossipSubscriptionFuture
     where
         S: Stream<Item = Self::NodeGossip> + Send + 'static;
 }

--- a/network-core/src/gossip.rs
+++ b/network-core/src/gossip.rs
@@ -1,24 +1,5 @@
 use chain_core::property::{Deserialize, Serialize};
-use std::{error, fmt, net::SocketAddr};
-
-#[derive(Clone, Debug)]
-pub enum NodeIdError {
-    InvalidSize(usize),
-}
-
-impl error::Error for NodeIdError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        None
-    }
-}
-
-impl fmt::Display for NodeIdError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            NodeIdError::InvalidSize(size) => write!(f, "invalid node id size: {}", size),
-        }
-    }
-}
+use std::net::SocketAddr;
 
 /// Abstract trait for data types representing gossip about network nodes.
 pub trait NodeGossip {

--- a/network-core/src/gossip.rs
+++ b/network-core/src/gossip.rs
@@ -1,17 +1,43 @@
 use chain_core::property::{Deserialize, Serialize};
-use std::net::SocketAddr;
+
+use std::{iter::FromIterator, net::SocketAddr};
+
+/// Marker trait for the type representing a node ID.
+pub trait NodeId: Serialize + Deserialize {}
 
 /// Abstract trait for data types representing gossip about network nodes.
-pub trait NodeGossip {
+pub trait Node: Serialize + Deserialize {
     /// Type that represents the node identifier in the gossip message.
-    type NodeId: Serialize + Deserialize;
-
-    /// Constructs a new instance from an id and a socket address.
-    fn new(id: Self::NodeId, addr: SocketAddr) -> Self;
+    type Id: NodeId;
 
     /// Returns the node identifier.
-    fn id(&self) -> Self::NodeId;
+    fn id(&self) -> Self::Id;
 
-    /// Returns the TCP socket address.
-    fn addr(&self) -> SocketAddr;
+    /// Returns the TCP socket address, if available for this node.
+    fn address(&self) -> Option<SocketAddr>;
+}
+
+pub struct Gossip<T: Node> {
+    sender: T::Id,
+    nodes: Vec<T>,
+}
+
+impl<T: Node> Gossip<T> {
+    pub fn from_nodes<I>(sender: T::Id, iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        Gossip {
+            sender,
+            nodes: Vec::from_iter(iter.into_iter()),
+        }
+    }
+
+    pub fn sender(&self) -> &T::Id {
+        &self.sender
+    }
+
+    pub fn nodes(&self) -> &[T] {
+        &self.nodes
+    }
 }

--- a/network-core/src/gossip.rs
+++ b/network-core/src/gossip.rs
@@ -1,8 +1,5 @@
 use chain_core::property::{Deserialize, Serialize};
-use std::{error, fmt};
-
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
-pub struct NodeId([u8; 16]);
+use std::{error, fmt, net::SocketAddr};
 
 #[derive(Clone, Debug)]
 pub enum NodeIdError {
@@ -23,28 +20,17 @@ impl fmt::Display for NodeIdError {
     }
 }
 
-impl NodeId {
-    pub fn from_slice(slice: &[u8]) -> Result<Self, NodeIdError> {
-        if slice.len() != 16 {
-            return Err(NodeIdError::InvalidSize(slice.len()));
-        }
-        let mut buf = [0; 16];
-        buf[0..16].clone_from_slice(slice);
-        Ok(NodeId(buf))
-    }
+/// Abstract trait for data types representing gossip about network nodes.
+pub trait NodeGossip {
+    /// Type that represents the node identifier in the gossip message.
+    type NodeId: Serialize + Deserialize;
 
-    pub fn to_bytes(&self) -> Vec<u8> {
-        self.0[..].into()
-    }
-}
+    /// Constructs a new instance from an id and a socket address.
+    fn new(id: Self::NodeId, addr: SocketAddr) -> Self;
 
-pub trait Gossip: Serialize + Deserialize {
-    /// Type that represents NodeId in the gossip message.
-    type NodeId: Sized;
-    /// Information about the node that is kept in the gossip message.
-    type Node;
+    /// Returns the node identifier.
+    fn id(&self) -> Self::NodeId;
 
-    fn from_nodes<I>(iter: I) -> Self
-    where
-        I: IntoIterator<Item = Self::Node>;
+    /// Returns the TCP socket address.
+    fn addr(&self) -> SocketAddr;
 }

--- a/network-core/src/server/content.rs
+++ b/network-core/src/server/content.rs
@@ -36,7 +36,7 @@ pub trait ContentService {
     /// by the peer via the bidirectional subscription.
     type MessageSubscription: Stream<Item = Self::Message, Error = Error>;
 
-    /// The type of asynchronous futures returned by method `block_subscription`.
+    /// The type of asynchronous futures returned by method `message_subscription`.
     ///
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a server-streamed response.

--- a/network-core/src/server/gossip.rs
+++ b/network-core/src/server/gossip.rs
@@ -1,5 +1,8 @@
 ///! Gossip service abstraction.
-use crate::{error::Error, gossip::NodeGossip};
+use crate::{
+    error::Error,
+    gossip::{Gossip, Node},
+};
 
 use futures::prelude::*;
 
@@ -7,11 +10,11 @@ use futures::prelude::*;
 /// in the p2p network.
 pub trait GossipService {
     /// Gossip message content.
-    type NodeGossip: NodeGossip;
+    type Node: Node;
 
     /// The type of an asynchronous stream that retrieves node gossip
     /// messages from a peer.
-    type GossipSubscription: Stream<Item = Self::NodeGossip, Error = Error>;
+    type GossipSubscription: Stream<Item = Gossip<Self::Node>, Error = Error>;
 
     /// The type of asynchronous futures returned by method `gossip_subscription`.
     ///
@@ -20,11 +23,11 @@ pub trait GossipService {
     type GossipSubscriptionFuture: Future<Item = Self::GossipSubscription, Error = Error>;
 
     // Establishes a bidirectional subscription for node gossip messages,
-    // taking an asynchronous stream that provides the outbound announcements.
+    // taking an asynchronous stream that provides the inbound announcements.
     //
     // Returns a future that resolves to an asynchronous subscription stream
     // that receives node gossip messages sent by the peer.
-    fn gossip_subscription<Out>(&mut self, outbound: Out) -> Self::GossipSubscriptionFuture
+    fn gossip_subscription<In>(&mut self, inbound: In) -> Self::GossipSubscriptionFuture
     where
-        Out: Stream<Item = Self::NodeGossip, Error = Error>;
+        In: Stream<Item = Gossip<Self::Node>, Error = Error>;
 }

--- a/network-core/src/server/gossip.rs
+++ b/network-core/src/server/gossip.rs
@@ -13,7 +13,7 @@ pub trait GossipService {
     /// messages from a peer.
     type GossipSubscription: Stream<Item = Self::NodeGossip, Error = Error>;
 
-    /// The type of asynchronous futures returned by method `subscription`.
+    /// The type of asynchronous futures returned by method `gossip_subscription`.
     ///
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a server-streamed response.
@@ -24,7 +24,7 @@ pub trait GossipService {
     //
     // Returns a future that resolves to an asynchronous subscription stream
     // that receives node gossip messages sent by the peer.
-    fn subscription<Out>(&mut self, outbound: Out) -> Self::GossipSubscriptionFuture
+    fn gossip_subscription<Out>(&mut self, outbound: Out) -> Self::GossipSubscriptionFuture
     where
         Out: Stream<Item = Self::NodeGossip, Error = Error>;
 }

--- a/network-grpc/proto/node.proto
+++ b/network-grpc/proto/node.proto
@@ -50,14 +50,12 @@ message Message {
     bytes content = 1;
 }
 
-// Gossip message with information of a single network node.
-message NodeGossip {
-    // The node identifier.
-    bytes id = 1;
-    // The IP address.
-    string host = 2;
-    // Port number.
-    uint32 port = 3;
+// Gossip message with information on nodes in the network.
+message Gossip {
+    // ID of the sender node (TODO: replace with gRPC metadata).
+    bytes sender = 1;
+    // Serialized descriptions of nodes.
+    repeated bytes nodes = 2;
 }
 
 service Node {
@@ -84,5 +82,5 @@ service Node {
 
     // Establishes a bidirectional stream to exchange information on new
     // network peers.
-    rpc GossipSubscription (stream NodeGossip) returns (stream NodeGossip);
+    rpc GossipSubscription (stream Gossip) returns (stream Gossip);
 }

--- a/network-grpc/proto/node.proto
+++ b/network-grpc/proto/node.proto
@@ -50,14 +50,14 @@ message Message {
     bytes content = 1;
 }
 
-// Gossip message.
-message GossipMessage {
-    message NodeId {
-      bytes content = 1;
-    }
-
-    NodeId node_id = 1;
-    bytes content = 2;
+// Gossip message with information of a single network node.
+message NodeGossip {
+    // The node identifier.
+    bytes id = 1;
+    // The IP address.
+    string host = 2;
+    // Port number.
+    uint32 port = 3;
 }
 
 service Node {
@@ -82,5 +82,7 @@ service Node {
     // messages created or accepted by the peers.
     rpc MessageSubscription (stream Message) returns (stream Message);
 
-    rpc Gossip (GossipMessage) returns (GossipMessage);
+    // Establishes a bidirectional stream to exchange information on new
+    // network peers.
+    rpc GossipSubscription (stream NodeGossip) returns (stream NodeGossip);
 }

--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -417,7 +417,7 @@ where
     type GossipSubscription = ResponseStream<C::NodeGossip, gen::node::NodeGossip>;
     type GossipSubscriptionFuture = BidiStreamFuture<C::NodeGossip, gen::node::NodeGossip>;
 
-    fn subscription<Out>(&mut self, outbound: Out) -> Self::GossipSubscriptionFuture
+    fn gossip_subscription<Out>(&mut self, outbound: Out) -> Self::GossipSubscriptionFuture
     where
         Out: Stream<Item = C::NodeGossip> + Send + 'static,
     {

--- a/network-grpc/src/service.rs
+++ b/network-grpc/src/service.rs
@@ -361,6 +361,6 @@ where
     ) -> Self::GossipSubscriptionFuture {
         let service = try_get_service!(self.gossip_service);
         let stream = RequestStream::new(request.into_inner());
-        ResponseFuture::new(service.subscription(stream))
+        ResponseFuture::new(service.gossip_subscription(stream))
     }
 }

--- a/network-grpc/src/service.rs
+++ b/network-grpc/src/service.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 use network_core::{
-    error as core_error, gossip,
+    error as core_error,
     server::{block::BlockService, content::ContentService, gossip::GossipService, Node},
 };
 
@@ -277,7 +277,7 @@ where
         <<T as Node>::ContentService as ContentService>::MessageSubscriptionFuture,
     >;
     type GossipSubscriptionStream = ResponseStream<
-        gen::node::NodeGossip,
+        gen::node::Gossip,
         <<T as Node>::GossipService as GossipService>::GossipSubscription,
     >;
     type GossipSubscriptionFuture = ResponseFuture<
@@ -357,7 +357,7 @@ where
 
     fn gossip_subscription(
         &mut self,
-        request: Request<Streaming<gen::node::NodeGossip>>,
+        request: Request<Streaming<gen::node::Gossip>>,
     ) -> Self::GossipSubscriptionFuture {
         let service = try_get_service!(self.gossip_service);
         let stream = RequestStream::new(request.into_inner());


### PR DESCRIPTION
Make node gossip propagated bidirectionally, like blocks and
transactions.
Each gossip message carries information on a single node.