### PR TITLE
Add Bech32 encoding to signature

### DIFF
--- a/chain-crypto/src/algorithms/ed25519_extended.rs
+++ b/chain-crypto/src/algorithms/ed25519_extended.rs
@@ -6,7 +6,7 @@ use super::ed25519 as ei;
 use cryptoxide::ed25519;
 use rand::{CryptoRng, RngCore};
 
-use ed25519_bip32::{XPrv, XPRV_SIZE, XPUB_SIZE};
+use ed25519_bip32::{XPrv, XPRV_SIZE};
 
 /// ED25519 Signing Algorithm with extended secret key
 pub struct Ed25519Extended;
@@ -59,7 +59,7 @@ impl AsymmetricKey for Ed25519Extended {
         }
         let mut buf = [0; ed25519::PRIVATE_KEY_LENGTH];
         buf[0..ed25519::PRIVATE_KEY_LENGTH].clone_from_slice(data);
-        /// TODO structure check
+        // TODO structure check
         Ok(ExtendedPriv(buf))
     }
     fn public_from_binary(data: &[u8]) -> Result<Self::Public, PublicKeyError> {

--- a/chain-crypto/src/bech32.rs
+++ b/chain-crypto/src/bech32.rs
@@ -1,5 +1,4 @@
 use bech32::{Bech32 as Bech32Data, Error as Bech32Error, FromBase32, ToBase32};
-use std::borrow::Cow;
 use std::error::Error as StdError;
 use std::fmt;
 use std::result::Result as StdResult;
@@ -11,31 +10,26 @@ pub trait Bech32 {
 
     fn try_from_bech32_str(bech32_str: &str) -> Result<Self>
     where
-        Self: Sized,
-    {
-        let bech32: Bech32Data = bech32_str.parse()?;
-        if bech32.hrp() != Self::BECH32_HRP {
-            return Err(Error::HrpInvalid {
-                expected: Self::BECH32_HRP,
-                actual: bech32.hrp().to_string(),
-            });
-        }
-        let bytes = Vec::<u8>::from_base32(bech32.data())?;
-        Self::try_from_bytes(&bytes)
-    }
-
-    fn try_from_bytes(bytes: &[u8]) -> Result<Self>
-    where
         Self: Sized;
 
-    fn to_bech32_str(&self) -> String {
-        let data = self.to_bytes();
-        Bech32Data::new(Self::BECH32_HRP.to_string(), data.to_base32())
-            .unwrap_or_else(|e| panic!("Failed to build bech32: {}", e))
-            .to_string()
-    }
+    fn to_bech32_str(&self) -> String;
+}
 
-    fn to_bytes(&self) -> Cow<[u8]>;
+pub fn to_bech32_from_bytes<B: Bech32>(bytes: &[u8]) -> String {
+    Bech32Data::new(B::BECH32_HRP.to_string(), bytes.to_base32())
+        .unwrap_or_else(|e| panic!("Failed to build bech32: {}", e))
+        .to_string()
+}
+
+pub fn try_from_bech32_to_bytes<B: Bech32>(bech32_str: &str) -> Result<Vec<u8>> {
+    let bech32: Bech32Data = bech32_str.parse()?;
+    if bech32.hrp() != B::BECH32_HRP {
+        return Err(Error::HrpInvalid {
+            expected: B::BECH32_HRP,
+            actual: bech32.hrp().to_string(),
+        });
+    }
+    Vec::<u8>::from_base32(bech32.data()).map_err(Into::into)
 }
 
 #[derive(Debug)]

--- a/chain-crypto/src/bech32.rs
+++ b/chain-crypto/src/bech32.rs
@@ -48,6 +48,12 @@ pub enum Error {
     DataInvalid(Box<StdError + 'static>),
 }
 
+impl Error {
+    pub fn data_invalid(cause: impl StdError + 'static) -> Self {
+        Error::DataInvalid(Box::new(cause))
+    }
+}
+
 impl From<Bech32Error> for Error {
     fn from(error: Bech32Error) -> Self {
         Error::Bech32Malformed(error)

--- a/chain-crypto/src/hash.rs
+++ b/chain-crypto/src/hash.rs
@@ -1,13 +1,9 @@
 //! module to provide some handy interfaces atop the hashes so we have
 //! the common interfaces for the project to work with.
 
-use std::{
-    borrow::Cow,
-    error, fmt,
-    hash::{Hash, Hasher},
-    result,
-    str::FromStr,
-};
+use std::hash::{Hash, Hasher};
+use std::str::FromStr;
+use std::{error, fmt, result};
 
 use cryptoxide::blake2b::Blake2b;
 use cryptoxide::digest::Digest;
@@ -125,12 +121,13 @@ macro_rules! define_hash_object {
         impl Bech32 for $hash_ty {
             const BECH32_HRP: &'static str = $bech32_hrp;
 
-            fn try_from_bytes(bytes: &[u8]) -> bech32::Result<Self> {
-                Self::try_from_slice(bytes).map_err(|e| bech32::Error::DataInvalid(Box::new(e)))
+            fn try_from_bech32_str(bech32_str: &str) -> bech32::Result<Self> {
+                let bytes = bech32::try_from_bech32_to_bytes::<Self>(bech32_str)?;
+                Self::try_from_slice(&bytes).map_err(bech32::Error::data_invalid)
             }
 
-            fn to_bytes(&self) -> Cow<[u8]> {
-                self.as_ref().into()
+            fn to_bech32_str(&self) -> String {
+                bech32::to_bech32_from_bytes::<Self>(self.as_ref())
             }
         }
     };

--- a/chain-crypto/src/key.rs
+++ b/chain-crypto/src/key.rs
@@ -178,7 +178,7 @@ impl<A: AsymmetricKey> Bech32 for PublicKey<A> {
     const BECH32_HRP: &'static str = A::PUBLIC_BECH32_HRP;
 
     fn try_from_bytes(bytes: &[u8]) -> Result<Self, bech32::Error> {
-        Self::from_bytes(bytes).map_err(|e| bech32::Error::DataInvalid(Box::new(e)))
+        Self::from_bytes(bytes).map_err(bech32::Error::data_invalid)
     }
 
     fn to_bytes(&self) -> Cow<[u8]> {

--- a/chain-crypto/src/key.rs
+++ b/chain-crypto/src/key.rs
@@ -1,7 +1,6 @@
 use crate::bech32::{self, Bech32};
 use crate::hex;
 use rand::{CryptoRng, RngCore};
-use std::borrow::Cow;
 use std::fmt;
 use std::hash::Hash;
 
@@ -177,24 +176,26 @@ impl<A: AsymmetricKey> Hash for PublicKey<A> {
 impl<A: AsymmetricKey> Bech32 for PublicKey<A> {
     const BECH32_HRP: &'static str = A::PUBLIC_BECH32_HRP;
 
-    fn try_from_bytes(bytes: &[u8]) -> Result<Self, bech32::Error> {
-        Self::from_bytes(bytes).map_err(bech32::Error::data_invalid)
+    fn try_from_bech32_str(bech32_str: &str) -> Result<Self, bech32::Error> {
+        let bytes = bech32::try_from_bech32_to_bytes::<Self>(bech32_str)?;
+        Self::from_bytes(&bytes).map_err(bech32::Error::data_invalid)
     }
 
-    fn to_bytes(&self) -> Cow<[u8]> {
-        self.as_ref().into()
+    fn to_bech32_str(&self) -> String {
+        bech32::to_bech32_from_bytes::<Self>(self.as_ref())
     }
 }
 
 impl<A: AsymmetricKey> Bech32 for SecretKey<A> {
     const BECH32_HRP: &'static str = A::SECRET_BECH32_HRP;
 
-    fn try_from_bytes(bytes: &[u8]) -> Result<Self, bech32::Error> {
-        Self::from_bytes(bytes).map_err(|e| bech32::Error::DataInvalid(Box::new(e)))
+    fn try_from_bech32_str(bech32_str: &str) -> Result<Self, bech32::Error> {
+        let bytes = bech32::try_from_bech32_to_bytes::<Self>(bech32_str)?;
+        Self::from_bytes(&bytes).map_err(bech32::Error::data_invalid)
     }
 
-    fn to_bytes(&self) -> Cow<[u8]> {
-        self.0.as_ref().into()
+    fn to_bech32_str(&self) -> String {
+        bech32::to_bech32_from_bytes::<Self>(self.0.as_ref())
     }
 }
 

--- a/chain-crypto/src/sign.rs
+++ b/chain-crypto/src/sign.rs
@@ -1,6 +1,5 @@
 use crate::bech32::{self, Bech32};
 use crate::{hex, kes, key};
-use std::borrow::Cow;
 use std::fmt;
 use std::marker::PhantomData;
 
@@ -124,12 +123,13 @@ impl<T, A: VerificationAlgorithm> AsRef<[u8]> for Signature<T, A> {
 impl<T, A: VerificationAlgorithm> Bech32 for Signature<T, A> {
     const BECH32_HRP: &'static str = A::SECRET_BECH32_HRP;
 
-    fn try_from_bytes(bytes: &[u8]) -> Result<Self, bech32::Error> {
-        Self::from_bytes(bytes).map_err(bech32::Error::data_invalid)
+    fn try_from_bech32_str(bech32_str: &str) -> Result<Self, bech32::Error> {
+        let bytes = bech32::try_from_bech32_to_bytes::<Self>(bech32_str)?;
+        Self::from_bytes(&bytes).map_err(bech32::Error::data_invalid)
     }
 
-    fn to_bytes(&self) -> Cow<[u8]> {
-        self.as_ref().into()
+    fn to_bech32_str(&self) -> String {
+        bech32::to_bech32_from_bytes::<Self>(self.as_ref())
     }
 }
 

--- a/chain-crypto/src/sign.rs
+++ b/chain-crypto/src/sign.rs
@@ -1,4 +1,6 @@
+use crate::bech32::{self, Bech32};
 use crate::{hex, kes, key};
+use std::borrow::Cow;
 use std::fmt;
 use std::marker::PhantomData;
 
@@ -116,6 +118,18 @@ impl<T, A: VerificationAlgorithm> Clone for Signature<T, A> {
 impl<T, A: VerificationAlgorithm> AsRef<[u8]> for Signature<T, A> {
     fn as_ref(&self) -> &[u8] {
         self.signdata.as_ref()
+    }
+}
+
+impl<T, A: VerificationAlgorithm> Bech32 for Signature<T, A> {
+    const BECH32_HRP: &'static str = A::SECRET_BECH32_HRP;
+
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self, bech32::Error> {
+        Self::from_bytes(bytes).map_err(bech32::Error::data_invalid)
+    }
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        self.as_ref().into()
     }
 }
 


### PR DESCRIPTION
This is needed so signature can be loaded directly from bech32-encoded private key file in Jormungandr CLI.

Also slimmed down Bech32 trait by removing helper methods and adding helper functions.