### PR TITLE
network-core: Resolve services by reference

### DIFF
--- a/network-core/src/server.rs
+++ b/network-core/src/server.rs
@@ -21,13 +21,13 @@ pub trait Node {
 
     /// Instantiates the block service,
     /// if supported by this node.
-    fn block_service(&self) -> Option<Self::BlockService>;
+    fn block_service(&mut self) -> Option<&mut Self::BlockService>;
 
     /// Instantiates the content service,
     /// if supported by this node.
-    fn content_service(&self) -> Option<Self::ContentService>;
+    fn content_service(&mut self) -> Option<&mut Self::ContentService>;
 
     /// Instantiates the gossip service,
     /// if supported by this node.
-    fn gossip_service(&self) -> Option<Self::GossipService>;
+    fn gossip_service(&mut self) -> Option<&mut Self::GossipService>;
 }

--- a/network-grpc/src/server.rs
+++ b/network-grpc/src/server.rs
@@ -24,10 +24,7 @@ use std::path::Path;
 /// service trait `Node`.
 pub struct Server<T, E>
 where
-    T: Node,
-    T::BlockService: Clone,
-    T::ContentService: Clone,
-    T::GossipService: Clone,
+    T: Node + Clone,
     <T::BlockService as BlockService>::Header: Send + 'static,
     <T::ContentService as ContentService>::Message: Send + 'static,
     <T::GossipService as GossipService>::Node: Send + 'static,
@@ -44,10 +41,7 @@ where
 pub struct Connection<S, T, E>
 where
     S: AsyncRead + AsyncWrite,
-    T: Node,
-    T::BlockService: Clone,
-    T::ContentService: Clone,
-    T::GossipService: Clone,
+    T: Node + Clone,
     <T::BlockService as BlockService>::Header: Send + 'static,
     <T::ContentService as ContentService>::Message: Send + 'static,
     <T::GossipService as GossipService>::Node: Send + 'static,
@@ -65,10 +59,7 @@ where
 impl<S, T, E> Future for Connection<S, T, E>
 where
     S: AsyncRead + AsyncWrite,
-    T: Node + 'static,
-    T::BlockService: Clone,
-    T::ContentService: Clone,
-    T::GossipService: Clone,
+    T: Node + Clone + 'static,
     <T::BlockService as BlockService>::Header: Send + 'static,
     <T::ContentService as ContentService>::Message: Send + 'static,
     <T::GossipService as GossipService>::Node: Send + 'static,
@@ -89,10 +80,7 @@ where
 
 impl<T, E> Server<T, E>
 where
-    T: Node + 'static,
-    T::BlockService: Clone,
-    T::ContentService: Clone,
-    T::GossipService: Clone,
+    T: Node + Clone + 'static,
     <T::BlockService as BlockService>::Header: Send + 'static,
     <T::ContentService as ContentService>::Message: Send + 'static,
     <T::GossipService as GossipService>::Node: Send + 'static,
@@ -167,10 +155,7 @@ type H2Error<T> = tower_h2::server::Error<gen_server::NodeServer<NodeService<T>>
 // So we match it into our own variants.
 impl<T> From<H2Error<T>> for Error
 where
-    T: Node,
-    T::BlockService: Clone,
-    T::ContentService: Clone,
-    T::GossipService: Clone,
+    T: Node + Clone,
     <T::BlockService as BlockService>::Header: Send + 'static,
     <T::ContentService as ContentService>::Message: Send + 'static,
     <T::GossipService as GossipService>::Node: Send + 'static,

--- a/network-ntt/src/server.rs
+++ b/network-ntt/src/server.rs
@@ -116,7 +116,7 @@ where
 /// So we see the high-level framed protocol, with the messages
 /// types that has the semantics for our application.
 pub fn run_connection<N, T>(
-    server: Server<N>,
+    mut server: Server<N>,
     connection: protocol::Connection<
         T,
         <<N as Node>::BlockService as BlockService>::Block,
@@ -166,7 +166,7 @@ where
                     let sink2 = sink_tx.clone();
                     let sink3 = sink_tx.clone();
                     future::Either::B(future::Either::A({
-                        let mut service = server
+                        let service = server
                             .node
                             .block_service()
                             .expect("block service is not implemented");


### PR DESCRIPTION
This simplifies the code and allows service implementations to be
the node object itself or parts of it, sharing common state.