### PR TITLE
Communicate node ID in metadata of subscription requests

### DIFF
--- a/network-core/src/gossip.rs
+++ b/network-core/src/gossip.rs
@@ -23,23 +23,17 @@ pub trait Node: Serialize + Deserialize {
 
 #[derive(Clone, Debug)]
 pub struct Gossip<T: Node> {
-    sender: T::Id,
     nodes: Vec<T>,
 }
 
 impl<T: Node> Gossip<T> {
-    pub fn from_nodes<I>(sender: T::Id, iter: I) -> Self
+    pub fn from_nodes<I>(iter: I) -> Self
     where
         I: IntoIterator<Item = T>,
     {
         Gossip {
-            sender,
-            nodes: Vec::from_iter(iter.into_iter()),
+            nodes: Vec::from_iter(iter),
         }
-    }
-
-    pub fn sender(&self) -> &T::Id {
-        &self.sender
     }
 
     pub fn nodes(&self) -> &[T] {

--- a/network-core/src/gossip.rs
+++ b/network-core/src/gossip.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 /// Marker trait for the type representing a node ID.
-pub trait NodeId: Serialize + Deserialize {}
+pub trait NodeId: Clone + Serialize + Deserialize {}
 
 /// Abstract trait for data types representing gossip about network nodes.
 pub trait Node: Serialize + Deserialize {

--- a/network-core/src/server.rs
+++ b/network-core/src/server.rs
@@ -4,6 +4,8 @@ pub mod block;
 pub mod content;
 pub mod gossip;
 
+use crate::gossip::NodeId;
+
 /// Interface to application logic of the blockchain node server.
 ///
 /// An implementation of a blockchain node implements this trait to
@@ -35,4 +37,14 @@ pub trait Node {
     /// Instantiates the gossip service,
     /// if supported by this node.
     fn gossip_service(&mut self) -> Option<&mut Self::GossipService>;
+}
+
+/// Base trait for the services that use node identifiers to
+/// distinguish subscription streams.
+pub trait P2pService {
+    /// Network node identifier.
+    type NodeId: NodeId;
+
+    /// Returns the identifier of this node.
+    fn node_id(&self) -> Self::NodeId;
 }

--- a/network-core/src/server.rs
+++ b/network-core/src/server.rs
@@ -9,6 +9,11 @@ pub mod gossip;
 /// An implementation of a blockchain node implements this trait to
 /// serve the network protocols using node's subsystems such as
 /// block storage and transaction engine.
+///
+/// A `Node` implementation is expected to be stateless, that is,
+/// there is no particular association between client peers and instances
+/// of the implementing type, and conversely, multiple instances can be
+/// created to serve different requests from a single client.
 pub trait Node {
     /// The implementation of the block service.
     type BlockService: block::BlockService;

--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -96,8 +96,8 @@ pub trait BlockService {
         to: &Self::BlockId,
     ) -> Self::PullBlocksFuture;
 
-    // Stream blocks from either of the given starting points
-    // to the server's tip.
+    /// Stream blocks from either of the given starting points
+    /// to the server's tip.
     fn pull_blocks_to_tip(&mut self, from: &[Self::BlockId]) -> Self::PullBlocksFuture;
 
     /// Get block headers, walking forward in a range between any of the given
@@ -108,8 +108,8 @@ pub trait BlockService {
         to: &Self::BlockId,
     ) -> Self::PullHeadersFuture;
 
-    // Stream block headers from either of the given starting points
-    // to the server's tip.
+    /// Stream block headers from either of the given starting points
+    /// to the server's tip.
     fn pull_headers_to_tip(&mut self, from: &[Self::BlockId]) -> Self::PullHeadersFuture;
 
     // Establishes a bidirectional subscription for announcing blocks,

--- a/network-grpc/proto/node.proto
+++ b/network-grpc/proto/node.proto
@@ -8,79 +8,77 @@ message TipRequest {}
 
 // Response message for method Tip.
 message TipResponse {
-    // Serialized content of the tip block header.
-    bytes block_header = 1;
+  // Serialized content of the tip block header.
+  bytes block_header = 1;
 }
 
 // Request to fetch the methods for blocks and headers.
 message BlockIds {
-    // The identifiers of blocks for loading.
-    repeated bytes id = 1;
+  // The identifiers of blocks for loading.
+  repeated bytes id = 1;
 }
 
 // Request to fetch the methods for blocks and headers.
 message MessageIds {
-    // The identifiers of blocks for loading.
-    repeated bytes id = 1;
+  // The identifiers of blocks for loading.
+  repeated bytes id = 1;
 }
 
 // Request message for method PullBlocksToTip.
 message PullBlocksToTipRequest {
-    // The identifiers of blocks to consider as the
-    // starting point, in order of appearance.
-    repeated bytes from = 1;
+  // The identifiers of blocks to consider as the
+  // starting point, in order of appearance.
+  repeated bytes from = 1;
 }
 
 // Representation of a block.
 message Block {
-    // The serialized content of the block.
-    bytes content = 1;
+  // The serialized content of the block.
+  bytes content = 1;
 }
 
 // Representation of a block header.
 message Header {
-    // The serialized content of the block header.
-    bytes content = 1;
+  // The serialized content of the block header.
+  bytes content = 1;
 }
 
 // Representation of a blockchain message, that is, a transaction or other
 // content item. A block in the blockchain consists of messages.
 message Message {
-    // The serialized content of the message.
-    bytes content = 1;
+  // The serialized content of the message.
+  bytes content = 1;
 }
 
 // Gossip message with information on nodes in the network.
 message Gossip {
-    // ID of the sender node (TODO: replace with gRPC metadata).
-    bytes sender = 1;
-    // Serialized descriptions of nodes.
-    repeated bytes nodes = 2;
+  // Serialized descriptions of nodes.
+  repeated bytes nodes = 2;
 }
 
 service Node {
-    rpc Tip (TipRequest) returns (TipResponse);
-    rpc GetBlocks (BlockIds) returns (stream Block) {
-        option idempotency_level = NO_SIDE_EFFECTS;
-    }
-    rpc GetHeaders (BlockIds) returns (stream Header) {
-        option idempotency_level = NO_SIDE_EFFECTS;
-    }
-    rpc GetMessages (MessageIds) returns (stream Message) {
-        option idempotency_level = NO_SIDE_EFFECTS;
-    }
+  rpc Tip(TipRequest) returns (TipResponse);
+  rpc GetBlocks(BlockIds) returns (stream Block) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc GetHeaders(BlockIds) returns (stream Header) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc GetMessages(MessageIds) returns (stream Message) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
 
-    rpc PullBlocksToTip (PullBlocksToTipRequest) returns (stream Block);
+  rpc PullBlocksToTip(PullBlocksToTipRequest) returns (stream Block);
 
-    // Establishes a bidirectional stream to exchange information on new
-    // blocks created or accepted by the peers.
-    rpc BlockSubscription (stream Header) returns (stream Header);
+  // Establishes a bidirectional stream to exchange information on new
+  // blocks created or accepted by the peers.
+  rpc BlockSubscription(stream Header) returns (stream Header);
 
-    // Establishes a bidirectional stream to exchange information on new
-    // messages created or accepted by the peers.
-    rpc MessageSubscription (stream Message) returns (stream Message);
+  // Establishes a bidirectional stream to exchange information on new
+  // messages created or accepted by the peers.
+  rpc MessageSubscription(stream Message) returns (stream Message);
 
-    // Establishes a bidirectional stream to exchange information on new
-    // network peers.
-    rpc GossipSubscription (stream Gossip) returns (stream Gossip);
+  // Establishes a bidirectional stream to exchange information on new
+  // network peers.
+  rpc GossipSubscription(stream Gossip) returns (stream Gossip);
 }

--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -442,7 +442,7 @@ impl From<ConnectError<io::Error>> for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Error::Connect(e) => write!(f, "connection error: {}", e),
+            Error::Connect(_) => write!(f, "failed to establish connection"),
         }
     }
 }

--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -13,10 +13,10 @@ use network_core::{
 use futures::future::Executor;
 use tokio::io;
 use tokio::prelude::*;
-use tower::MakeService;
+use tower::{MakeService, Service};
 use tower_add_origin::{self, AddOrigin};
-use tower_grpc::{codegen::server::tower::Service, BoxBody, Request, Streaming};
 use tower_h2::client::{Background, Connect, ConnectError, Connection};
+use tower_grpc::{BoxBody, Request, Streaming};
 
 use std::{error, fmt, marker::PhantomData};
 

--- a/network-grpc/src/client/connect.rs
+++ b/network-grpc/src/client/connect.rs
@@ -1,0 +1,216 @@
+use super::{Connection, ProtocolConfig};
+use crate::gen::node::client as gen_client;
+
+use network_core::gossip;
+
+use futures::future::Executor;
+use futures::prelude::*;
+use futures::try_ready;
+use http::uri::{self, Uri};
+use tower::{MakeConnection, MakeService, Service};
+use tower_grpc::BoxBody;
+use tower_h2::client::Background;
+
+use std::{error::Error, fmt, mem};
+
+/// Builder-like API for establishing a protocol client connection.
+pub struct Connect<P, A, C, E>
+where
+    P: ProtocolConfig,
+{
+    tower_connect: tower_h2::client::Connect<A, C, E, BoxBody>,
+    origin: Option<Origin>,
+    node_id: Option<<P::Node as gossip::Node>::Id>,
+}
+
+struct Origin {
+    scheme: uri::Scheme,
+    authority: uri::Authority,
+}
+
+impl<P, A, C, E> Connect<P, A, C, E>
+where
+    P: ProtocolConfig,
+    C: MakeConnection<A>,
+    E: Executor<Background<C::Connection, BoxBody>> + Clone,
+{
+    pub fn new(make_conn: C, executor: E) -> Self {
+        Connect {
+            tower_connect: tower_h2::client::Connect::new(make_conn, Default::default(), executor),
+            origin: None,
+            node_id: None,
+        }
+    }
+
+    pub fn origin(&mut self, scheme: uri::Scheme, authority: uri::Authority) -> &mut Self {
+        self.origin = Some(Origin { scheme, authority });
+        self
+    }
+
+    pub fn node_id(&mut self, id: <P::Node as gossip::Node>::Id) -> &mut Self {
+        self.node_id = Some(id);
+        self
+    }
+}
+
+impl<P, A, C, E> Service<A> for Connect<P, A, C, E>
+where
+    P: ProtocolConfig,
+    C: MakeConnection<A> + 'static,
+    E: Executor<Background<C::Connection, BoxBody>> + Clone,
+{
+    type Response = Connection<P, C::Connection, E>;
+    type Error = ConnectError<C::Error>;
+    type Future = ConnectFuture<P, A, C, E>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        MakeService::poll_ready(&mut self.tower_connect).map_err(|e| e.into())
+    }
+
+    fn call(&mut self, target: A) -> Self::Future {
+        let origin_uri = match self.origin {
+            Some(ref origin) => {
+                match Uri::builder()
+                    .scheme(origin.scheme.clone())
+                    .authority(origin.authority.clone())
+                    .build()
+                {
+                    Ok(uri) => uri,
+                    Err(e) => {
+                        return ConnectFuture::error(ConnectError(ErrorKind::InvalidOrigin(e)));
+                    }
+                }
+            }
+            None => {
+                return ConnectFuture::error(ConnectError(ErrorKind::OriginMissing));
+            }
+        };
+        let node_id = match self.node_id.as_ref() {
+            Some(id) => id.clone(),
+            None => {
+                return ConnectFuture::error(ConnectError(ErrorKind::NodeIdMissing));
+            }
+        };
+        let inner = self.tower_connect.make_service(target);
+        ConnectFuture {
+            state: State::Connecting {
+                inner,
+                origin_uri,
+                node_id,
+            },
+        }
+    }
+}
+
+/// Completes with a protocol client Connection when it has been
+/// set up.
+pub struct ConnectFuture<P, A, C, E>
+where
+    P: ProtocolConfig,
+    C: MakeConnection<A>,
+{
+    state: State<P, A, C, E>,
+}
+
+enum State<P, A, C, E>
+where
+    P: ProtocolConfig,
+    C: MakeConnection<A>,
+{
+    Connecting {
+        inner: tower_h2::client::ConnectFuture<A, C, E, BoxBody>,
+        origin_uri: Uri,
+        node_id: <P::Node as gossip::Node>::Id,
+    },
+    Error(ConnectError<C::Error>),
+    Finished,
+}
+
+impl<P, A, C, E> ConnectFuture<P, A, C, E>
+where
+    P: ProtocolConfig,
+    C: MakeConnection<A>,
+{
+    fn error(err: ConnectError<C::Error>) -> Self {
+        ConnectFuture {
+            state: State::Error(err),
+        }
+    }
+}
+
+impl<P, A, C, E> Future for ConnectFuture<P, A, C, E>
+where
+    P: ProtocolConfig,
+    C: MakeConnection<A>,
+    E: Executor<Background<C::Connection, BoxBody>> + Clone,
+{
+    type Item = Connection<P, C::Connection, E>;
+    type Error = ConnectError<C::Error>;
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        if let State::Connecting {
+            inner,
+            origin_uri,
+            node_id,
+        } = &mut self.state
+        {
+            let conn = try_ready!(inner.poll());
+            let conn = tower_add_origin::Builder::new()
+                .uri(origin_uri.clone())
+                .build(conn)
+                .unwrap();
+            let conn = Connection {
+                service: gen_client::Node::new(conn),
+                node_id: node_id.clone(),
+            };
+            self.state = State::Finished;
+            return Ok(Async::Ready(conn));
+        }
+        match mem::replace(&mut self.state, State::Finished) {
+            State::Connecting { .. } => unreachable!(),
+            State::Error(e) => Err(e),
+            State::Finished => panic!("polled a finished future"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ConnectError<T>(ErrorKind<T>);
+
+#[derive(Debug)]
+enum ErrorKind<T> {
+    Http(tower_h2::client::ConnectError<T>),
+    OriginMissing,
+    InvalidOrigin(http::Error),
+    NodeIdMissing,
+}
+
+impl<T> fmt::Display for ConnectError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.0 {
+            ErrorKind::Http(_) => write!(f, "HTTP/2.0 connection error"),
+            ErrorKind::OriginMissing => write!(f, "request origin not specified"),
+            ErrorKind::InvalidOrigin(_) => write!(f, "invalid request origin"),
+            ErrorKind::NodeIdMissing => write!(f, "node identifier not set"),
+        }
+    }
+}
+
+impl<T> Error for ConnectError<T>
+where
+    T: Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self.0 {
+            ErrorKind::Http(ref e) => Some(e),
+            ErrorKind::OriginMissing => None,
+            ErrorKind::InvalidOrigin(ref e) => Some(e),
+            ErrorKind::NodeIdMissing => None,
+        }
+    }
+}
+
+impl<T> From<tower_h2::client::ConnectError<T>> for ConnectError<T> {
+    fn from(err: tower_h2::client::ConnectError<T>) -> Self {
+        ConnectError(ErrorKind::Http(err))
+    }
+}

--- a/network-grpc/src/convert.rs
+++ b/network-grpc/src/convert.rs
@@ -111,9 +111,8 @@ where
     T: Node,
 {
     fn from_message(msg: gen::node::Gossip) -> Result<Gossip<T>, core_error::Error> {
-        let sender = deserialize_bytes(&msg.sender)?;
         let nodes = deserialize_vec(&msg.nodes)?;
-        let gossip = Gossip::from_nodes(sender, nodes);
+        let gossip = Gossip::from_nodes(nodes);
         Ok(gossip)
     }
 }
@@ -188,9 +187,7 @@ where
     T: Node,
 {
     fn into_message(self) -> Result<gen::node::Gossip, tower_grpc::Status> {
-        let sender = serialize_to_bytes(self.sender())?;
         let nodes = serialize_to_vec(self.nodes())?;
-        let gossip = gen::node::Gossip { sender, nodes };
-        Ok(gossip)
+        Ok(gen::node::Gossip { nodes })
     }
 }

--- a/network-grpc/src/convert.rs
+++ b/network-grpc/src/convert.rs
@@ -117,7 +117,7 @@ where
     }
 }
 
-pub fn serialize_to_bytes<T>(obj: &T) -> Result<Vec<u8>, tower_grpc::Status>
+pub fn serialize_to_bytes<T>(obj: &T) -> Result<Vec<u8>, Status>
 where
     T: property::Serialize,
 {
@@ -125,11 +125,8 @@ where
     match obj.serialize(&mut bytes) {
         Ok(()) => Ok(bytes),
         Err(_e) => {
-            // FIXME: log the error
-            let status = tower_grpc::Status::new(
-                tower_grpc::Code::InvalidArgument,
-                "response serialization failed",
-            );
+            // TODO: log the error
+            let status = Status::new(Code::Internal, "response serialization failed");
             Err(status)
         }
     }

--- a/network-grpc/src/server.rs
+++ b/network-grpc/src/server.rs
@@ -28,7 +28,6 @@ where
     <T::BlockService as BlockService>::Header: Send + 'static,
     <T::ContentService as ContentService>::Message: Send + 'static,
     <T::GossipService as GossipService>::Node: Send + 'static,
-    <T::GossipService as GossipService>::NodeId: Send + 'static,
 {
     h2: tower_h2::Server<
         gen_server::NodeServer<NodeService<T>>,
@@ -45,7 +44,6 @@ where
     <T::BlockService as BlockService>::Header: Send + 'static,
     <T::ContentService as ContentService>::Message: Send + 'static,
     <T::GossipService as GossipService>::Node: Send + 'static,
-    <T::GossipService as GossipService>::NodeId: Send + 'static,
 {
     h2: tower_h2::server::Connection<
         S,
@@ -63,7 +61,6 @@ where
     <T::BlockService as BlockService>::Header: Send + 'static,
     <T::ContentService as ContentService>::Message: Send + 'static,
     <T::GossipService as GossipService>::Node: Send + 'static,
-    <T::GossipService as GossipService>::NodeId: Send + 'static,
     E: Executor<
         tower_h2::server::Background<
             gen_server::node::ResponseFuture<NodeService<T>>,
@@ -84,7 +81,6 @@ where
     <T::BlockService as BlockService>::Header: Send + 'static,
     <T::ContentService as ContentService>::Message: Send + 'static,
     <T::GossipService as GossipService>::Node: Send + 'static,
-    <T::GossipService as GossipService>::NodeId: Send + 'static,
     E: Executor<
             tower_h2::server::Background<
                 gen_server::node::ResponseFuture<NodeService<T>>,
@@ -159,7 +155,6 @@ where
     <T::BlockService as BlockService>::Header: Send + 'static,
     <T::ContentService as ContentService>::Message: Send + 'static,
     <T::GossipService as GossipService>::Node: Send + 'static,
-    <T::GossipService as GossipService>::NodeId: Send + 'static,
 {
     fn from(err: H2Error<T>) -> Self {
         use tower_h2::server::Error::*;


### PR DESCRIPTION
As the gRPC protocol is stateless, and transport connection information cannot reliably be used to establish the peer identity, we need to exchange node IDs along with subscription requests. Request metadata is the place to do it.

The sender ID field from `Gossip` therefore becomes redundant and is removed.