### PR TITLE
Multiverse improvements

### DIFF
--- a/chain-impl-mockchain/Cargo.toml
+++ b/chain-impl-mockchain/Cargo.toml
@@ -20,6 +20,7 @@ serde_derive = { version = "^1.0", optional = true }
 chain-core = { path = "../chain-core" }
 chain-addr = { path = "../chain-addr" }
 chain-crypto = { path = "../chain-crypto" }
+chain-storage = { path = "../chain-storage" }
 cardano = { path= "../cardano" }
 rand = "0.6"
 imhamt = { path = "../imhamt" }

--- a/chain-impl-mockchain/src/block/header.rs
+++ b/chain-impl-mockchain/src/block/header.rs
@@ -179,7 +179,7 @@ impl Header {
 
 impl property::ChainLength for ChainLength {
     fn next(&self) -> Self {
-        ChainLength(self.0 + 1)
+        ChainLength(self.0.checked_add(1).unwrap())
     }
 }
 

--- a/chain-impl-mockchain/src/block/headerraw.rs
+++ b/chain-impl-mockchain/src/block/headerraw.rs
@@ -18,7 +18,7 @@ impl property::Serialize for HeaderRaw {
         use std::io::Write;
 
         let mut codec = Codec::from(writer);
-        dbg!(self.0.len());
+        //dbg!(self.0.len());
         codec.put_u16(self.0.len() as u16)?;
         codec.write_all(&self.0)?;
         Ok(())
@@ -35,7 +35,7 @@ impl property::Deserialize for HeaderRaw {
         let mut codec = Codec::from(reader);
 
         let header_size = codec.get_u16()? as usize;
-        dbg!(header_size);
+        //dbg!(header_size);
         let mut v = vec![0u8; header_size];
         codec.read_exact(&mut v[..])?;
         Ok(HeaderRaw(v))

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -219,10 +219,12 @@ impl Multiverse {
             cur_hash = cur_block_info.parent_id();
         };
 
+        /*
         println!(
             "applying {} blocks to reconstruct state",
             blocks_to_apply.len()
         );
+        */
 
         for hash in blocks_to_apply.iter().rev() {
             let block = store.get_block(&hash).unwrap().0;

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -121,7 +121,10 @@ impl Multiverse {
             let mut to_keep = ChainLength(0);
 
             for (chain_length, hashes) in &self.states_by_chain_length {
-                // Keep states close to the current longest chain.
+                // Keep states close to the current longest
+                // chain. FIXME: we should keep only the state that is
+                // an ancestor of the current longest chain. However,
+                // checking ancestry requires access to BlockStore.
                 if chain_length.0 + SUFFIX_TO_KEEP >= longest_chain.0 {
                     break;
                 }

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -6,9 +6,12 @@
 //! For now this only track block at the headerhash level, and doesn't order them
 //! temporaly, leaving no way to do garbage collection
 
-use chain_core::property::BlockId;
-use std::collections::{hash_map::Entry, BTreeMap, HashMap};
+use crate::block::ChainLength;
+use std::collections::{hash_map::Entry, BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, RwLock};
+
+type State = crate::ledger::Ledger;
+type BlockId = crate::key::Hash;
 
 //
 // The multiverse is characterized by a single origin and multiple state of a given time
@@ -25,24 +28,29 @@ use std::sync::{Arc, RwLock};
 // +------------------------------+-----> time
 // t=0                            t=latest known
 //
-pub struct Multiverse<Hash: BlockId, ST> {
-    known_states: BTreeMap<Hash, ST>,
-    roots: Arc<RwLock<Roots<Hash>>>,
+pub struct Multiverse {
+    states_by_hash: HashMap<BlockId, State>,
+    states_by_chain_length: BTreeMap<ChainLength, HashSet<BlockId>>, // FIXME: use multimap?
+    roots: Arc<RwLock<Roots>>,
 }
 
-struct Roots<Hash: BlockId> {
-    roots: HashMap<Hash, usize>,
+/// Keep all states that are this close to the longest chain.
+const SUFFIX_TO_KEEP: u32 = 50;
+
+struct Roots {
+    /// Record how many GCRoot objects currently exist for this block ID.
+    roots: HashMap<BlockId, usize>,
 }
 
 /// A RAII wrapper around a block identifier that keeps the state
 /// corresponding to the block pinned in memory.
-pub struct GCRoot<Hash: BlockId> {
-    hash: Hash,
-    roots: Arc<RwLock<Roots<Hash>>>,
+pub struct GCRoot {
+    hash: BlockId,
+    roots: Arc<RwLock<Roots>>,
 }
 
-impl<Hash: BlockId> GCRoot<Hash> {
-    fn new(hash: Hash, roots: Arc<RwLock<Roots<Hash>>>) -> Self {
+impl GCRoot {
+    fn new(hash: BlockId, roots: Arc<RwLock<Roots>>) -> Self {
         {
             let mut roots = roots.write().unwrap();
             *roots.roots.entry(hash.clone()).or_insert(0) += 1;
@@ -52,14 +60,14 @@ impl<Hash: BlockId> GCRoot<Hash> {
     }
 }
 
-impl<Hash: BlockId> std::ops::Deref for GCRoot<Hash> {
-    type Target = Hash;
+impl std::ops::Deref for GCRoot {
+    type Target = BlockId;
     fn deref(&self) -> &Self::Target {
         &self.hash
     }
 }
 
-impl<Hash: BlockId> Drop for GCRoot<Hash> {
+impl Drop for GCRoot {
     fn drop(&mut self) {
         let mut roots = self.roots.write().unwrap();
         if let Entry::Occupied(mut entry) = roots.roots.entry(self.hash.clone()) {
@@ -76,10 +84,11 @@ impl<Hash: BlockId> Drop for GCRoot<Hash> {
     }
 }
 
-impl<Hash: BlockId, ST> Multiverse<Hash, ST> {
+impl Multiverse {
     pub fn new() -> Self {
         Multiverse {
-            known_states: BTreeMap::new(),
+            states_by_hash: HashMap::new(),
+            states_by_chain_length: BTreeMap::new(),
             roots: Arc::new(RwLock::new(Roots {
                 roots: HashMap::new(),
             })),
@@ -88,8 +97,12 @@ impl<Hash: BlockId, ST> Multiverse<Hash, ST> {
 
     /// Add a state to the multiverse. Return a GCRoot object that
     /// pins the state into memory.
-    pub fn add(&mut self, k: Hash, st: ST) -> GCRoot<Hash> {
-        self.known_states.entry(k.clone()).or_insert(st);
+    pub fn add(&mut self, k: BlockId, st: State) -> GCRoot {
+        self.states_by_chain_length
+            .entry(st.chain_length())
+            .or_insert(HashSet::new())
+            .insert(k.clone());
+        self.states_by_hash.entry(k.clone()).or_insert(st);
 
         GCRoot::new(k, self.roots.clone())
     }
@@ -98,30 +111,126 @@ impl<Hash: BlockId, ST> Multiverse<Hash, ST> {
     /// and less likely to be used anymore, so we leave
     /// a gap between different version that gets bigger and bigger
     pub fn gc(&mut self) {
-        let roots = self.roots.read().unwrap();
-
         let mut garbage = vec![];
 
-        for (k, _) in &self.known_states {
-            if !roots.roots.contains_key(&k) {
-                garbage.push(k.clone());
+        {
+            let roots = self.roots.read().unwrap();
+
+            let longest_chain = self.states_by_chain_length.iter().next_back().unwrap().0;
+
+            let mut to_keep = ChainLength(0);
+
+            for (chain_length, hashes) in &self.states_by_chain_length {
+                // Keep states close to the current longest chain.
+                if chain_length.0 + SUFFIX_TO_KEEP >= longest_chain.0 {
+                    break;
+                }
+                // Keep states in gaps that get exponentially smaller as
+                // they get closer to the longest chain.
+                if chain_length >= &to_keep {
+                    to_keep = ChainLength(chain_length.0 + (longest_chain.0 - chain_length.0) / 2);
+                } else {
+                    for k in hashes {
+                        // Keep states that are GC roots.
+                        if !roots.roots.contains_key(&k) {
+                            garbage.push(k.clone());
+                        }
+                    }
+                }
             }
         }
 
-        println!("deleting {} states from multiverse", garbage.len());
+        //println!("deleting {} states from multiverse", garbage.len());
 
         for k in garbage {
-            //println!("deleting state {:?}", k);
-            self.known_states.remove(&k);
+            self.delete(&k);
         }
     }
 
-    pub fn get(&self, k: &Hash) -> Option<&ST> {
-        self.known_states.get(&k)
+    fn delete(&mut self, k: &BlockId) {
+        //println!("deleting state {:?}", k);
+        let st = self.states_by_hash.remove(&k).unwrap();
+        // Remove the hash from states_by_chain_length, then prune
+        // the latter.
+        if let std::collections::btree_map::Entry::Occupied(mut entry) =
+            self.states_by_chain_length.entry(st.chain_length())
+        {
+            let removed = entry.get_mut().remove(&k);
+            assert!(removed);
+            if entry.get().is_empty() {
+                //println!("removing chain length {}", st.chain_length().0);
+                entry.remove_entry();
+            }
+        } else {
+            unreachable!();
+        }
     }
 
-    pub fn get_from_root(&self, root: &GCRoot<Hash>) -> &ST {
+    pub fn get(&self, k: &BlockId) -> Option<&State> {
+        self.states_by_hash.get(&k)
+    }
+
+    pub fn get_from_root(&self, root: &GCRoot) -> &State {
         assert!(Arc::ptr_eq(&root.roots, &self.roots));
         self.get(&*root).unwrap()
     }
+
+    /// Return the number of states stored in memory.
+    pub fn nr_states(&self) -> usize {
+        self.states_by_hash.len()
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::{Multiverse, State};
+    use crate::block::{Block, BlockBuilder};
+    use crate::message::{InitialEnts, Message};
+    use chain_core::property::{Block as _, ChainLength as _, HasMessages as _};
+    use quickcheck::StdGen;
+
+    fn apply_block(state: &State, block: &Block) -> State {
+        if state.chain_length().0 != 0 {
+            assert_eq!(state.chain_length().0 + 1, block.chain_length().0);
+        }
+        state
+            .apply_block(&state.get_ledger_parameters(), block.messages())
+            .unwrap()
+    }
+
+    #[test]
+    pub fn multiverse() {
+        let mut multiverse = Multiverse::new();
+
+        let mut g = StdGen::new(rand::thread_rng(), 10);
+        let leader_key = crate::key::test::arbitrary_secret_key(&mut g);
+
+        let mut genesis_block = BlockBuilder::new();
+        genesis_block.message(Message::Initial(InitialEnts::new()));
+        let genesis_block = genesis_block.make_genesis_block();
+        let genesis_state = State::new(genesis_block.id(), genesis_block.messages()).unwrap();
+        assert_eq!(genesis_state.chain_length().0, 0);
+        multiverse.add(genesis_block.id(), genesis_state.clone());
+
+        let mut state = genesis_state;
+        let mut _root = None;
+        let mut parent = genesis_block.id();
+        for i in 1..10001 {
+            let mut block = BlockBuilder::new();
+            block.chain_length(state.chain_length.next());
+            block.parent(parent);
+            let block = block.make_bft_block(&leader_key);
+            state = apply_block(&state, &block);
+            assert_eq!(state.chain_length().0, i);
+            _root = Some(multiverse.add(block.id(), state.clone()));
+            multiverse.gc();
+            parent = block.id();
+            assert!(
+                multiverse.nr_states()
+                    <= super::SUFFIX_TO_KEEP as usize + ((i as f32).log2()) as usize
+            );
+        }
+    }
+
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ nixpkgs ? fetchTarball https://github.com/NixOS/nixpkgs/archive/7fff567ee99c1f343ecdd82fef2e35fb6f50e423.tar.gz
+{ nixpkgs ? fetchTarball https://github.com/NixOS/nixpkgs/archive/8d3e91077ba074e2c947a152ee8ab7be885c42ab.tar.gz
 , pkgs ? import nixpkgs {}
 }:
 

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,7 @@
 with pkgs;
 
 stdenv.mkDerivation {
-  name = "rust-carano";
+  name = "rust-cardano";
 
   src = null;
 


### PR DESCRIPTION
This PR:

* Improves `Multiverse::gc()` by keeping all states with a chain length close to the current longest chain (as determined by the `SUFFIX_TO_KEEP` constant), as well as states at exponentially increasing gaps from the longest chain. This ensures that reconstructing an arbitrary state should be O(n) where n is the block's distance from the current longest chain.

* Adds a method `Multiverse::get_from_storage()` that gets the chain state at block `k` from memory if present, and otherwise reconstructs it by reading blocks from storage and applying them to the nearest ancestor state that we do have.

* Adds a test for `Multiverse`.