### PR TITLE
network: Disambiguate subscription methods

### DIFF
--- a/network-core/src/client/block.rs
+++ b/network-core/src/client/block.rs
@@ -68,7 +68,7 @@ pub trait BlockService {
     ///
     /// The client can use the stream that the returned future resolves to
     /// as a long-lived subscription handle.
-    fn subscription<S>(&mut self, outbound: S) -> Self::BlockSubscriptionFuture
+    fn block_subscription<S>(&mut self, outbound: S) -> Self::BlockSubscriptionFuture
     where
         S: Stream<Item = <Self::Block as HasHeader>::Header> + Send + 'static;
 }

--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -117,7 +117,7 @@ pub trait BlockService {
     //
     // Returns a future that resolves to an asynchronous subscription stream
     // that receives blocks announced by the peer.
-    fn subscription<Out>(&mut self, outbound: Out) -> Self::BlockSubscriptionFuture
+    fn block_subscription<Out>(&mut self, outbound: Out) -> Self::BlockSubscriptionFuture
     where
         Out: Stream<Item = Self::Header, Error = Error>;
 }

--- a/network-core/src/server/transaction.rs
+++ b/network-core/src/server/transaction.rs
@@ -56,7 +56,10 @@ pub trait TransactionService {
     //
     // Returns a future that resolves to an asynchronous subscription stream
     // that receives transactions announced by the peer.
-    fn subscription<Out>(&mut self, outbound: Out) -> Self::TransactionSubscriptionFuture
+    fn transaction_subscription<Out>(
+        &mut self,
+        outbound: Out,
+    ) -> Self::TransactionSubscriptionFuture
     where
         Out: Stream<Item = Self::Transaction, Error = Error>;
 }

--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -397,7 +397,7 @@ where
         ServerStreamFuture::new(future)
     }
 
-    fn subscription<Out>(&mut self, outbound: Out) -> Self::BlockSubscriptionFuture
+    fn block_subscription<Out>(&mut self, outbound: Out) -> Self::BlockSubscriptionFuture
     where
         Out: Stream<Item = C::Header> + Send + 'static,
     {

--- a/network-grpc/src/service.rs
+++ b/network-grpc/src/service.rs
@@ -345,7 +345,7 @@ where
     ) -> Self::BlockSubscriptionFuture {
         let service = try_get_service!(self.block_service);
         let stream = RequestStream::new(request.into_inner());
-        ResponseFuture::new(service.subscription(stream))
+        ResponseFuture::new(service.block_subscription(stream))
     }
 
     fn transaction_subscription(
@@ -354,7 +354,7 @@ where
     ) -> Self::TransactionSubscriptionFuture {
         let service = try_get_service!(self.tx_service);
         let stream = RequestStream::new(request.into_inner());
-        ResponseFuture::new(service.subscription(stream))
+        ResponseFuture::new(service.transaction_subscription(stream))
     }
 
     /// Work with gossip message.

--- a/network-ntt/src/client.rs
+++ b/network-ntt/src/client.rs
@@ -186,7 +186,7 @@ where
         }
     }
 
-    fn subscription<Out>(&mut self, _outbound: Out) -> Self::BlockSubscriptionFuture
+    fn block_subscription<Out>(&mut self, _outbound: Out) -> Self::BlockSubscriptionFuture
     where
         Out: Stream<Item = T::Header>,
     {


### PR DESCRIPTION
Prefix names of subscription methods in network-core APIs with the object of subscription.
This helps to disambiguate methods on the client side. The server side API
is also changed for consistency.