### PR TITLE
Add support for init message consensus

### DIFF
--- a/chain-addr/src/lib.rs
+++ b/chain-addr/src/lib.rs
@@ -500,6 +500,16 @@ pub mod testing {
             Address(discrimination, kind)
         }
     }
+
+    impl Arbitrary for Discrimination {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            match u8::arbitrary(g) % 2 {
+                0 => Discrimination::Production,
+                1 => Discrimination::Test,
+                _ => unreachable!(),
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/chain-impl-mockchain/Cargo.toml
+++ b/chain-impl-mockchain/Cargo.toml
@@ -25,6 +25,8 @@ cardano = { path= "../cardano" }
 rand = "0.6"
 imhamt = { path = "../imhamt" }
 lazy_static = "1.3.0"
+strum = "0.15.0"
+strum_macros = "0.15.0"
 
 [dev-dependencies]
 quickcheck = "0.8"

--- a/chain-impl-mockchain/src/account.rs
+++ b/chain-impl-mockchain/src/account.rs
@@ -106,6 +106,10 @@ impl State {
             })),
         }
     }
+
+    pub fn get_value(&self) -> Value {
+        self.value
+    }
 }
 
 /// Spending counter associated to an account.
@@ -204,5 +208,10 @@ impl Ledger {
             .update(account, |st| st.sub(value))
             .map(|ledger| (Ledger(ledger), counter))
             .map_err(|e| e.into())
+    }
+
+    pub fn get_total_value(&self) -> Result<Value, ValueError> {
+        let values = self.0.iter().map(|(_, state)| state.get_value());
+        Value::sum(values)
     }
 }

--- a/chain-impl-mockchain/src/block/header.rs
+++ b/chain-impl-mockchain/src/block/header.rs
@@ -312,7 +312,7 @@ mod test {
 
     impl Arbitrary for ConsensusVersion {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
-            ConsensusVersion::from_u16(u16::arbitrary(g) % 3).unwrap()
+            ConsensusVersion::from_u16(u16::arbitrary(g) % 2 + 1).unwrap()
         }
     }
 

--- a/chain-impl-mockchain/src/block/version.rs
+++ b/chain-impl-mockchain/src/block/version.rs
@@ -2,6 +2,8 @@ use lazy_static::lazy_static;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use std::collections::BTreeMap;
+use strum::IntoEnumIterator;
+use strum_macros::{Display, EnumIter, EnumString, IntoStaticStr};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AnyBlockVersion {
@@ -51,7 +53,7 @@ impl From<BlockVersion> for AnyBlockVersion {
     }
 }
 
-#[derive(Debug, Clone, Copy, FromPrimitive, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, EnumIter, FromPrimitive, PartialEq, Eq)]
 pub enum BlockVersion {
     Genesis = 0,
     Ed25519Signed = 1,
@@ -68,10 +70,26 @@ impl BlockVersion {
     }
 }
 
-#[derive(Debug, Clone, Copy, FromPrimitive, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Display,
+    EnumString,
+    FromPrimitive,
+    IntoStaticStr,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+)]
 pub enum ConsensusVersion {
+    #[strum(to_string = "none")]
     None = 0,
+    #[strum(to_string = "bft")]
     Bft = 1,
+    #[strum(to_string = "genesis")]
     GenesisPraos = 2,
 }
 
@@ -80,14 +98,10 @@ impl ConsensusVersion {
         lazy_static! {
             static ref MAPPING: BTreeMap<u16, Vec<BlockVersion>> = {
                 let mut map = BTreeMap::<_, Vec<_>>::new();
-                for block_ord in 0.. {
-                    match BlockVersion::from_u64(block_ord) {
-                        Some(block) => map
-                            .entry(block.get_consensus() as u16)
-                            .or_default()
-                            .push(block),
-                        None => break,
-                    }
+                for block_version in BlockVersion::iter() {
+                    map.entry(block_version.get_consensus() as u16)
+                        .or_default()
+                        .push(block_version)
                 }
                 map
             };

--- a/chain-impl-mockchain/src/block/version.rs
+++ b/chain-impl-mockchain/src/block/version.rs
@@ -61,11 +61,11 @@ pub enum BlockVersion {
 }
 
 impl BlockVersion {
-    pub fn get_consensus(self) -> ConsensusVersion {
+    pub fn get_consensus(self) -> Option<ConsensusVersion> {
         match self {
-            BlockVersion::Genesis => ConsensusVersion::None,
-            BlockVersion::Ed25519Signed => ConsensusVersion::Bft,
-            BlockVersion::KesVrfproof => ConsensusVersion::GenesisPraos,
+            BlockVersion::Genesis => None,
+            BlockVersion::Ed25519Signed => Some(ConsensusVersion::Bft),
+            BlockVersion::KesVrfproof => Some(ConsensusVersion::GenesisPraos),
         }
     }
 }
@@ -85,8 +85,6 @@ impl BlockVersion {
     Hash,
 )]
 pub enum ConsensusVersion {
-    #[strum(to_string = "none")]
-    None = 0,
     #[strum(to_string = "bft")]
     Bft = 1,
     #[strum(to_string = "genesis")]
@@ -99,9 +97,9 @@ impl ConsensusVersion {
             static ref MAPPING: BTreeMap<u16, Vec<BlockVersion>> = {
                 let mut map = BTreeMap::<_, Vec<_>>::new();
                 for block_version in BlockVersion::iter() {
-                    map.entry(block_version.get_consensus() as u16)
-                        .or_default()
-                        .push(block_version)
+                    if let Some(consensus) = block_version.get_consensus() {
+                        map.entry(consensus as u16).or_default().push(block_version)
+                    }
                 }
                 map
             };

--- a/chain-impl-mockchain/src/config.rs
+++ b/chain-impl-mockchain/src/config.rs
@@ -1,5 +1,7 @@
+use crate::block::ConsensusVersion;
 use crate::message::initial::{Tag, TagPayload};
 use chain_addr::Discrimination;
+use num_traits::FromPrimitive;
 use std::str::FromStr;
 
 /// Seconds elapsed since 1-Jan-1970 (unix time)
@@ -94,6 +96,33 @@ impl ConfigParam for Discrimination {
             "test" => Ok(Discrimination::Test),
             _ => Err(Error::UnknownString(s.to_string())),
         }
+    }
+}
+
+impl ConfigParam for ConsensusVersion {
+    const TAG: Tag = Tag::unchecked_new(3);
+    const NAME: &'static str = "block0-consensus";
+
+    fn to_payload(&self) -> TagPayload {
+        (*self as u16).to_be_bytes().to_vec()
+    }
+
+    fn from_payload(payload: &TagPayload) -> Result<Self, Error> {
+        let mut bytes = 0u16.to_ne_bytes();
+        if payload.len() != bytes.len() {
+            return Err(Error::SizeInvalid);
+        };
+        bytes.copy_from_slice(&payload);
+        let integer = u16::from_be_bytes(bytes);
+        ConsensusVersion::from_u16(integer).ok_or(Error::StructureInvalid)
+    }
+
+    fn to_string(&self) -> String {
+        format!("{}", self)
+    }
+
+    fn from_string(s: &str) -> Result<Self, Error> {
+        s.parse().map_err(|_| Error::UnknownString(s.to_string()))
     }
 }
 

--- a/chain-impl-mockchain/src/config.rs
+++ b/chain-impl-mockchain/src/config.rs
@@ -1,7 +1,11 @@
 use crate::block::ConsensusVersion;
-use crate::message::initial::{Tag, TagPayload};
 use chain_addr::Discrimination;
+use chain_core::mempack::{ReadBuf, ReadError, Readable};
+use chain_core::packer::Codec;
+use chain_core::property;
 use num_traits::FromPrimitive;
+use std::fmt::{self, Display, Formatter};
+use std::io::{self, Write};
 use std::str::FromStr;
 
 /// Seconds elapsed since 1-Jan-1970 (unix time)
@@ -17,42 +21,144 @@ pub enum Error {
     UnknownString(String),
 }
 
-pub trait ConfigParam: Clone + Eq + PartialEq {
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Error::InvalidTag => write!(f, "Invalid config parameter tag"),
+            Error::SizeInvalid => write!(f, "Invalid config parameter size"),
+            Error::StructureInvalid => write!(f, "Invalid config parameter structure"),
+            Error::UnknownString(s) => write!(f, "Invalid config parameter string '{}'", s),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl Into<ReadError> for Error {
+    fn into(self) -> ReadError {
+        ReadError::StructureInvalid(self.to_string())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ConfigParam {
+    Block0Date(Block0Date),
+    Discrimination(Discrimination),
+    ConsensusVersion(ConsensusVersion),
+}
+
+impl Readable for ConfigParam {
+    fn read<'a>(buf: &mut ReadBuf<'a>) -> Result<Self, ReadError> {
+        let taglen = TagLen(buf.get_u16()?);
+        let bytes = buf.get_slice(taglen.get_len())?;
+        match taglen.get_tag() {
+            Block0Date::TAG => Block0Date::from_payload(bytes).map(ConfigParam::Block0Date),
+            Discrimination::TAG => {
+                Discrimination::from_payload(bytes).map(ConfigParam::Discrimination)
+            }
+            ConsensusVersion::TAG => {
+                ConsensusVersion::from_payload(bytes).map(ConfigParam::ConsensusVersion)
+            }
+            _ => Err(Error::InvalidTag),
+        }
+        .map_err(Into::into)
+    }
+}
+
+impl property::Serialize for ConfigParam {
+    type Error = io::Error;
+
+    fn serialize<W: Write>(&self, writer: W) -> Result<(), Self::Error> {
+        let (tag, bytes) = match self {
+            ConfigParam::Block0Date(data) => (Block0Date::TAG, data.to_payload()),
+            ConfigParam::Discrimination(data) => (Discrimination::TAG, data.to_payload()),
+            ConfigParam::ConsensusVersion(data) => (ConsensusVersion::TAG, data.to_payload()),
+        };
+        let taglen = TagLen::new(tag, bytes.len()).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "initial ent payload too big".to_string(),
+            )
+        })?;
+        let mut codec = Codec::from(writer);
+        codec.put_u16(taglen.0)?;
+        codec.write_all(&bytes)
+    }
+}
+
+#[cfg(feature = "generic-serialization")]
+mod serde_impl {
+    use super::*;
+    use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
+
+    impl<'de> Deserialize<'de> for ConfigParam {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let (tag, value) = <(String, String)>::deserialize(deserializer)?;
+            match &*tag {
+                Block0Date::NAME => Block0Date::from_cfg_str(&value).map(ConfigParam::Block0Date),
+                Discrimination::NAME => {
+                    Discrimination::from_cfg_str(&value).map(ConfigParam::Discrimination)
+                }
+                ConsensusVersion::NAME => {
+                    ConsensusVersion::from_cfg_str(&value).map(ConfigParam::ConsensusVersion)
+                }
+                _ => Err(Error::InvalidTag),
+            }
+            .map_err(D::Error::custom)
+        }
+    }
+
+    impl Serialize for ConfigParam {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            match self {
+                ConfigParam::Block0Date(data) => (Block0Date::NAME, data.to_cfg_string()),
+                ConfigParam::Discrimination(data) => (Discrimination::NAME, data.to_cfg_string()),
+                ConfigParam::ConsensusVersion(data) => {
+                    (ConsensusVersion::NAME, data.to_cfg_string())
+                }
+            }
+            .serialize(serializer)
+        }
+    }
+}
+
+trait ConfigParamVariant: Clone + Eq + PartialEq {
     const TAG: Tag;
     const NAME: &'static str;
 
-    fn to_payload(&self) -> TagPayload;
+    fn to_payload(&self) -> Vec<u8>;
 
-    fn from_payload(payload: &TagPayload) -> Result<Self, Error>;
+    fn from_payload(payload: &[u8]) -> Result<Self, Error>;
 
-    fn to_string(&self) -> String;
-    fn from_string(s: &str) -> Result<Self, Error>;
+    fn to_cfg_string(&self) -> String;
+    fn from_cfg_str(s: &str) -> Result<Self, Error>;
 }
 
-impl ConfigParam for Block0Date {
-    const TAG: Tag = Tag::unchecked_new(1);
+impl ConfigParamVariant for Block0Date {
+    const TAG: Tag = Tag::new(1);
     const NAME: &'static str = "block0-date";
 
-    fn to_payload(&self) -> TagPayload {
+    fn to_payload(&self) -> Vec<u8> {
         let mut out = Vec::new();
         out.extend_from_slice(&self.0.to_be_bytes());
         out
     }
 
-    fn from_payload(payload: &TagPayload) -> Result<Self, Error> {
+    fn from_payload(payload: &[u8]) -> Result<Self, Error> {
         if payload.len() != 8 {
             return Err(Error::SizeInvalid);
         };
         let mut bytes = [0u8; 8];
-        bytes.copy_from_slice(&payload);
+        bytes.copy_from_slice(payload);
         let v = u64::from_be_bytes(bytes);
         Ok(Block0Date(v))
     }
 
-    fn to_string(&self) -> String {
+    fn to_cfg_string(&self) -> String {
         format!("{}", self.0).to_string()
     }
-    fn from_string(s: &str) -> Result<Self, Error> {
+
+    fn from_cfg_str(s: &str) -> Result<Self, Error> {
         let v = u64::from_str(s).map_err(|_| Error::UnknownString(s.to_string()))?;
         Ok(Block0Date(v))
     }
@@ -61,18 +167,18 @@ impl ConfigParam for Block0Date {
 const VAL_PROD: u8 = 1;
 const VAL_TEST: u8 = 2;
 
-impl ConfigParam for Discrimination {
-    const TAG: Tag = Tag::unchecked_new(2);
+impl ConfigParamVariant for Discrimination {
+    const TAG: Tag = Tag::new(2);
     const NAME: &'static str = "discrimination";
 
-    fn to_payload(&self) -> TagPayload {
+    fn to_payload(&self) -> Vec<u8> {
         match self {
             Discrimination::Production => vec![VAL_PROD],
             Discrimination::Test => vec![VAL_TEST],
         }
     }
 
-    fn from_payload(payload: &TagPayload) -> Result<Self, Error> {
+    fn from_payload(payload: &[u8]) -> Result<Self, Error> {
         if payload.len() != 1 {
             return Err(Error::SizeInvalid);
         };
@@ -83,14 +189,14 @@ impl ConfigParam for Discrimination {
         }
     }
 
-    fn to_string(&self) -> String {
+    fn to_cfg_string(&self) -> String {
         match self {
             Discrimination::Production => "production".to_string(),
             Discrimination::Test => "test".to_string(),
         }
     }
 
-    fn from_string(s: &str) -> Result<Self, Error> {
+    fn from_cfg_str(s: &str) -> Result<Self, Error> {
         match s {
             "production" => Ok(Discrimination::Production),
             "test" => Ok(Discrimination::Test),
@@ -99,75 +205,102 @@ impl ConfigParam for Discrimination {
     }
 }
 
-impl ConfigParam for ConsensusVersion {
-    const TAG: Tag = Tag::unchecked_new(3);
+impl ConfigParamVariant for ConsensusVersion {
+    const TAG: Tag = Tag::new(3);
     const NAME: &'static str = "block0-consensus";
 
-    fn to_payload(&self) -> TagPayload {
+    fn to_payload(&self) -> Vec<u8> {
         (*self as u16).to_be_bytes().to_vec()
     }
 
-    fn from_payload(payload: &TagPayload) -> Result<Self, Error> {
+    fn from_payload(payload: &[u8]) -> Result<Self, Error> {
         let mut bytes = 0u16.to_ne_bytes();
         if payload.len() != bytes.len() {
             return Err(Error::SizeInvalid);
         };
-        bytes.copy_from_slice(&payload);
+        bytes.copy_from_slice(payload);
         let integer = u16::from_be_bytes(bytes);
         ConsensusVersion::from_u16(integer).ok_or(Error::StructureInvalid)
     }
 
-    fn to_string(&self) -> String {
+    fn to_cfg_string(&self) -> String {
         format!("{}", self)
     }
 
-    fn from_string(s: &str) -> Result<Self, Error> {
+    fn from_cfg_str(s: &str) -> Result<Self, Error> {
         s.parse().map_err(|_| Error::UnknownString(s.to_string()))
     }
 }
 
-pub fn entity_to<T: ConfigParam>(t: &T) -> (Tag, TagPayload) {
-    (T::TAG, t.to_payload())
-}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct Tag(u16);
 
-pub fn entity_from<T: ConfigParam>(tag: Tag, payload: &TagPayload) -> Result<T, Error> {
-    if tag != T::TAG {
-        return Err(Error::InvalidTag);
+impl Tag {
+    pub const fn new(tag: u16) -> Self {
+        // validate that it's less than 1024 when const fns support ifs
+        Tag(tag)
     }
-    T::from_payload(payload)
 }
 
-pub fn entity_to_string<T: ConfigParam>(t: &T) -> (&'static str, String) {
-    (T::NAME, t.to_string())
-}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct TagLen(u16);
 
-pub fn entity_from_string<T: ConfigParam>(tag: &str, value: &str) -> Result<T, Error> {
-    if tag != T::NAME {
-        return Err(Error::InvalidTag);
-    }
-    T::from_string(value)
-}
+const MAXIMUM_LEN: usize = 64;
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Error::InvalidTag => write!(f, "Invalid tag"),
-            Error::SizeInvalid => write!(f, "Invalid payload size"),
-            Error::StructureInvalid => write!(f, "Invalid payload structure"),
-            Error::UnknownString(s) => write!(f, "Invalid payload string: {}", s),
+impl TagLen {
+    pub fn new(tag: Tag, len: usize) -> Option<Self> {
+        if len < MAXIMUM_LEN {
+            Some(TagLen(tag.0 << 6 | len as u16))
+        } else {
+            None
         }
     }
+
+    pub fn get_tag(self) -> Tag {
+        Tag::new(self.0 >> 6)
+    }
+
+    pub fn get_len(self) -> usize {
+        (self.0 & 0b11_1111) as usize
+    }
 }
-impl std::error::Error for Error {}
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use quickcheck::{Arbitrary, Gen};
+    use quickcheck::{Arbitrary, Gen, TestResult};
+
+    quickcheck! {
+        fn tag_len_computation_correct(tag: Tag, len: usize) -> TestResult {
+            let len = len % MAXIMUM_LEN;
+            let tag_len = TagLen::new(tag, len).unwrap();
+
+            assert_eq!(tag, tag_len.get_tag(), "Invalid tag");
+            assert_eq!(len, tag_len.get_len(), "Invalid len");
+            TestResult::passed()
+        }
+    }
+
+    impl Arbitrary for Tag {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            Tag::new(u16::arbitrary(g) % 1024)
+        }
+    }
 
     impl Arbitrary for Block0Date {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
             Block0Date(Arbitrary::arbitrary(g))
+        }
+    }
+
+    impl Arbitrary for ConfigParam {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            match u8::arbitrary(g) % 3 {
+                0 => ConfigParam::Block0Date(Arbitrary::arbitrary(g)),
+                1 => ConfigParam::Discrimination(Arbitrary::arbitrary(g)),
+                2 => ConfigParam::ConsensusVersion(Arbitrary::arbitrary(g)),
+                _ => unreachable!(),
+            }
         }
     }
 }

--- a/chain-impl-mockchain/src/leadership/mod.rs
+++ b/chain-impl-mockchain/src/leadership/mod.rs
@@ -128,7 +128,6 @@ impl LeadershipConsensus {
 impl Leadership {
     pub fn new(epoch: Epoch, ledger: &Ledger) -> Self {
         let inner = match ledger.settings.consensus_version {
-            ConsensusVersion::None => LeadershipConsensus::None(none::NoLeadership),
             ConsensusVersion::Bft => {
                 LeadershipConsensus::Bft(bft::BftLeaderSelection::new(ledger).unwrap())
             }

--- a/chain-impl-mockchain/src/message/initial.rs
+++ b/chain-impl-mockchain/src/message/initial.rs
@@ -1,89 +1,34 @@
+use crate::config::ConfigParam;
 use chain_core::mempack::{ReadBuf, ReadError, Readable};
 use chain_core::property;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Tag(u16);
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct TagLen(u16);
-
-pub type TagPayload = Vec<u8>;
-
-const MAXIMUM_TAG: u16 = 1024;
-const MAXIMUM_LEN: usize = 64;
-
-impl Tag {
-    pub fn new(tag: u16) -> Option<Self> {
-        if tag < MAXIMUM_TAG {
-            Some(Tag(tag))
-        } else {
-            None
-        }
-    }
-
-    pub(crate) const fn unchecked_new(tag: u16) -> Self {
-        Tag(tag)
-    }
-}
-
-impl TagLen {
-    pub fn new(tag: Tag, len: usize) -> Option<Self> {
-        if len < MAXIMUM_LEN {
-            Some(TagLen(tag.0 << 6 | len as u16))
-        } else {
-            None
-        }
-    }
-
-    pub fn deconstruct(self) -> (Tag, usize) {
-        (self.get_tag(), self.get_len())
-    }
-
-    pub fn get_tag(self) -> Tag {
-        Tag(self.0 >> 6)
-    }
-
-    pub fn get_len(self) -> usize {
-        (self.0 & 0b11_1111) as usize
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct InitialEnts(Vec<(Tag, TagPayload)>);
+#[cfg_attr(
+    feature = "generic-serialization",
+    derive(serde_derive::Serialize, serde_derive::Deserialize),
+    serde(transparent)
+)]
+pub struct InitialEnts(Vec<ConfigParam>);
 
 impl InitialEnts {
     pub fn new() -> Self {
         InitialEnts(Vec::new())
     }
 
-    pub fn push(&mut self, t: (Tag, TagPayload)) {
-        self.0.push(t)
+    pub fn push(&mut self, config: ConfigParam) {
+        self.0.push(config)
     }
 
-    pub fn iter(&self) -> std::slice::Iter<(Tag, TagPayload)> {
+    pub fn iter(&self) -> std::slice::Iter<ConfigParam> {
         self.0.iter()
     }
 }
 
 impl property::Serialize for InitialEnts {
     type Error = std::io::Error;
-    fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
-        use chain_core::packer::Codec;
-        use std::io::Write;
-        let mut codec = Codec::from(writer);
-        for (tag, bytes) in self.iter() {
-            match TagLen::new(*tag, bytes.len()) {
-                None => {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        "initial ent payload too big".to_owned(),
-                    ));
-                }
-                Some(taglen) => {
-                    codec.put_u16(taglen.0)?;
-                    codec.write_all(&bytes)?;
-                }
-            };
+    fn serialize<W: std::io::Write>(&self, mut writer: W) -> Result<(), Self::Error> {
+        for config in &self.0 {
+            config.serialize(&mut writer)?
         }
         Ok(())
     }
@@ -91,74 +36,22 @@ impl property::Serialize for InitialEnts {
 
 impl Readable for InitialEnts {
     fn read<'a>(buf: &mut ReadBuf<'a>) -> Result<Self, ReadError> {
-        let mut ents = Vec::new();
-
-        while !(buf.is_end()) {
-            let taglen = TagLen(buf.get_u16()?);
-            let (tag, len) = taglen.deconstruct();
-            let mut bytes = Vec::with_capacity(len);
-            bytes.extend_from_slice(buf.get_slice(len)?);
-            ents.push((tag, bytes))
+        let mut configs = vec![];
+        while !buf.is_end() {
+            configs.push(ConfigParam::read(buf)?);
         }
-        Ok(InitialEnts(ents))
+        Ok(InitialEnts(configs))
     }
 }
-
-pub const TAG_DISCRIMINATION: Tag = Tag(1);
-pub const TAG_BLOCK0_DATE: Tag = Tag(2);
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::config::{entity_to, Block0Date};
     use quickcheck::{Arbitrary, Gen, TestResult};
 
     quickcheck! {
         fn initial_ents_serialization_bijection(b: InitialEnts) -> TestResult {
             property::testing::serialization_bijection_r(b)
-        }
-
-        fn tag_len_computation_correct(b: InitialEnt) -> TestResult {
-            let InitialEnt(tag, payload) = b;
-            let tag_len = if let Some(tg)= TagLen::new(tag, payload.len()) {
-                tg
-            } else {
-                return TestResult::error(format!("cannot construct valid TagLen"));
-            };
-
-            let (tag_, len_) = tag_len.deconstruct();
-
-            if tag_ != tag {
-                return TestResult::error(format!("Invalid decoded Tag, received: {:?}", tag_));
-            }
-            if len_ != payload.len() {
-                return TestResult::error(format!("Invalid decoded Len: received: {}", len_));
-            }
-            TestResult::passed()
-        }
-    }
-
-    fn arbitrary_discrimination<G: Gen>(g: &mut G) -> (Tag, TagPayload) {
-        match u8::arbitrary(g) % 2 {
-            0 => entity_to(&chain_addr::Discrimination::Production),
-            _ => entity_to(&chain_addr::Discrimination::Test),
-        }
-    }
-
-    fn arbitrary_tag_payload<G: Gen>(g: &mut G) -> (Tag, TagPayload) {
-        match u8::arbitrary(g) % 2 {
-            0 => arbitrary_discrimination(g),
-            _ => entity_to(&Block0Date::arbitrary(g)),
-        }
-    }
-
-    #[derive(PartialEq, Eq, Clone, Debug)]
-    struct InitialEnt(Tag, TagPayload);
-
-    impl Arbitrary for InitialEnt {
-        fn arbitrary<G: Gen>(g: &mut G) -> Self {
-            let (tag, payload) = arbitrary_tag_payload(g);
-            InitialEnt(tag, payload)
         }
     }
 
@@ -166,7 +59,7 @@ mod test {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
             let size = u8::arbitrary(g) as usize;
             InitialEnts(
-                std::iter::repeat_with(move || arbitrary_tag_payload(g))
+                std::iter::repeat_with(|| ConfigParam::arbitrary(g))
                     .take(size)
                     .collect(),
             )

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -257,7 +257,7 @@ mod test {
 
     use super::Multiverse;
     use crate::block::{Block, BlockBuilder, ConsensusVersion};
-    use crate::config;
+    use crate::config::ConfigParam;
     use crate::ledger::Ledger;
     use crate::message::{InitialEnts, Message};
     use chain_core::property::{Block as _, ChainLength as _, HasMessages as _};
@@ -284,7 +284,7 @@ mod test {
 
         let mut genesis_block = BlockBuilder::new();
         let mut ents = InitialEnts::new();
-        ents.push(config::entity_to(&ConsensusVersion::Bft));
+        ents.push(ConfigParam::ConsensusVersion(ConsensusVersion::Bft));
         genesis_block.message(Message::Initial(ents));
         let genesis_block = genesis_block.make_genesis_block();
         let genesis_state = Ledger::new(genesis_block.id(), genesis_block.messages()).unwrap();

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -256,7 +256,8 @@ impl Multiverse<Ledger> {
 mod test {
 
     use super::Multiverse;
-    use crate::block::{Block, BlockBuilder};
+    use crate::block::{Block, BlockBuilder, ConsensusVersion};
+    use crate::config;
     use crate::ledger::Ledger;
     use crate::message::{InitialEnts, Message};
     use chain_core::property::{Block as _, ChainLength as _, HasMessages as _};
@@ -282,7 +283,9 @@ mod test {
         let mut store = chain_storage::memory::MemoryBlockStore::new();
 
         let mut genesis_block = BlockBuilder::new();
-        genesis_block.message(Message::Initial(InitialEnts::new()));
+        let mut ents = InitialEnts::new();
+        ents.push(config::entity_to(&ConsensusVersion::Bft));
+        genesis_block.message(Message::Initial(ents));
         let genesis_block = genesis_block.make_genesis_block();
         let genesis_state = Ledger::new(genesis_block.id(), genesis_block.messages()).unwrap();
         assert_eq!(genesis_state.chain_length().0, 0);

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -179,7 +179,7 @@ impl Settings {
         Self {
             max_number_of_transactions_per_block: 100,
             bootstrap_key_slots_percentage: SLOTS_PERCENTAGE_RANGE,
-            consensus_version: ConsensusVersion::None,
+            consensus_version: ConsensusVersion::Bft,
             bft_leaders: Arc::new(Vec::new()),
             allow_account_creation: false,
             linear_fees: Arc::new(LinearFee::new(0, 0, 0)),

--- a/chain-impl-mockchain/src/transaction/mod.rs
+++ b/chain-impl-mockchain/src/transaction/mod.rs
@@ -25,8 +25,6 @@ impl<Extra: property::Serialize> property::Serialize for AuthenticatedTransactio
     type Error = Extra::Error;
 
     fn serialize<W: std::io::Write>(&self, mut writer: W) -> Result<(), Extra::Error> {
-        assert_eq!(self.transaction.inputs.len(), self.witnesses.len());
-
         // encode the transaction body
         self.transaction.serialize(&mut writer)?;
 


### PR DESCRIPTION
This lets us save initial consensus with which genesis was created.

Also fixed https://github.com/input-output-hk/jormungandr/issues/239

Also fixes https://github.com/input-output-hk/rust-cardano/issues/577