### PR TITLE
network-core: Added error code FailedPrecondition

### DIFF
--- a/network-core/src/error.rs
+++ b/network-core/src/error.rs
@@ -7,6 +7,7 @@ pub enum Code {
     Unknown,
     InvalidArgument,
     NotFound,
+    FailedPrecondition,
     Unimplemented,
     Internal,
 }
@@ -47,6 +48,7 @@ impl fmt::Display for Error {
             Code::Unknown => "unknown error",
             Code::InvalidArgument => "invalid request data",
             Code::NotFound => "not found",
+            Code::FailedPrecondition => "system state does not permit the operation",
             Code::Unimplemented => "not implemented",
             Code::Internal => "internal processing error",
         };

--- a/network-grpc/src/convert.rs
+++ b/network-grpc/src/convert.rs
@@ -16,6 +16,7 @@ pub fn error_into_grpc(err: core_error::Error) -> Status {
         Unknown => Code::Unknown,
         InvalidArgument => Code::InvalidArgument,
         NotFound => Code::NotFound,
+        FailedPrecondition => Code::FailedPrecondition,
         Unimplemented => Code::Unimplemented,
         Internal => Code::Internal,
         // When a new case has to be added here, remember to
@@ -33,6 +34,7 @@ pub fn error_from_grpc(e: Status) -> core_error::Error {
         Unknown => core_error::Code::Unknown,
         InvalidArgument => core_error::Code::InvalidArgument,
         NotFound => core_error::Code::NotFound,
+        FailedPrecondition => core_error::Code::FailedPrecondition,
         Unimplemented => core_error::Code::Unimplemented,
         Internal => core_error::Code::Internal,
         _ => core_error::Code::Unknown,


### PR DESCRIPTION
Needed to inform peers of protocol requests made in a wrong order or state.