### PR TITLE
Minor updates

### DIFF
--- a/chain-impl-mockchain/src/config.rs
+++ b/chain-impl-mockchain/src/config.rs
@@ -119,6 +119,18 @@ pub fn entity_from_string<T: ConfigParam>(tag: &str, value: &str) -> Result<T, E
     T::from_string(value)
 }
 
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::InvalidTag => write!(f, "Invalid tag"),
+            Error::SizeInvalid => write!(f, "Invalid payload size"),
+            Error::StructureInvalid => write!(f, "Invalid payload structure"),
+            Error::UnknownString(s) => write!(f, "Invalid payload string: {}", s),
+        }
+    }
+}
+impl std::error::Error for Error {}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/chain-storage-sqlite/src/lib.rs
+++ b/chain-storage-sqlite/src/lib.rs
@@ -4,6 +4,7 @@ use chain_storage::{
     store::{BackLink, BlockInfo, BlockStore},
 };
 use rusqlite::types::Value;
+use std::path::Path;
 
 pub struct SQLiteBlockStore<B>
 where
@@ -17,7 +18,7 @@ impl<B> SQLiteBlockStore<B>
 where
     B: Block,
 {
-    pub fn new(path: &str) -> Self {
+    pub fn new<P: AsRef<Path>>(path: P) -> Self {
         let manager = r2d2_sqlite::SqliteConnectionManager::file(path);
         let pool = r2d2::Pool::new(manager).unwrap();
 


### PR DESCRIPTION
* add `Error` trait implementation to the block config Error type;
* change `SQLiteBlockStore::new` constructor to use `AsRef<Path>` instead of `&str` as parameter