### PR TITLE
network-grpc: the TcpConnectFuture adapter

### DIFF
--- a/network-grpc/src/peer.rs
+++ b/network-grpc/src/peer.rs
@@ -1,7 +1,8 @@
-use futures::Poll;
+use futures::try_ready;
 use tokio::net::tcp::{self, TcpStream};
 #[cfg(unix)]
 use tokio::net::unix::{self, UnixStream};
+use tokio::prelude::*;
 use tower_grpc::codegen::server::tower::Service;
 
 use std::{io, net::SocketAddr};
@@ -48,14 +49,40 @@ impl UnixPeer {
 impl Service<()> for TcpPeer {
     type Response = TcpStream;
     type Error = io::Error;
-    type Future = tcp::ConnectFuture;
+    type Future = TcpConnectFuture;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         Ok(().into())
     }
 
     fn call(&mut self, _: ()) -> Self::Future {
-        TcpStream::connect(self.addr())
+        TcpStream::connect(self.addr()).into()
+    }
+}
+
+/// A future adapter that resolves to a `TcpStream` optimized for
+/// the HTTP/2 protocol.
+/// It attempts to set the socket option `TCP_NODELAY` to true before
+/// resolving with the connection. Failure to set the option is silently
+/// ignored, which may result in degraded latency.
+pub struct TcpConnectFuture {
+    inner: tcp::ConnectFuture,
+}
+
+impl From<tcp::ConnectFuture> for TcpConnectFuture {
+    #[inline]
+    fn from(src: tcp::ConnectFuture) -> Self {
+        TcpConnectFuture { inner: src }
+    }
+}
+
+impl Future for TcpConnectFuture {
+    type Item = TcpStream;
+    type Error = io::Error;
+    fn poll(&mut self) -> Result<Async<TcpStream>, io::Error> {
+        let stream = try_ready!(self.inner.poll());
+        stream.set_nodelay(true).unwrap_or(());
+        Ok(Async::Ready(stream))
     }
 }
 


### PR DESCRIPTION
This future wraps Tokio's `net::tcp::ConnectFuture`, and sets
socket option `TCP_NODELAY` on the socket before resolving.

The connection implementation for `TcpPeer` now returns this future.