### PR TITLE
[IOHKCRB-15] transaction observers

### DIFF
--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -340,7 +340,8 @@ typedef struct cardano_transaction_balance {
     uint64_t value;
 } cardano_transaction_balance_t;
 
-cardano_transaction_balance_t cardano_transaction_builder_get_balance(cardano_transaction_builder *tb);
+cardano_transaction_balance_t cardano_transaction_builder_balance(cardano_transaction_builder *tb);
+cardano_transaction_balance_t cardano_transaction_builder_balance_without_fees(cardano_transaction_builder *tb);
 
 /*!
 * \brief Get a transaction object

--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -340,8 +340,10 @@ typedef struct cardano_transaction_balance {
     uint64_t value;
 } cardano_transaction_balance_t;
 
-cardano_transaction_balance_t cardano_transaction_builder_balance(cardano_transaction_builder *tb);
-cardano_transaction_balance_t cardano_transaction_builder_balance_without_fees(cardano_transaction_builder *tb);
+void cardano_transaction_balance_delete(cardano_transaction_balance_t *balance);
+
+cardano_transaction_error_t cardano_transaction_builder_balance(cardano_transaction_builder *tb, cardano_transaction_balance_t **out);
+cardano_transaction_error_t cardano_transaction_builder_balance_without_fees(cardano_transaction_builder *tb, cardano_transaction_balance_t **out);
 cardano_transaction_error_t cardano_transaction_builder_get_input_total(cardano_transaction_builder *tb, uint64_t *output);
 cardano_transaction_error_t cardano_transaction_builder_get_output_total(cardano_transaction_builder *tb, uint64_t *output);
 

--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -342,6 +342,8 @@ typedef struct cardano_transaction_balance {
 
 cardano_transaction_balance_t cardano_transaction_builder_balance(cardano_transaction_builder *tb);
 cardano_transaction_balance_t cardano_transaction_builder_balance_without_fees(cardano_transaction_builder *tb);
+cardano_transaction_error_t cardano_transaction_builder_get_input_total(cardano_transaction_builder *tb, uint64_t *output);
+cardano_transaction_error_t cardano_transaction_builder_get_output_total(cardano_transaction_builder *tb, uint64_t *output);
 
 /*!
 * \brief Get a transaction object

--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -335,6 +335,13 @@ cardano_result cardano_transaction_builder_add_change_addr(cardano_transaction_b
 */
 uint64_t cardano_transaction_builder_fee(cardano_transaction_builder *tb);
 
+typedef struct cardano_transaction_balance {
+    int32_t sign;
+    uint64_t value;
+} cardano_transaction_balance_t;
+
+cardano_transaction_balance_t cardano_transaction_builder_get_balance(cardano_transaction_builder *tb);
+
 /*!
 * \brief Get a transaction object
 * \returns CARDANO_TRANSACTION_SUCCESS | CARDANO_TRANSACTION_NO_INPUT | CARDANO_TRANSACTION_NO_OUTPUT

--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -226,13 +226,13 @@ typedef enum _transaction_config_error
     CARDANO_TRANSACTION_SUCCESS = 0,
     CARDANO_TRANSACTION_NO_OUTPUT = 1,
     CARDANO_TRANSACTION_NO_INPUT = 2,
-    //The number of signatures doesn't match the number of inputs
+    /*!The number of signatures doesn't match the number of inputs*/
     CARDANO_TRANSACTION_SIGNATURE_MISMATCH = 3,
-    //The transaction is too big
+    /*!The transaction is too big*/
     CARDANO_TRANSACTION_OVER_LIMIT = 4,
-    //The number of signatures is greater than the number of inputs
+    /*!The number of signatures is greater than the number of inputs*/
     CARDANO_TRANSACTION_SIGNATURES_EXCEEDED = 5,
-    //The given value is greater than the maximum allowed coin value
+    /*!The given value is greater than the maximum allowed coin value*/
     CARDANO_TRANSACTION_COIN_OUT_OF_BOUNDS = 6,
 } cardano_transaction_error_t;
 
@@ -335,16 +335,64 @@ cardano_result cardano_transaction_builder_add_change_addr(cardano_transaction_b
 */
 uint64_t cardano_transaction_builder_fee(cardano_transaction_builder *tb);
 
+/*!
+* struct for repressenting a balance returned with cardano_transaction_builder_balance and cardano_transaction_builder_balance_without_fees
+* \sa cardano_transaction_builder_balance() cardano_transaction_builder_balance_without_fees()
+*/
 typedef struct cardano_transaction_balance {
     int32_t sign;
     uint64_t value;
 } cardano_transaction_balance_t;
 
+/*!
+* \brief Deallocate the memory allocated with `cardano_transaction_builder_balance` and `cardano_transaction_builder_balance_without_fees`
+* \sa cardano_transaction_builder_balance() cardano_transaction_builder_balance_without_fees()
+*/
 void cardano_transaction_balance_delete(cardano_transaction_balance_t *balance);
 
+/*!
+* Try to return the differential between the outputs (including fees) and the inputs
+* \param [in] tb the builder for the transaction
+* \param [out] out a pointer to a cardano_transaction_balance_t where: 
+*   - (sign == 0) means we have a balanced transaction where inputs === outputs
+*   - (sign == -1) means (outputs+fees) > inputs. More inputs required.
+*   - (sign == 1) means inputs > (outputs+fees). 
+*   .
+* and the value field indicates the quantity (in -1 and 1 cases)
+* Excessive input goes to larger fee.
+* \returns CARDANO_TRANSACTION_SUCCESS | CARDANO_TRANSACTION_COIN_OUT_OF_BOUNDS if the total is too big
+* \sa cardano_transaction_balance_delete()
+*/
 cardano_transaction_error_t cardano_transaction_builder_balance(cardano_transaction_builder *tb, cardano_transaction_balance_t **out);
+
+/*!
+* Try to return the differential between the outputs (excluding fees) and the inputs
+* \param [in] tb the builder for the transaction
+* \param [out] out a pointer to a cardano_transaction_balance_t where:
+*   - (sign == 0) means we have a balanced transaction where inputs === outputs
+*   - (sign == -1) means (outputs) > inputs. More inputs required.
+*   - (sign == 1) means inputs > (outputs). 
+*   .
+* and the value field indicates the quantity (in -1 and 1 cases)
+* \returns CARDANO_TRANSACTION_SUCCESS | CARDANO_TRANSACTION_COIN_OUT_OF_BOUNDS if the total is too big
+* \sa cardano_transaction_balance_delete()
+*/
 cardano_transaction_error_t cardano_transaction_builder_balance_without_fees(cardano_transaction_builder *tb, cardano_transaction_balance_t **out);
+
+/*!
+* Try to return the sum of the inputs
+* \param [in] tb the builder for the transaction
+* \param [out] output the sum
+* \returns CARDANO_TRANSACTION_SUCCESS | CARDANO_TRANSACTION_COIN_OUT_OF_BOUNDS if the total is too big
+*/
 cardano_transaction_error_t cardano_transaction_builder_get_input_total(cardano_transaction_builder *tb, uint64_t *output);
+
+/*!
+* Try to return the sum of the outputs
+* \param [in] tb the builder for the transaction
+* \param [out] output the sum
+* \returns CARDANO_TRANSACTION_SUCCESS | CARDANO_TRANSACTION_COIN_OUT_OF_BOUNDS if the total is too big
+*/
 cardano_transaction_error_t cardano_transaction_builder_get_output_total(cardano_transaction_builder *tb, uint64_t *output);
 
 /*!

--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -336,48 +336,58 @@ cardano_result cardano_transaction_builder_add_change_addr(cardano_transaction_b
 uint64_t cardano_transaction_builder_fee(cardano_transaction_builder *tb);
 
 /*!
+* struct for representing the sign in cardano_transaction_coin_diff_t
+* \sa cardano_transaction_coin_diff
+*/
+typedef enum difference_type {
+    DIFF_POSITIVE,
+    DIFF_NEGATIVE,
+    DIFF_ZERO,
+} difference_type_t;
+
+/*!
 * struct for repressenting a balance returned with cardano_transaction_builder_balance and cardano_transaction_builder_balance_without_fees
 * \sa cardano_transaction_builder_balance() cardano_transaction_builder_balance_without_fees()
 */
-typedef struct cardano_transaction_balance {
-    int32_t sign;
+typedef struct cardano_transaction_coin_diff {
+    difference_type_t sign;
     uint64_t value;
-} cardano_transaction_balance_t;
+} cardano_transaction_coin_diff_t;
 
 /*!
 * \brief Deallocate the memory allocated with `cardano_transaction_builder_balance` and `cardano_transaction_builder_balance_without_fees`
 * \sa cardano_transaction_builder_balance() cardano_transaction_builder_balance_without_fees()
 */
-void cardano_transaction_balance_delete(cardano_transaction_balance_t *balance);
+void cardano_transaction_balance_delete(cardano_transaction_coin_diff_t *balance);
 
 /*!
 * Try to return the differential between the outputs (including fees) and the inputs
 * \param [in] tb the builder for the transaction
-* \param [out] out a pointer to a cardano_transaction_balance_t where: 
-*   - (sign == 0) means we have a balanced transaction where inputs === outputs
-*   - (sign == -1) means (outputs+fees) > inputs. More inputs required.
-*   - (sign == 1) means inputs > (outputs+fees). 
+* \param [out] out a pointer to a cardano_transaction_coin_diff_t where: 
+*   - (sign == DIFF_ZERO) means we have a balanced transaction where inputs === outputs
+*   - (sign == DIFF_NEGATIVE) means (outputs+fees) > inputs. More inputs required.
+*   - (sign == DIFF_POSITIVE) means inputs > (outputs+fees). 
 *   .
 * and the value field indicates the quantity (in -1 and 1 cases)
 * Excessive input goes to larger fee.
 * \returns CARDANO_TRANSACTION_SUCCESS | CARDANO_TRANSACTION_COIN_OUT_OF_BOUNDS if the total is too big
 * \sa cardano_transaction_balance_delete()
 */
-cardano_transaction_error_t cardano_transaction_builder_balance(cardano_transaction_builder *tb, cardano_transaction_balance_t **out);
+cardano_transaction_error_t cardano_transaction_builder_balance(cardano_transaction_builder *tb, cardano_transaction_coin_diff_t **out);
 
 /*!
 * Try to return the differential between the outputs (excluding fees) and the inputs
 * \param [in] tb the builder for the transaction
-* \param [out] out a pointer to a cardano_transaction_balance_t where:
-*   - (sign == 0) means we have a balanced transaction where inputs === outputs
-*   - (sign == -1) means (outputs) > inputs. More inputs required.
-*   - (sign == 1) means inputs > (outputs). 
+* \param [out] out a pointer to a cardano_transaction_coin_diff_t where:
+*   - (sign == DIFF_ZERO) means we have a balanced transaction where inputs === outputs
+*   - (sign == DIFF_NEGATIVE) means (outputs) > inputs. More inputs required.
+*   - (sign == DIFF_POSITIVE) means inputs > (outputs). 
 *   .
 * and the value field indicates the quantity (in -1 and 1 cases)
 * \returns CARDANO_TRANSACTION_SUCCESS | CARDANO_TRANSACTION_COIN_OUT_OF_BOUNDS if the total is too big
 * \sa cardano_transaction_balance_delete()
 */
-cardano_transaction_error_t cardano_transaction_builder_balance_without_fees(cardano_transaction_builder *tb, cardano_transaction_balance_t **out);
+cardano_transaction_error_t cardano_transaction_builder_balance_without_fees(cardano_transaction_builder *tb, cardano_transaction_coin_diff_t **out);
 
 /*!
 * Try to return the sum of the inputs

--- a/cardano-c/src/transaction.rs
+++ b/cardano-c/src/transaction.rs
@@ -119,11 +119,9 @@ pub struct Balance {
     value: u64,
 }
 
-#[no_mangle]
-pub extern "C" fn cardano_transaction_builder_get_balance(tb: TransactionBuilderPtr) -> Balance {
-    let builder = unsafe { tb.as_mut() }.expect("Not a NULL PTR");
-    match builder.balance(&LinearFee::default()) {
-        Ok(v) => match v {
+impl From<CoinDiff> for Balance {
+    fn from(cd: CoinDiff) -> Self {
+        match cd {
             CoinDiff::Positive(i) => Balance {
                 sign: 1,
                 value: u64::from(i),
@@ -133,8 +131,27 @@ pub extern "C" fn cardano_transaction_builder_get_balance(tb: TransactionBuilder
                 value: u64::from(i),
             },
             CoinDiff::Zero => Balance { value: 0, sign: 0 },
-        },
-        Err(_) => panic!("idk"),
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn cardano_transaction_builder_balance(tb: TransactionBuilderPtr) -> Balance {
+    let builder = unsafe { tb.as_mut() }.expect("Not a NULL PTR");
+    match builder.balance(&LinearFee::default()) {
+        Ok(coin_diff) => Balance::from(coin_diff),
+        Err(_) => panic!("Shouldn't happen"),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn cardano_transaction_builder_balance_without_fees(
+    tb: TransactionBuilderPtr,
+) -> Balance {
+    let builder = unsafe { tb.as_mut() }.expect("Not a NULL PTR");
+    match builder.balance_without_fees() {
+        Ok(coin_diff) => Balance::from(coin_diff),
+        Err(_) => panic!("Shouldn't happen"),
     }
 }
 

--- a/cardano-c/src/transaction.rs
+++ b/cardano-c/src/transaction.rs
@@ -156,6 +156,38 @@ pub extern "C" fn cardano_transaction_builder_balance_without_fees(
 }
 
 #[no_mangle]
+pub extern "C" fn cardano_transaction_builder_get_input_total(
+    tb: TransactionBuilderPtr,
+    out: *mut u64,
+) -> CardanoTransactionErrorCode {
+    let builder = unsafe { tb.as_mut() }.expect("Not a NULL PTR");
+    match builder.get_input_total() {
+        Ok(number) => {
+            unsafe { ptr::write(out, u64::from(number)) };
+            CardanoTransactionErrorCode::success()
+        }
+        Err(Error::CoinError(_)) => CardanoTransactionErrorCode::coin_out_of_bounds(),
+        _ => panic!("Shouldn't happen"),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn cardano_transaction_builder_get_output_total(
+    tb: TransactionBuilderPtr,
+    out: *mut u64,
+) -> CardanoTransactionErrorCode {
+    let builder = unsafe { tb.as_mut() }.expect("Not a NULL PTR");
+    match builder.get_output_total() {
+        Ok(number) => {
+            unsafe { ptr::write(out, u64::from(number)) };
+            CardanoTransactionErrorCode::success()
+        }
+        Err(Error::CoinError(_)) => CardanoTransactionErrorCode::coin_out_of_bounds(),
+        _ => panic!("Shouldn't happen"),
+    }
+}
+
+#[no_mangle]
 pub extern "C" fn cardano_transaction_builder_finalize(
     tb: TransactionBuilderPtr,
     tx_out: *mut TransactionPtr,

--- a/cardano-c/src/types.rs
+++ b/cardano-c/src/types.rs
@@ -100,8 +100,15 @@ impl From<txbuild::Error> for CardanoTransactionErrorCode {
 }
 
 #[repr(C)]
+pub enum DiffType {
+    Positive,
+    Negative,
+    Zero,
+}
+
+#[repr(C)]
 pub struct Balance {
-    sign: i32,
+    sign: DiffType,
     value: u64,
 }
 
@@ -109,14 +116,17 @@ impl From<CoinDiff> for Balance {
     fn from(cd: CoinDiff) -> Self {
         match cd {
             CoinDiff::Positive(i) => Balance {
-                sign: 1,
+                sign: DiffType::Positive,
                 value: i.into(),
             },
             CoinDiff::Negative(i) => Balance {
-                sign: -1,
+                sign: DiffType::Negative,
                 value: i.into(),
             },
-            CoinDiff::Zero => Balance { value: 0, sign: 0 },
+            CoinDiff::Zero => Balance {
+                sign: DiffType::Zero,
+                value: 0,
+            },
         }
     }
 }

--- a/cardano-c/src/types.rs
+++ b/cardano-c/src/types.rs
@@ -1,4 +1,5 @@
 use cardano::address;
+use cardano::coin::CoinDiff;
 use cardano::hdwallet;
 use cardano::tx;
 use cardano::txbuild;
@@ -79,6 +80,44 @@ impl CardanoTransactionErrorCode {
     ///value is to big, max = 45000000000000000
     pub fn coin_out_of_bounds() -> Self {
         CardanoTransactionErrorCode(6)
+    }
+}
+
+impl From<txbuild::Error> for CardanoTransactionErrorCode {
+    fn from(err: txbuild::Error) -> Self {
+        match err {
+            txbuild::Error::TxInvalidNoInput => Self::no_inputs(),
+            txbuild::Error::TxInvalidNoOutput => Self::no_outputs(),
+            txbuild::Error::TxNotEnoughTotalInput => unimplemented!(),
+            txbuild::Error::TxOverLimit(_) => Self::over_limit(),
+            txbuild::Error::TxOutputPolicyNotEnoughCoins(_) => unimplemented!(),
+            txbuild::Error::TxSignaturesExceeded => Self::signatures_exceeded(),
+            txbuild::Error::TxSignaturesMismatch => Self::signature_mismatch(),
+            txbuild::Error::CoinError(_) => Self::coin_out_of_bounds(),
+            txbuild::Error::FeeError(_) => unimplemented!(),
+        }
+    }
+}
+
+#[repr(C)]
+pub struct Balance {
+    sign: i32,
+    value: u64,
+}
+
+impl From<CoinDiff> for Balance {
+    fn from(cd: CoinDiff) -> Self {
+        match cd {
+            CoinDiff::Positive(i) => Balance {
+                sign: 1,
+                value: i.into(),
+            },
+            CoinDiff::Negative(i) => Balance {
+                sign: -1,
+                value: i.into(),
+            },
+            CoinDiff::Zero => Balance { value: 0, sign: 0 },
+        }
     }
 }
 

--- a/cardano-c/test/test_transaction.c
+++ b/cardano-c/test/test_transaction.c
@@ -167,6 +167,40 @@ void test_transaction_finalized_output_success()
     cardano_transaction_signed_delete(txaux);
 }
 
+void test_transaction_builder_balance() {
+    cardano_txoptr *input1 = cardano_transaction_output_ptr_new(txid, 1);
+    cardano_txoptr *input2 = cardano_transaction_output_ptr_new(txid, 2);
+    cardano_txoptr *input3 = cardano_transaction_output_ptr_new(txid, 3);
+
+    cardano_result irc1 = cardano_transaction_builder_add_input(txbuilder, input1, 1000);
+
+    cardano_txoutput *output = cardano_transaction_output_new(output_address, 1000);
+    cardano_transaction_builder_add_output(txbuilder, output);
+
+    cardano_transaction_balance_t balance = cardano_transaction_builder_get_balance(txbuilder);
+    uint64_t fee = cardano_transaction_builder_fee(txbuilder);
+
+    TEST_ASSERT_EQUAL(fee, balance.value);
+    TEST_ASSERT_EQUAL(-1, balance.sign);
+
+    cardano_result irc2 = cardano_transaction_builder_add_input(txbuilder, input2, 174015);
+    cardano_transaction_balance_t new_balance = cardano_transaction_builder_get_balance(txbuilder);
+
+    TEST_ASSERT_EQUAL(0, new_balance.value);
+    TEST_ASSERT_EQUAL(0, new_balance.sign);
+
+    cardano_result irc3 = cardano_transaction_builder_add_input(txbuilder, input3, 174015);
+    cardano_transaction_balance_t balance3 = cardano_transaction_builder_get_balance(txbuilder);
+
+    TEST_ASSERT_EQUAL(166061, balance3.value);
+    TEST_ASSERT_EQUAL(1, balance3.sign);
+
+    cardano_transaction_output_ptr_delete(input1);
+    cardano_transaction_output_ptr_delete(input2);
+    cardano_transaction_output_ptr_delete(input3);
+    cardano_transaction_output_delete(output);
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -177,5 +211,6 @@ int main(void)
     RUN_TEST(test_builder_finalize_error_code_no_outputs);
     RUN_TEST(test_transaction_finalized_output_error_code_signature_mismatch);
     RUN_TEST(test_transaction_finalized_output_success);
+    RUN_TEST(test_transaction_builder_balance);
     return UNITY_END();
 }

--- a/cardano-c/test/test_transaction.c
+++ b/cardano-c/test/test_transaction.c
@@ -19,6 +19,7 @@ static uint32_t PROTOCOL_MAGIC = 1;
 static uint8_t input_xprv[XPRV_SIZE] = {0};
 static const uint8_t static_wallet_entropy[16] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
 static uint8_t txid[32] = {0};
+const uint64_t MAX_COIN = 45000000000000000;
 
 void setUp()
 {
@@ -73,7 +74,6 @@ void test_add_input_returns_success_with_valid_value()
 
 void test_add_input_returns_error_with_big_value()
 {
-    const uint64_t MAX_COIN = 45000000000000000;
     cardano_transaction_error_t irc = cardano_transaction_builder_add_input(txbuilder, input, MAX_COIN + 1);
 
     TEST_ASSERT_EQUAL(CARDANO_TRANSACTION_COIN_OUT_OF_BOUNDS, irc);
@@ -162,6 +162,8 @@ void test_transaction_finalized_output_success()
     cardano_signed_transaction *txaux;
     cardano_transaction_error_t rc = cardano_transaction_finalized_output(tf, &txaux);
 
+    TEST_ASSERT_EQUAL(CARDANO_TRANSACTION_SUCCESS, rc);
+
     cardano_transaction_delete(tx);
     cardano_transaction_finalized_delete(tf);
     cardano_transaction_signed_delete(txaux);
@@ -177,28 +179,68 @@ void test_transaction_builder_balance() {
     cardano_txoutput *output = cardano_transaction_output_new(output_address, 1000);
     cardano_transaction_builder_add_output(txbuilder, output);
 
-    cardano_transaction_balance_t balance = cardano_transaction_builder_balance(txbuilder);
+    cardano_transaction_balance_t *balance1; 
+    cardano_transaction_error_t brc1 = cardano_transaction_builder_balance(txbuilder, &balance1);
     uint64_t fee = cardano_transaction_builder_fee(txbuilder);
 
-    TEST_ASSERT_EQUAL(fee, balance.value);
-    TEST_ASSERT_EQUAL(-1, balance.sign);
+    TEST_ASSERT_EQUAL(fee, (*balance1).value);
+    TEST_ASSERT_EQUAL(-1, (*balance1).sign);
 
     cardano_result irc2 = cardano_transaction_builder_add_input(txbuilder, input2, 174015);
-    cardano_transaction_balance_t new_balance = cardano_transaction_builder_balance(txbuilder);
+    cardano_transaction_balance_t *balance2;
+    cardano_transaction_error_t brc2 = cardano_transaction_builder_balance(txbuilder, &balance2);
 
-    TEST_ASSERT_EQUAL(0, new_balance.value);
-    TEST_ASSERT_EQUAL(0, new_balance.sign);
+    TEST_ASSERT_EQUAL(0, (*balance2).value);
+    TEST_ASSERT_EQUAL(0, (*balance2).sign);
 
     cardano_result irc3 = cardano_transaction_builder_add_input(txbuilder, input3, 174015);
-    cardano_transaction_balance_t balance3 = cardano_transaction_builder_balance(txbuilder);
+    cardano_transaction_balance_t *balance3;
+    cardano_transaction_error_t brc3 = cardano_transaction_builder_balance(txbuilder, &balance3);
 
-    TEST_ASSERT_EQUAL(166061, balance3.value);
-    TEST_ASSERT_EQUAL(1, balance3.sign);
+    TEST_ASSERT_EQUAL(166061, (*balance3).value);
+    TEST_ASSERT_EQUAL(1, (*balance3).sign);
 
     cardano_transaction_output_ptr_delete(input1);
     cardano_transaction_output_ptr_delete(input2);
     cardano_transaction_output_ptr_delete(input3);
+
+    cardano_transaction_balance_delete(balance1);
+    cardano_transaction_balance_delete(balance2);
+    cardano_transaction_balance_delete(balance3);
+
     cardano_transaction_output_delete(output);
+}
+
+void test_transaction_builder_balance_too_big() {
+    cardano_txoptr *input1 = cardano_transaction_output_ptr_new(txid, 1);
+    cardano_txoptr *input2 = cardano_transaction_output_ptr_new(txid, 2);
+
+    cardano_result irc1 = cardano_transaction_builder_add_input(txbuilder, input1, MAX_COIN);
+    cardano_result irc2 = cardano_transaction_builder_add_input(txbuilder, input1, 1);
+
+    cardano_transaction_balance_t *balance; 
+    cardano_transaction_error_t brc1 = cardano_transaction_builder_balance(txbuilder, &balance);
+
+    TEST_ASSERT_EQUAL(CARDANO_TRANSACTION_COIN_OUT_OF_BOUNDS, brc1);
+
+    cardano_transaction_output_ptr_delete(input1);
+    cardano_transaction_output_ptr_delete(input2);
+}
+
+void test_transaction_builder_balance_without_fee_too_big() {
+    cardano_txoptr *input1 = cardano_transaction_output_ptr_new(txid, 1);
+    cardano_txoptr *input2 = cardano_transaction_output_ptr_new(txid, 2);
+
+    cardano_result irc1 = cardano_transaction_builder_add_input(txbuilder, input1, MAX_COIN);
+    cardano_result irc2 = cardano_transaction_builder_add_input(txbuilder, input1, 1);
+
+    cardano_transaction_balance_t *balance; 
+    cardano_transaction_error_t brc1 = cardano_transaction_builder_balance_without_fees(txbuilder, &balance);
+
+    TEST_ASSERT_EQUAL(CARDANO_TRANSACTION_COIN_OUT_OF_BOUNDS, brc1);
+
+    cardano_transaction_output_ptr_delete(input1);
+    cardano_transaction_output_ptr_delete(input2);
 }
 
 void test_transaction_balance_without_fee() {
@@ -208,25 +250,33 @@ void test_transaction_balance_without_fee() {
     cardano_txoutput *output = cardano_transaction_output_new(output_address, 1000);
 
     cardano_transaction_builder_add_output(txbuilder, output);
-    cardano_transaction_balance_t balance1 = cardano_transaction_builder_balance_without_fees(txbuilder);
+    cardano_transaction_balance_t *balance1;
+    cardano_transaction_error_t rc1 = cardano_transaction_builder_balance_without_fees(txbuilder, &balance1);
 
-    TEST_ASSERT_EQUAL(1000, balance1.value);
-    TEST_ASSERT_EQUAL(-1, balance1.sign);
+    TEST_ASSERT_EQUAL(1000, (*balance1).value);
+    TEST_ASSERT_EQUAL(-1, (*balance1).sign);
     
     cardano_result irc1 = cardano_transaction_builder_add_input(txbuilder, input1, 1000);
-    cardano_transaction_balance_t balance2 = cardano_transaction_builder_balance_without_fees(txbuilder);
+    cardano_transaction_balance_t *balance2;
+    cardano_transaction_error_t rc2 = cardano_transaction_builder_balance_without_fees(txbuilder, &balance2);
 
-    TEST_ASSERT_EQUAL(0, balance2.value);
-    TEST_ASSERT_EQUAL(0, balance2.sign);
+    TEST_ASSERT_EQUAL(0, (*balance2).value);
+    TEST_ASSERT_EQUAL(0, (*balance2).sign);
 
     cardano_result irc2 = cardano_transaction_builder_add_input(txbuilder, input2, 1000);
-    cardano_transaction_balance_t balance3 = cardano_transaction_builder_balance_without_fees(txbuilder);
+    cardano_transaction_balance_t *balance3;
+    cardano_transaction_error_t rc3 = cardano_transaction_builder_balance_without_fees(txbuilder, &balance3);
 
-    TEST_ASSERT_EQUAL(1000, balance3.value);
-    TEST_ASSERT_EQUAL(1, balance3.sign);
+    TEST_ASSERT_EQUAL(1000, (*balance3).value);
+    TEST_ASSERT_EQUAL(1, (*balance3).sign);
 
     cardano_transaction_output_ptr_delete(input1);
     cardano_transaction_output_ptr_delete(input2);
+
+    cardano_transaction_balance_delete(balance1);
+    cardano_transaction_balance_delete(balance2);
+    cardano_transaction_balance_delete(balance3);
+
     cardano_transaction_output_delete(output);
 }
 
@@ -258,7 +308,6 @@ void test_transaction_get_output_total_no_outputs() {
 
 void test_transaction_get_input_total_too_big()
 {
-    const uint64_t MAX_COIN = 45000000000000000;
     cardano_transaction_error_t irc1 = cardano_transaction_builder_add_input(txbuilder, input, MAX_COIN);
     cardano_transaction_error_t irc2 = cardano_transaction_builder_add_input(txbuilder, input, 1);
     TEST_ASSERT_EQUAL(CARDANO_TRANSACTION_SUCCESS, irc1);
@@ -271,7 +320,6 @@ void test_transaction_get_input_total_too_big()
 
 void test_transaction_get_output_total_too_big()
 {
-    const uint64_t MAX_COIN = 45000000000000000;
     cardano_txoutput *output1 = cardano_transaction_output_new(output_address, MAX_COIN);
     cardano_txoutput *output2 = cardano_transaction_output_new(output_address, 1);
 
@@ -280,6 +328,9 @@ void test_transaction_get_output_total_too_big()
     uint64_t output_total;
     cardano_transaction_error_t rc = cardano_transaction_builder_get_output_total(txbuilder, &output_total);
     TEST_ASSERT_EQUAL(CARDANO_TRANSACTION_COIN_OUT_OF_BOUNDS, rc);
+
+    cardano_transaction_output_delete(output1);
+    cardano_transaction_output_delete(output2);
 }
 
 int main(void)
@@ -293,7 +344,9 @@ int main(void)
     RUN_TEST(test_transaction_finalized_output_error_code_signature_mismatch);
     RUN_TEST(test_transaction_finalized_output_success);
     RUN_TEST(test_transaction_builder_balance);
+    RUN_TEST(test_transaction_builder_balance_too_big);
     RUN_TEST(test_transaction_balance_without_fee);
+    RUN_TEST(test_transaction_builder_balance_without_fee_too_big);
     RUN_TEST(test_transaction_get_input_total);
     RUN_TEST(test_transaction_get_input_total_no_inputs);
     RUN_TEST(test_transaction_get_output_total);

--- a/cardano-c/test/test_transaction.c
+++ b/cardano-c/test/test_transaction.c
@@ -179,26 +179,26 @@ void test_transaction_builder_balance() {
     cardano_txoutput *output = cardano_transaction_output_new(output_address, 1000);
     cardano_transaction_builder_add_output(txbuilder, output);
 
-    cardano_transaction_balance_t *balance1; 
+    cardano_transaction_coin_diff_t *balance1; 
     cardano_transaction_error_t brc1 = cardano_transaction_builder_balance(txbuilder, &balance1);
     uint64_t fee = cardano_transaction_builder_fee(txbuilder);
 
     TEST_ASSERT_EQUAL(fee, (*balance1).value);
-    TEST_ASSERT_EQUAL(-1, (*balance1).sign);
+    TEST_ASSERT_EQUAL(DIFF_NEGATIVE, (*balance1).sign);
 
     cardano_result irc2 = cardano_transaction_builder_add_input(txbuilder, input2, 174015);
-    cardano_transaction_balance_t *balance2;
+    cardano_transaction_coin_diff_t *balance2;
     cardano_transaction_error_t brc2 = cardano_transaction_builder_balance(txbuilder, &balance2);
 
     TEST_ASSERT_EQUAL(0, (*balance2).value);
-    TEST_ASSERT_EQUAL(0, (*balance2).sign);
+    TEST_ASSERT_EQUAL(DIFF_ZERO, (*balance2).sign);
 
     cardano_result irc3 = cardano_transaction_builder_add_input(txbuilder, input3, 174015);
-    cardano_transaction_balance_t *balance3;
+    cardano_transaction_coin_diff_t *balance3;
     cardano_transaction_error_t brc3 = cardano_transaction_builder_balance(txbuilder, &balance3);
 
     TEST_ASSERT_EQUAL(166061, (*balance3).value);
-    TEST_ASSERT_EQUAL(1, (*balance3).sign);
+    TEST_ASSERT_EQUAL(DIFF_POSITIVE, (*balance3).sign);
 
     cardano_transaction_output_ptr_delete(input1);
     cardano_transaction_output_ptr_delete(input2);
@@ -218,7 +218,7 @@ void test_transaction_builder_balance_too_big() {
     cardano_result irc1 = cardano_transaction_builder_add_input(txbuilder, input1, MAX_COIN);
     cardano_result irc2 = cardano_transaction_builder_add_input(txbuilder, input1, 1);
 
-    cardano_transaction_balance_t *balance; 
+    cardano_transaction_coin_diff_t *balance; 
     cardano_transaction_error_t brc1 = cardano_transaction_builder_balance(txbuilder, &balance);
 
     TEST_ASSERT_EQUAL(CARDANO_TRANSACTION_COIN_OUT_OF_BOUNDS, brc1);
@@ -234,7 +234,7 @@ void test_transaction_builder_balance_without_fee_too_big() {
     cardano_result irc1 = cardano_transaction_builder_add_input(txbuilder, input1, MAX_COIN);
     cardano_result irc2 = cardano_transaction_builder_add_input(txbuilder, input1, 1);
 
-    cardano_transaction_balance_t *balance; 
+    cardano_transaction_coin_diff_t *balance; 
     cardano_transaction_error_t brc1 = cardano_transaction_builder_balance_without_fees(txbuilder, &balance);
 
     TEST_ASSERT_EQUAL(CARDANO_TRANSACTION_COIN_OUT_OF_BOUNDS, brc1);
@@ -250,25 +250,25 @@ void test_transaction_balance_without_fee() {
     cardano_txoutput *output = cardano_transaction_output_new(output_address, 1000);
 
     cardano_transaction_builder_add_output(txbuilder, output);
-    cardano_transaction_balance_t *balance1;
+    cardano_transaction_coin_diff_t *balance1;
     cardano_transaction_error_t rc1 = cardano_transaction_builder_balance_without_fees(txbuilder, &balance1);
 
     TEST_ASSERT_EQUAL(1000, (*balance1).value);
-    TEST_ASSERT_EQUAL(-1, (*balance1).sign);
+    TEST_ASSERT_EQUAL(DIFF_NEGATIVE, (*balance1).sign);
     
     cardano_result irc1 = cardano_transaction_builder_add_input(txbuilder, input1, 1000);
-    cardano_transaction_balance_t *balance2;
+    cardano_transaction_coin_diff_t *balance2;
     cardano_transaction_error_t rc2 = cardano_transaction_builder_balance_without_fees(txbuilder, &balance2);
 
     TEST_ASSERT_EQUAL(0, (*balance2).value);
-    TEST_ASSERT_EQUAL(0, (*balance2).sign);
+    TEST_ASSERT_EQUAL(DIFF_ZERO, (*balance2).sign);
 
     cardano_result irc2 = cardano_transaction_builder_add_input(txbuilder, input2, 1000);
-    cardano_transaction_balance_t *balance3;
+    cardano_transaction_coin_diff_t *balance3;
     cardano_transaction_error_t rc3 = cardano_transaction_builder_balance_without_fees(txbuilder, &balance3);
 
     TEST_ASSERT_EQUAL(1000, (*balance3).value);
-    TEST_ASSERT_EQUAL(1, (*balance3).sign);
+    TEST_ASSERT_EQUAL(DIFF_POSITIVE, (*balance3).sign);
 
     cardano_transaction_output_ptr_delete(input1);
     cardano_transaction_output_ptr_delete(input2);

--- a/cardano-c/test/test_transaction.c
+++ b/cardano-c/test/test_transaction.c
@@ -177,20 +177,20 @@ void test_transaction_builder_balance() {
     cardano_txoutput *output = cardano_transaction_output_new(output_address, 1000);
     cardano_transaction_builder_add_output(txbuilder, output);
 
-    cardano_transaction_balance_t balance = cardano_transaction_builder_get_balance(txbuilder);
+    cardano_transaction_balance_t balance = cardano_transaction_builder_balance(txbuilder);
     uint64_t fee = cardano_transaction_builder_fee(txbuilder);
 
     TEST_ASSERT_EQUAL(fee, balance.value);
     TEST_ASSERT_EQUAL(-1, balance.sign);
 
     cardano_result irc2 = cardano_transaction_builder_add_input(txbuilder, input2, 174015);
-    cardano_transaction_balance_t new_balance = cardano_transaction_builder_get_balance(txbuilder);
+    cardano_transaction_balance_t new_balance = cardano_transaction_builder_balance(txbuilder);
 
     TEST_ASSERT_EQUAL(0, new_balance.value);
     TEST_ASSERT_EQUAL(0, new_balance.sign);
 
     cardano_result irc3 = cardano_transaction_builder_add_input(txbuilder, input3, 174015);
-    cardano_transaction_balance_t balance3 = cardano_transaction_builder_get_balance(txbuilder);
+    cardano_transaction_balance_t balance3 = cardano_transaction_builder_balance(txbuilder);
 
     TEST_ASSERT_EQUAL(166061, balance3.value);
     TEST_ASSERT_EQUAL(1, balance3.sign);
@@ -198,6 +198,35 @@ void test_transaction_builder_balance() {
     cardano_transaction_output_ptr_delete(input1);
     cardano_transaction_output_ptr_delete(input2);
     cardano_transaction_output_ptr_delete(input3);
+    cardano_transaction_output_delete(output);
+}
+
+void test_transaction_balance_without_fee() {
+    cardano_txoptr *input1 = cardano_transaction_output_ptr_new(txid, 1);
+    cardano_txoptr *input2 = cardano_transaction_output_ptr_new(txid, 2);
+
+    cardano_txoutput *output = cardano_transaction_output_new(output_address, 1000);
+
+    cardano_transaction_builder_add_output(txbuilder, output);
+    cardano_transaction_balance_t balance1 = cardano_transaction_builder_balance_without_fees(txbuilder);
+
+    TEST_ASSERT_EQUAL(1000, balance1.value);
+    TEST_ASSERT_EQUAL(-1, balance1.sign);
+    
+    cardano_result irc1 = cardano_transaction_builder_add_input(txbuilder, input1, 1000);
+    cardano_transaction_balance_t balance2 = cardano_transaction_builder_balance_without_fees(txbuilder);
+
+    TEST_ASSERT_EQUAL(0, balance2.value);
+    TEST_ASSERT_EQUAL(0, balance2.sign);
+
+    cardano_result irc2 = cardano_transaction_builder_add_input(txbuilder, input2, 1000);
+    cardano_transaction_balance_t balance3 = cardano_transaction_builder_balance_without_fees(txbuilder);
+
+    TEST_ASSERT_EQUAL(1000, balance3.value);
+    TEST_ASSERT_EQUAL(1, balance3.sign);
+
+    cardano_transaction_output_ptr_delete(input1);
+    cardano_transaction_output_ptr_delete(input2);
     cardano_transaction_output_delete(output);
 }
 
@@ -212,5 +241,6 @@ int main(void)
     RUN_TEST(test_transaction_finalized_output_error_code_signature_mismatch);
     RUN_TEST(test_transaction_finalized_output_success);
     RUN_TEST(test_transaction_builder_balance);
+    RUN_TEST(test_transaction_balance_without_fee);
     return UNITY_END();
 }


### PR DESCRIPTION
# Add functions to observe the state of a txbuilder
- `cardano_transaction_builder_balance`
- `cardano_transaction_builder_balance_without_fees`
- `cardano_transaction_builder_get_input_total`
- `cardano_transaction_builder_get_output_total`

Mapping to the following functions in the txbuilder module: 
- `pub fn get_input_total(&self) -> Result<Coin>`
- `pub fn get_output_total(&self) -> Result<Coin>`
- `pub fn balance<'a, F: FeeAlgorithm>(&self, f: &'a F) -> Result<CoinDiff>`
- `pub fn balance_without_fees(&self) -> Result<CoinDiff>`

The balance is represented as the following C non-opaque struct, where the sign is used to represent the `Positive` (1), `Negative` (-1) and `Zero` (0) variants of the possible results (represented by a `CoinDiff`).
```C
typedef struct cardano_transaction_balance {
    int32_t sign;
    uint64_t value;
} cardano_transaction_balance_t
```
Altough the struct is non-opaque, it is allocated in the heap by the Rust code, to be consistent with the existing allocation, and the memory is freed with 
`cardano_transaction_balance_delete`