### PR TITLE
[IOHKCRB-13] Improve error handling for transaction module

### DIFF
--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -207,17 +207,17 @@ void cardano_account_delete_addresses(char *addresses_ptr[], unsigned long lengt
 /* transaction error definitions */
 typedef enum _transaction_config_error
 {
-    TRANSACTION_SUCCESS = 0,
-    TRANSACTION_NO_OUTPUT = 1,
-    TRANSACTION_NO_INPUT = 2,
+    CARDANO_TRANSACTION_SUCCESS = 0,
+    CARDANO_TRANSACTION_NO_OUTPUT = 1,
+    CARDANO_TRANSACTION_NO_INPUT = 2,
     //The number of signatures doesn't match the number of inputs
-    TRANSACTION_SIGNATURE_MISMATCH = 3,
+    CARDANO_TRANSACTION_SIGNATURE_MISMATCH = 3,
     //The transaction is too big
-    TRANSACTION_OVER_LIMIT = 4,
+    CARDANO_TRANSACTION_OVER_LIMIT = 4,
     //The number of signatures is greater than the number of inputs
-    TRANSACTION_SIGNATURES_EXCEEDED = 5,
+    CARDANO_TRANSACTION_SIGNATURES_EXCEEDED = 5,
     //The given value is greater than the maximum allowed coin value
-    TRANSACTION_COIN_OUT_OF_BOUNDS = 6,
+    CARDANO_TRANSACTION_COIN_OUT_OF_BOUNDS = 6,
 } cardano_transaction_error_t;
 
 typedef struct cardano_transaction_builder cardano_transaction_builder;
@@ -290,6 +290,7 @@ void cardano_transaction_builder_add_output(cardano_transaction_builder *tb, car
 * \param [in] c_txo created with `cardano_transaction_output_ptr_new`
 * \param [in] value the cost 
 * \sa cardano_transaction_output_ptr_new()
+* \returns CARDANO_TRANSACTION_SUCCESS | CARDANO_TRANSACTION_COIN_OUT_OF_BOUNDS
 */
 cardano_transaction_error_t cardano_transaction_builder_add_input(cardano_transaction_builder *tb, cardano_txoptr *c_txo, uint64_t value);
 
@@ -320,7 +321,7 @@ uint64_t cardano_transaction_builder_fee(cardano_transaction_builder *tb);
 
 /*!
 * \brief Get a transaction object
-* \returns TRANSACTION_SUCCESS | TRANSACTION_NO_INPUT | TRANSACTION_NO_OUTPUT
+* \returns CARDANO_TRANSACTION_SUCCESS | CARDANO_TRANSACTION_NO_INPUT | CARDANO_TRANSACTION_NO_OUTPUT
 */
 cardano_transaction_error_t cardano_transaction_builder_finalize(cardano_transaction_builder *tb, cardano_transaction **tx);
 void cardano_transaction_delete(cardano_transaction *c_tx);
@@ -340,7 +341,7 @@ void cardano_transaction_finalized_delete(cardano_transaction_finalized *tf);
 * \param protocol_magic
 * \param c_txid
 * \sa cardano_transaction_builder_new
-* \returns TRANSACTION_SUCCESS | TRANSACTION_SIGNATURES_EXCEEDED
+* \returns CARDANO_TRANSACTION_SUCCESS | CARDANO_TRANSACTION_SIGNATURES_EXCEEDED
 */
 cardano_transaction_error_t cardano_transaction_finalized_add_witness(cardano_transaction_finalized *tf, uint8_t c_xprv[96], uint32_t protocol_magic, uint8_t c_txid[32]);
 
@@ -348,6 +349,7 @@ cardano_transaction_error_t cardano_transaction_finalized_add_witness(cardano_tr
 * \brief A finalized transaction with the vector of witnesses
 * \param tf a finalized transaction with witnesses
 * \sa cardano_transaction_finalized_add_witness()
+* \returns CARDANO_TRANSACTION_SUCCESS | CARDANO_TRANSACTION_SIGNATURE_MISMATCH | CARDANO_TRANSACTION_OVER_LIMIT
 */
 cardano_transaction_error_t cardano_transaction_finalized_output(cardano_transaction_finalized *tf, cardano_signed_transaction **txaux);
 void cardano_transaction_signed_delete(cardano_signed_transaction *txaux);

--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -204,6 +204,18 @@ void cardano_account_delete_addresses(char *addresses_ptr[], unsigned long lengt
 /* Transactions */
 /****************/
 
+/* transaction error definitions */
+typedef enum _transaction_config_error
+{
+    TRANSACTION_SUCCESS = 0,
+    TRANSACTION_NO_INPUT = 1,
+    TRANSACTION_NO_OUTPUT = 2,
+    TRANSACTION_SIGNATURE_MISMATCH = 3,
+    TRANSACTION_OVER_LIMIT = 4,
+    TRANSACTION_SIGNATURES_EXCEEDED = 5,
+    TRANSACTION_COIN_OUT_OF_BOUNDS = 6,
+} cardano_transaction_error_t;
+
 typedef struct cardano_transaction_builder cardano_transaction_builder;
 typedef struct cardano_transaction_finalized cardano_transaction_finalized;
 /*!
@@ -305,7 +317,7 @@ uint64_t cardano_transaction_builder_fee(cardano_transaction_builder *tb);
 /*!
 * \brief Get a transaction object
 */
-cardano_transaction *cardano_transaction_builder_finalize(cardano_transaction_builder *tb);
+cardano_transaction_error_t *cardano_transaction_builder_finalize(cardano_transaction_builder *tb, cardano_transaction **tx);
 void cardano_transaction_delete(cardano_transaction *c_tx);
 
 /*!

--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -208,11 +208,15 @@ void cardano_account_delete_addresses(char *addresses_ptr[], unsigned long lengt
 typedef enum _transaction_config_error
 {
     TRANSACTION_SUCCESS = 0,
-    TRANSACTION_NO_INPUT = 1,
-    TRANSACTION_NO_OUTPUT = 2,
+    TRANSACTION_NO_OUTPUT = 1,
+    TRANSACTION_NO_INPUT = 2,
+    //The number of signatures doesn't match the number of inputs
     TRANSACTION_SIGNATURE_MISMATCH = 3,
+    //The transaction is too big
     TRANSACTION_OVER_LIMIT = 4,
+    //The number of signatures is greater than the number of inputs
     TRANSACTION_SIGNATURES_EXCEEDED = 5,
+    //The given value is greater than the maximum allowed coin value
     TRANSACTION_COIN_OUT_OF_BOUNDS = 6,
 } cardano_transaction_error_t;
 
@@ -316,6 +320,7 @@ uint64_t cardano_transaction_builder_fee(cardano_transaction_builder *tb);
 
 /*!
 * \brief Get a transaction object
+* \returns TRANSACTION_SUCCESS | TRANSACTION_NO_INPUT | TRANSACTION_NO_OUTPUT
 */
 cardano_transaction_error_t cardano_transaction_builder_finalize(cardano_transaction_builder *tb, cardano_transaction **tx);
 void cardano_transaction_delete(cardano_transaction *c_tx);
@@ -335,6 +340,7 @@ void cardano_transaction_finalized_delete(cardano_transaction_finalized *tf);
 * \param protocol_magic
 * \param c_txid
 * \sa cardano_transaction_builder_new
+* \returns TRANSACTION_SUCCESS | TRANSACTION_SIGNATURES_EXCEEDED
 */
 cardano_transaction_error_t cardano_transaction_finalized_add_witness(cardano_transaction_finalized *tf, uint8_t c_xprv[96], uint32_t protocol_magic, uint8_t c_txid[32]);
 

--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -350,6 +350,7 @@ cardano_transaction_error_t cardano_transaction_finalized_add_witness(cardano_tr
 * \sa cardano_transaction_finalized_add_witness()
 */
 cardano_transaction_error_t cardano_transaction_finalized_output(cardano_transaction_finalized *tf, cardano_signed_transaction **txaux);
+void cardano_transaction_signed_delete(cardano_signed_transaction *txaux);
 
 #ifdef __cplusplus
 }

--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -287,7 +287,7 @@ void cardano_transaction_builder_add_output(cardano_transaction_builder *tb, car
 * \param [in] value the cost 
 * \sa cardano_transaction_output_ptr_new()
 */
-cardano_result cardano_transaction_builder_add_input(cardano_transaction_builder *tb, cardano_txoptr *c_txo, uint64_t value);
+cardano_transaction_error_t cardano_transaction_builder_add_input(cardano_transaction_builder *tb, cardano_txoptr *c_txo, uint64_t value);
 
 /*!
 * \brief This associate all the leftover values, if any to an output with the specified address.

--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -317,7 +317,7 @@ uint64_t cardano_transaction_builder_fee(cardano_transaction_builder *tb);
 /*!
 * \brief Get a transaction object
 */
-cardano_transaction_error_t *cardano_transaction_builder_finalize(cardano_transaction_builder *tb, cardano_transaction **tx);
+cardano_transaction_error_t cardano_transaction_builder_finalize(cardano_transaction_builder *tb, cardano_transaction **tx);
 void cardano_transaction_delete(cardano_transaction *c_tx);
 
 /*!
@@ -336,14 +336,14 @@ void cardano_transaction_finalized_delete(cardano_transaction_finalized *tf);
 * \param c_txid
 * \sa cardano_transaction_builder_new
 */
-cardano_result cardano_transaction_finalized_add_witness(cardano_transaction_finalized *tf, uint8_t c_xprv[96], uint32_t protocol_magic, uint8_t c_txid[32]);
+cardano_transaction_error_t cardano_transaction_finalized_add_witness(cardano_transaction_finalized *tf, uint8_t c_xprv[96], uint32_t protocol_magic, uint8_t c_txid[32]);
 
 /*!
 * \brief A finalized transaction with the vector of witnesses
 * \param tf a finalized transaction with witnesses
 * \sa cardano_transaction_finalized_add_witness()
 */
-cardano_signed_transaction *cardano_transaction_finalized_output(cardano_transaction_finalized *tf);
+cardano_transaction_error_t cardano_transaction_finalized_output(cardano_transaction_finalized *tf, cardano_signed_transaction **txaux);
 
 #ifdef __cplusplus
 }

--- a/cardano-c/src/transaction.rs
+++ b/cardano-c/src/transaction.rs
@@ -72,14 +72,14 @@ pub extern "C" fn cardano_transaction_builder_add_input(
     tb: TransactionBuilderPtr,
     c_txo: TransactionOutputPointerPtr,
     value: u64,
-) -> CardanoResult {
+) -> CardanoTransactionErrorCode {
     let builder = unsafe { tb.as_mut() }.expect("Not a NULL PTR");
     let txo = unsafe { c_txo.as_ref() }.expect("Not a NULL PTR");
     if let Ok(coin) = Coin::new(value) {
         builder.add_input(txo, coin);
-        CardanoResult::success()
+        CardanoTransactionErrorCode::success()
     } else {
-        CardanoResult::failure()
+        CardanoTransactionErrorCode::coin_out_of_bounds()
     }
 }
 

--- a/cardano-c/src/transaction.rs
+++ b/cardano-c/src/transaction.rs
@@ -188,3 +188,8 @@ pub extern "C" fn cardano_transaction_finalized_output(
         _ => panic!("Shouldn't happen"),
     }
 }
+
+#[no_mangle]
+pub extern "C" fn cardano_transaction_signed_delete(txaux: SignedTransactionPtr) {
+    unsafe { Box::from_raw(txaux) };
+}

--- a/cardano-c/src/types.rs
+++ b/cardano-c/src/types.rs
@@ -51,26 +51,32 @@ impl CardanoTransactionErrorCode {
         CardanoTransactionErrorCode(0)
     }
 
+    ///Transaction has no outputs
     pub fn no_outputs() -> Self {
         CardanoTransactionErrorCode(1)
     }
 
+    ///Transaction has no inputs
     pub fn no_inputs() -> Self {
         CardanoTransactionErrorCode(2)
     }
 
+    ///Number of signatures does not match the number of witnesses
     pub fn signature_mismatch() -> Self {
         CardanoTransactionErrorCode(3)
     }
 
+    ///Transaction is too big
     pub fn over_limit() -> Self {
         CardanoTransactionErrorCode(4)
     }
 
+    ///Transaction has already enough signatures
     pub fn signatures_exceeded() -> Self {
         CardanoTransactionErrorCode(5)
     }
 
+    ///value is to big, max = 45000000000000000
     pub fn coin_out_of_bounds() -> Self {
         CardanoTransactionErrorCode(6)
     }

--- a/cardano-c/src/types.rs
+++ b/cardano-c/src/types.rs
@@ -43,6 +43,23 @@ impl CardanoBIP39ErrorCode {
     }
 }
 
+#[repr(C)]
+pub struct CardanoTransactionErrorCode(c_int);
+
+impl CardanoTransactionErrorCode {
+    pub fn success() -> Self {
+        CardanoTransactionErrorCode(0)
+    }
+
+    pub fn no_outputs() -> Self {
+        CardanoTransactionErrorCode(1)
+    }
+
+    pub fn no_inputs() -> Self {
+        CardanoTransactionErrorCode(2)
+    }
+}
+
 /// C pointer to an Extended Private Key
 pub type XPrvPtr = *mut hdwallet::XPrv;
 

--- a/cardano-c/src/types.rs
+++ b/cardano-c/src/types.rs
@@ -58,6 +58,18 @@ impl CardanoTransactionErrorCode {
     pub fn no_inputs() -> Self {
         CardanoTransactionErrorCode(2)
     }
+
+    pub fn signature_mismatch() -> Self {
+        CardanoTransactionErrorCode(3)
+    }
+
+    pub fn over_limit() -> Self {
+        CardanoTransactionErrorCode(4)
+    }
+
+    pub fn signatures_exceeded() -> Self {
+        CardanoTransactionErrorCode(5)
+    }
 }
 
 /// C pointer to an Extended Private Key

--- a/cardano-c/src/types.rs
+++ b/cardano-c/src/types.rs
@@ -70,6 +70,10 @@ impl CardanoTransactionErrorCode {
     pub fn signatures_exceeded() -> Self {
         CardanoTransactionErrorCode(5)
     }
+
+    pub fn coin_out_of_bounds() -> Self {
+        CardanoTransactionErrorCode(6)
+    }
 }
 
 /// C pointer to an Extended Private Key

--- a/cardano-c/test/test_transaction.c
+++ b/cardano-c/test/test_transaction.c
@@ -75,7 +75,7 @@ void test_add_input_returns_error_with_big_value()
     const uint64_t MAX_COIN = 45000000000000000;
     cardano_transaction_error_t irc = cardano_transaction_builder_add_input(txbuilder, input, MAX_COIN + 1);
 
-    TEST_ASSERT_EQUAL(TRANSACTION_COIN_OUT_OF_BOUNDS, irc);
+    TEST_ASSERT_EQUAL(CARDANO_TRANSACTION_COIN_OUT_OF_BOUNDS, irc);
 }
 
 void test_add_witness_returns_error_with_less_inputs()
@@ -85,21 +85,20 @@ void test_add_witness_returns_error_with_less_inputs()
     /* the builder finalize fails without outputs*/
     cardano_transaction_builder_add_output(txbuilder, output);
 
-    cardano_transaction *tx;
-    cardano_transaction_error_t tx_rc = cardano_transaction_builder_finalize(txbuilder, &tx);
+    cardano_transaction *tx; cardano_transaction_error_t tx_rc = cardano_transaction_builder_finalize(txbuilder, &tx);
 
-    TEST_ASSERT_EQUAL(TRANSACTION_SUCCESS, tx_rc);
+    TEST_ASSERT_EQUAL(CARDANO_TRANSACTION_SUCCESS, tx_rc);
 
     cardano_transaction_finalized *tf = cardano_transaction_finalized_new(tx);
 
     cardano_transaction_error_t rc1 = cardano_transaction_finalized_add_witness(tf, input_xprv, PROTOCOL_MAGIC, txid);
 
-    TEST_ASSERT_EQUAL(TRANSACTION_SUCCESS, rc1);
+    TEST_ASSERT_EQUAL(CARDANO_TRANSACTION_SUCCESS, rc1);
 
     cardano_transaction_error_t rc2 = cardano_transaction_finalized_add_witness(tf, input_xprv, PROTOCOL_MAGIC, txid);
 
     //#witnesses > #inputs
-    TEST_ASSERT_EQUAL(TRANSACTION_SIGNATURES_EXCEEDED, rc2);
+    TEST_ASSERT_EQUAL(CARDANO_TRANSACTION_SIGNATURES_EXCEEDED, rc2);
 
     cardano_transaction_delete(tx);
     cardano_transaction_finalized_delete(tf);
@@ -111,7 +110,7 @@ void test_builder_finalize_error_code_no_inputs()
 
     cardano_transaction *tx;
     cardano_transaction_error_t tx_rc = cardano_transaction_builder_finalize(txbuilder, &tx);
-    TEST_ASSERT_EQUAL(TRANSACTION_NO_INPUT, tx_rc);
+    TEST_ASSERT_EQUAL(CARDANO_TRANSACTION_NO_INPUT, tx_rc);
 }
 
 void test_builder_finalize_error_code_no_outputs()
@@ -120,7 +119,7 @@ void test_builder_finalize_error_code_no_outputs()
 
     cardano_transaction *tx;
     cardano_transaction_error_t tx_rc = cardano_transaction_builder_finalize(txbuilder, &tx);
-    TEST_ASSERT_EQUAL(TRANSACTION_NO_OUTPUT, tx_rc);
+    TEST_ASSERT_EQUAL(CARDANO_TRANSACTION_NO_OUTPUT, tx_rc);
 }
 
 void test_transaction_finalized_output_error_code_signature_mismatch()
@@ -141,7 +140,7 @@ void test_transaction_finalized_output_error_code_signature_mismatch()
     cardano_transaction_error_t rc = cardano_transaction_finalized_output(tf, &txaux);
 
     //#inputs (2) > #witnesses (1)
-    TEST_ASSERT_EQUAL(TRANSACTION_SIGNATURE_MISMATCH, rc);
+    TEST_ASSERT_EQUAL(CARDANO_TRANSACTION_SIGNATURE_MISMATCH, rc);
 
     cardano_transaction_delete(tx);
     cardano_transaction_finalized_delete(tf);

--- a/cardano-c/test/test_transaction.c
+++ b/cardano-c/test/test_transaction.c
@@ -11,6 +11,8 @@ cardano_account *account;
 cardano_address *input_address;
 cardano_address *output_address;
 cardano_transaction_builder *txbuilder;
+cardano_txoptr *input;
+cardano_txoutput *output;
 
 //Constants
 static uint32_t PROTOCOL_MAGIC = 1;
@@ -39,47 +41,48 @@ void setUp()
     cardano_account_delete_addresses(addresses, sizeof(addresses) / sizeof(char *));
 
     txbuilder = cardano_transaction_builder_new();
+    
+    input = cardano_transaction_output_ptr_new(txid, 1);
+    output = cardano_transaction_output_new(output_address, 1000);
 }
 
 void tearDown()
 {
-    cardano_account_delete(account);
+    cardano_transaction_output_delete(output);
+
+    cardano_transaction_output_ptr_delete(input);
 
     cardano_wallet_delete(wallet);
+
+    cardano_transaction_builder_delete(txbuilder);
 
     cardano_address_delete(input_address);
 
     cardano_address_delete(output_address);
 
-    cardano_transaction_builder_delete(txbuilder);
+    cardano_account_delete(account);
 }
 
 void test_add_input_returns_success_with_valid_value()
 {
-    cardano_txoptr *input = cardano_transaction_output_ptr_new(txid, 1);
     cardano_transaction_error_t irc = cardano_transaction_builder_add_input(txbuilder, input, 1000);
 
     TEST_ASSERT_EQUAL(CARDANO_RESULT_SUCCESS, irc);
-    cardano_transaction_output_ptr_delete(input);
 }
 
 void test_add_input_returns_error_with_big_value()
 {
     const uint64_t MAX_COIN = 45000000000000000;
-    cardano_txoptr *input = cardano_transaction_output_ptr_new(txid, 1);
     cardano_transaction_error_t irc = cardano_transaction_builder_add_input(txbuilder, input, MAX_COIN + 1);
 
     TEST_ASSERT_EQUAL(TRANSACTION_COIN_OUT_OF_BOUNDS, irc);
-    cardano_transaction_output_ptr_delete(input);
 }
 
 void test_add_witness_returns_error_with_less_inputs()
 {
-    cardano_txoptr *input = cardano_transaction_output_ptr_new(txid, 1);
     cardano_result irc = cardano_transaction_builder_add_input(txbuilder, input, 1000);
 
     /* the builder finalize fails without outputs*/
-    cardano_txoutput *output = cardano_transaction_output_new(output_address, 1000);
     cardano_transaction_builder_add_output(txbuilder, output);
 
     cardano_transaction *tx;
@@ -98,44 +101,33 @@ void test_add_witness_returns_error_with_less_inputs()
     //#witnesses > #inputs
     TEST_ASSERT_EQUAL(TRANSACTION_SIGNATURES_EXCEEDED, rc2);
 
-    cardano_transaction_output_ptr_delete(input);
-    cardano_transaction_output_delete(output);
     cardano_transaction_delete(tx);
     cardano_transaction_finalized_delete(tf);
 }
 
 void test_builder_finalize_error_code_no_inputs()
 {
-    cardano_txoutput *output = cardano_transaction_output_new(output_address, 1000);
     cardano_transaction_builder_add_output(txbuilder, output);
 
     cardano_transaction *tx;
     cardano_transaction_error_t tx_rc = cardano_transaction_builder_finalize(txbuilder, &tx);
     TEST_ASSERT_EQUAL(TRANSACTION_NO_INPUT, tx_rc);
-
-    cardano_transaction_output_delete(output);
 }
 
 void test_builder_finalize_error_code_no_outputs()
 {
-    cardano_txoptr *input = cardano_transaction_output_ptr_new(txid, 1);
     cardano_transaction_error_t irc = cardano_transaction_builder_add_input(txbuilder, input, 1000);
 
     cardano_transaction *tx;
     cardano_transaction_error_t tx_rc = cardano_transaction_builder_finalize(txbuilder, &tx);
     TEST_ASSERT_EQUAL(TRANSACTION_NO_OUTPUT, tx_rc);
-
-    cardano_transaction_output_ptr_delete(input);
 }
 
 void test_transaction_finalized_output_error_code_signature_mismatch()
 {
-    cardano_txoptr *input = cardano_transaction_output_ptr_new(txid, 1);
-
     cardano_transaction_error_t irc1 = cardano_transaction_builder_add_input(txbuilder, input, 1000);
     cardano_transaction_error_t irc2 = cardano_transaction_builder_add_input(txbuilder, input, 1000);
 
-    cardano_txoutput *output = cardano_transaction_output_new(output_address, 1000);
     cardano_transaction_builder_add_output(txbuilder, output);
 
     cardano_transaction *tx;
@@ -151,19 +143,13 @@ void test_transaction_finalized_output_error_code_signature_mismatch()
     //#inputs (2) > #witnesses (1)
     TEST_ASSERT_EQUAL(TRANSACTION_SIGNATURE_MISMATCH, rc);
 
-    cardano_transaction_output_ptr_delete(input);
-    cardano_transaction_output_delete(output);
     cardano_transaction_delete(tx);
     cardano_transaction_finalized_delete(tf);
 }
 
 void test_transaction_finalized_output_success()
 {
-    cardano_txoptr *input = cardano_transaction_output_ptr_new(txid, 1);
-
     cardano_transaction_error_t irc1 = cardano_transaction_builder_add_input(txbuilder, input, 1000);
-
-    cardano_txoutput *output = cardano_transaction_output_new(output_address, 1000);
     cardano_transaction_builder_add_output(txbuilder, output);
 
     cardano_transaction *tx;
@@ -176,8 +162,6 @@ void test_transaction_finalized_output_success()
     cardano_signed_transaction *txaux;
     cardano_transaction_error_t rc = cardano_transaction_finalized_output(tf, &txaux);
 
-    cardano_transaction_output_ptr_delete(input);
-    cardano_transaction_output_delete(output);
     cardano_transaction_delete(tx);
     cardano_transaction_finalized_delete(tf);
     cardano_transaction_signed_delete(txaux);


### PR DESCRIPTION
---
name: [IOHKCRB-13] Improve error handling for transaction module
---
# Description

## Change the following functions to return error codes.

- `cardano_transaction_builder_add_input`
- `cardano_transaction_finalized_add_witness`
- `cardano_transaction_builder_fee`
- `cardano_transaction_finalized_output`

Add the `cardano_transaction_error_t` to add more information to the error code, this is a mapping to the different possible Error variants.

Add tests to ensure that the mappings are correct

## Add missing delete function
`cardano_transaction_signed_delete` for the memory allocated with `cardano_transaction_finalized_output`



