### PR TITLE
network: Demand sendable inbound subscription streams

### DIFF
--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -119,5 +119,5 @@ pub trait BlockService {
     // that receives blocks announced by the peer.
     fn block_subscription<In>(&mut self, inbound: In) -> Self::BlockSubscriptionFuture
     where
-        In: Stream<Item = Self::Header, Error = Error>;
+        In: Stream<Item = Self::Header, Error = Error> + Send + 'static;
 }

--- a/network-core/src/server/content.rs
+++ b/network-core/src/server/content.rs
@@ -58,7 +58,7 @@ pub trait ContentService {
     // that receives messages announced by the peer.
     fn message_subscription<In>(&mut self, inbound: In) -> Self::MessageSubscriptionFuture
     where
-        In: Stream<Item = Self::Message, Error = Error>;
+        In: Stream<Item = Self::Message, Error = Error> + Send + 'static;
 }
 
 /// Response from the `propose_transactions` method of a `TransactionService`.

--- a/network-core/src/server/gossip.rs
+++ b/network-core/src/server/gossip.rs
@@ -1,7 +1,7 @@
 ///! Gossip service abstraction.
 use crate::{
     error::Error,
-    gossip::{Gossip, Node},
+    gossip::{Gossip, Node, NodeId},
 };
 
 use futures::prelude::*;
@@ -9,8 +9,11 @@ use futures::prelude::*;
 /// Intreface for the node discovery service implementation
 /// in the p2p network.
 pub trait GossipService {
-    /// Gossip message content.
-    type Node: Node;
+    /// Network node identifier.
+    type NodeId: NodeId;
+
+    /// Gossip message describing a network node.
+    type Node: Node<Id = Self::NodeId>;
 
     /// The type of an asynchronous stream that retrieves node gossip
     /// messages from a peer.
@@ -29,5 +32,5 @@ pub trait GossipService {
     // that receives node gossip messages sent by the peer.
     fn gossip_subscription<In>(&mut self, inbound: In) -> Self::GossipSubscriptionFuture
     where
-        In: Stream<Item = Gossip<Self::Node>, Error = Error>;
+        In: Stream<Item = Gossip<Self::Node>, Error = Error> + Send + 'static;
 }

--- a/network-grpc/src/server.rs
+++ b/network-grpc/src/server.rs
@@ -1,6 +1,8 @@
 use crate::{gen::node::server as gen_server, service::NodeService};
 
-use network_core::server::Node;
+use network_core::server::{
+    block::BlockService, content::ContentService, gossip::GossipService, Node,
+};
 
 use futures::future::Executor;
 use tokio::net::{TcpListener, TcpStream};
@@ -26,6 +28,10 @@ where
     T::BlockService: Clone,
     T::ContentService: Clone,
     T::GossipService: Clone,
+    <T::BlockService as BlockService>::Header: Send + 'static,
+    <T::ContentService as ContentService>::Message: Send + 'static,
+    <T::GossipService as GossipService>::Node: Send + 'static,
+    <T::GossipService as GossipService>::NodeId: Send + 'static,
 {
     h2: tower_h2::Server<
         gen_server::NodeServer<NodeService<T>>,
@@ -42,6 +48,10 @@ where
     T::BlockService: Clone,
     T::ContentService: Clone,
     T::GossipService: Clone,
+    <T::BlockService as BlockService>::Header: Send + 'static,
+    <T::ContentService as ContentService>::Message: Send + 'static,
+    <T::GossipService as GossipService>::Node: Send + 'static,
+    <T::GossipService as GossipService>::NodeId: Send + 'static,
 {
     h2: tower_h2::server::Connection<
         S,
@@ -59,6 +69,10 @@ where
     T::BlockService: Clone,
     T::ContentService: Clone,
     T::GossipService: Clone,
+    <T::BlockService as BlockService>::Header: Send + 'static,
+    <T::ContentService as ContentService>::Message: Send + 'static,
+    <T::GossipService as GossipService>::Node: Send + 'static,
+    <T::GossipService as GossipService>::NodeId: Send + 'static,
     E: Executor<
         tower_h2::server::Background<
             gen_server::node::ResponseFuture<NodeService<T>>,
@@ -79,6 +93,10 @@ where
     T::BlockService: Clone,
     T::ContentService: Clone,
     T::GossipService: Clone,
+    <T::BlockService as BlockService>::Header: Send + 'static,
+    <T::ContentService as ContentService>::Message: Send + 'static,
+    <T::GossipService as GossipService>::Node: Send + 'static,
+    <T::GossipService as GossipService>::NodeId: Send + 'static,
     E: Executor<
             tower_h2::server::Background<
                 gen_server::node::ResponseFuture<NodeService<T>>,
@@ -153,6 +171,10 @@ where
     T::BlockService: Clone,
     T::ContentService: Clone,
     T::GossipService: Clone,
+    <T::BlockService as BlockService>::Header: Send + 'static,
+    <T::ContentService as ContentService>::Message: Send + 'static,
+    <T::GossipService as GossipService>::Node: Send + 'static,
+    <T::GossipService as GossipService>::NodeId: Send + 'static,
 {
     fn from(err: H2Error<T>) -> Self {
         use tower_h2::server::Error::*;

--- a/network-grpc/src/service.rs
+++ b/network-grpc/src/service.rs
@@ -220,9 +220,13 @@ macro_rules! try_get_service {
 impl<T> gen::node::server::Node for NodeService<T>
 where
     T: Node,
-    <T as Node>::BlockService: Clone,
-    <T as Node>::ContentService: Clone,
-    <T as Node>::GossipService: Clone,
+    T::BlockService: Clone,
+    T::ContentService: Clone,
+    T::GossipService: Clone,
+    <T::BlockService as BlockService>::Header: Send + 'static,
+    <T::ContentService as ContentService>::Message: Send + 'static,
+    <T::GossipService as GossipService>::Node: Send + 'static,
+    <T::GossipService as GossipService>::NodeId: Send + 'static,
 {
     type TipFuture = ResponseFuture<
         gen::node::TipResponse,


### PR DESCRIPTION
The application code would want to pass the stream to other async tasks.
The `Send` + `'static` bounds are similar to the outbound subscription
streams of the client-side subscription API (which need these bounds
to implement `tower_grpc::client::Encodable`).