### PR TITLE
add serde generic serialization as an optional feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,49 +8,156 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - cargo-v2-{{ checksum "Cargo.toml" }}-
-            - cargo-v2-
-      - run: cargo update
+            - cargo-v3-{{ checksum "Cargo.toml" }}
+            - cargo-v3-
+      - run: git submodule sync
+      - run: git submodule update --init
       - run: cargo fetch
       - persist_to_workspace:
-          root: "."
+          root: /mnt/crate
           paths:
             - Cargo.lock
       - save_cache:
-          key: cargo-v2-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
+          key: cargo-v3-{{ checksum "Cargo.toml" }}
           paths:
             - /usr/local/cargo/registry
             - /usr/local/cargo/git
-  test:
+
+  rustfmt:
+    docker:
+      - image: rust:latest
+    working_directory: /mnt/crate
+    steps:
+      - checkout
+      - run:
+          name: Install rustfmt
+          command: rustup component add rustfmt
+      - run:
+          name: Print version information
+          command: cargo fmt -- --version
+      - run:
+          name: Check rustfmt
+          command: cargo fmt -- --check
+
+  build_debug:
     docker:
       - image: rust:latest
     working_directory: /mnt/crate
     steps:
       - checkout
       - attach_workspace:
-          at: "."
+          at: /mnt/crate
+      - run: git submodule sync
+      - run: git submodule update --init
       - restore_cache:
           keys:
-            - cargo-v2-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
+            - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
+            - cargo-v3-{{ checksum "Cargo.toml" }}
+            - cargo-v3-
       - run:
           name: Print version information
           command: rustc --version; cargo --version
       - run:
-          name: Build and test
-          command: cargo test --frozen --verbose
-          environment:
-            # Need this for the coverage run
-            RUSTFLAGS: "-C link-dead-code"
+          name: Build
+          command: cargo build
+  test_debug:
+    docker:
+      - image: rust:latest
+    working_directory: /mnt/crate
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /mnt/crate
+      - run: git submodule sync
+      - run: git submodule update --init
+      - restore_cache:
+          keys:
+            - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
+            - cargo-v3-{{ checksum "Cargo.toml" }}
+            - cargo-v3-
       - run:
-          name: Prune the output files
-          command: |
-            for file in target/debug/* target/debug/.??*; do
-              [ -d $file -o ! -x $file ] && rm -r $file
-            done
-      - persist_to_workspace:
-          root: "."
-          paths:
-            - target/debug/*
+          name: Print version information
+          command: rustc --version; cargo --version
+      - run:
+          name: Test
+          command: cargo test --verbose
+  build_debug_serde:
+    docker:
+      - image: rust:latest
+    working_directory: /mnt/crate
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /mnt/crate
+      - run: git submodule sync
+      - run: git submodule update --init
+      - restore_cache:
+          keys:
+            - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
+            - cargo-v3-{{ checksum "Cargo.toml" }}
+            - cargo-v3-
+      - run:
+          name: Print version information
+          command: rustc --version; cargo --version
+      - run:
+          name: Build chain-crypto with serde
+          command: cd chain-crypto && cargo build --features=generic-serialization
+      - run:
+          name: Build chain-addr with serde
+          command: cd chain-addr && cargo build --features=generic-serialization
+      - run:
+          name: Build chain-impl-mockchain with serde
+          command: cd chain-impl-mockchain && cargo build --features=generic-serialization
+  test_debug_serde:
+    docker:
+      - image: rust:latest
+    working_directory: /mnt/crate
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /mnt/crate
+      - run: git submodule sync
+      - run: git submodule update --init
+      - restore_cache:
+          keys:
+            - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
+            - cargo-v3-{{ checksum "Cargo.toml" }}
+            - cargo-v3-
+      - run:
+          name: Print version information
+          command: rustc --version; cargo --version
+      - run:
+          name: Test chain-crypto with serde
+          command: cd chain-crypto && cargo test --features=generic-serialization
+      - run:
+          name: Test chain-addr with serde
+          command: cd chain-addr && cargo test --features=generic-serialization
+      - run:
+          name: Test chain-impl-mockchain with serde
+          command: cd chain-impl-mockchain && cargo test --features=generic-serialization
+
+  build_release:
+    docker:
+      - image: rust:latest
+    working_directory: /mnt/crate
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /mnt/crate
+      - run: git submodule sync
+      - run: git submodule update --init
+      - restore_cache:
+          keys:
+            - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
+            - cargo-v3-{{ checksum "Cargo.toml" }}
+            - cargo-v3-
+      - run:
+          name: Print version information
+          command: rustc --version; cargo --version
+      - run:
+          name: Build in release profile
+          command: cargo build --release
+
   test_release:
     docker:
       - image: rust:latest
@@ -58,16 +165,21 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: "."
+          at: /mnt/crate
+      - run: git submodule sync
+      - run: git submodule update --init
       - restore_cache:
           keys:
-            - cargo-v2-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
+            - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
+            - cargo-v3-{{ checksum "Cargo.toml" }}
+            - cargo-v3-
       - run:
           name: Print version information
           command: rustc --version; cargo --version
       - run:
-          name: Build and test in release profile
-          command: cargo test --release --frozen --verbose
+          name: Test
+          command: cargo test --release --verbose
+
   test_nightly:
     docker:
       - image: rustlang/rust:nightly
@@ -75,79 +187,47 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: "."
+          at: /mnt/crate
       - restore_cache:
           keys:
-            - cargo-v2-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
+            - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
+            - cargo-v3-{{ checksum "Cargo.toml" }}
+            - cargo-v3-
       - run:
           name: Print version information
           command: rustc --version; cargo --version
       - run:
           name: Build and test with nightly Rust
-          command: cargo test --frozen --verbose
-  coverage:
-    docker:
-      - image: ragnaroek/kcov:v33
-        entrypoint: /bin/bash
-    working_directory: /mnt/crate
-    steps:
-      - checkout
-      - attach_workspace:
-          at: "."
-      - run: mkdir target/coverage
-      - run:
-          name: Rerun the tests collecting coverage
-          command: |
-            for file in ./target/debug/*; do
-              if test -x $file; then
-                kcov --verify --exclude-pattern=tests \
-                  --exclude-path=src/testmocks.rs \
-                  target/coverage/$(basename $file) \
-                  $file --quiet
-              fi
-            done
-            kcov --merge target/coverage-merged target/coverage/*
-      - store_artifacts:
-          path: target/coverage
-          destination: coverage
-      - store_artifacts:
-          path: target/coverage-merged
-          destination: coverage-merged
-      - persist_to_workspace:
-          root: "."
-          paths:
-            - target/coverage
-  codecov_upload:
-    docker:
-      - image: buildpack-deps:curl
-    working_directory: /mnt/crate
-    steps:
-      # Codecov uploader needs the source and binaries
-      # exactly as everything was during the test run.
-      - checkout
-      - attach_workspace:
-          at: "."
-      - run:
-          name: Upload to Codecov
-          command: bash <(curl -s https://codecov.io/bash)
+          command: cargo test --verbose
+
 
 workflows:
   version: 2
-  test_all_and_coverage:
+  test_all:
     jobs:
       - cargo_fetch
-      - test:
+      - rustfmt
+      - build_debug:
           requires:
+            - rustfmt
             - cargo_fetch
+      - build_release:
+          requires:
+            - rustfmt
+            - cargo_fetch
+      - build_debug_serde:
+          requires:
+            - build_debug
+      - test_debug:
+          requires:
+            - build_debug
       - test_release:
           requires:
-            - cargo_fetch
+            - build_release
       - test_nightly:
           requires:
+            - rustfmt
             - cargo_fetch
-      - coverage:
+      - test_debug_serde:
           requires:
-            - test
-      - codecov_upload:
-          requires:
-            - coverage
+            - build_debug_serde

--- a/chain-addr/Cargo.toml
+++ b/chain-addr/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 keywords = [ "Cardano", "Wallet", "Crypto", "Address" ]
 
 [features]
-generic-serialization = [ "serde", "serde_derive" ]
+generic-serialization = [ "serde" ]
 property-test-api = ["quickcheck"]
 
 [dependencies]
@@ -15,9 +15,12 @@ bech32 = "0.6"
 chain-core = { path = "../chain-core" }
 chain-crypto = { path = "../chain-crypto" }
 cryptoxide = "0.1"
+cfg-if = "0.1"
 quickcheck = { version = "0.8", optional = true }
 serde = { version = "^1.0", optional = true }
-serde_derive = { version = "^1.0", optional = true }
 
 [dev-dependencies]
 quickcheck = "0.8"
+serde_json = "1.0"
+bincode = "1.1"
+chain-crypto = { path = "../chain-crypto", features = [ "property-test-api" ] }

--- a/chain-addr/src/serde.rs
+++ b/chain-addr/src/serde.rs
@@ -1,0 +1,124 @@
+use crate::{Address, AddressReadable};
+use serde::{
+    de::{Deserialize, Deserializer, Error, Visitor},
+    ser::{Serialize, Serializer},
+};
+use std::fmt;
+
+impl Serialize for Address {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if serializer.is_human_readable() {
+            AddressReadable::from_address(self).serialize(serializer)
+        } else {
+            serializer.serialize_bytes(&self.to_bytes())
+        }
+    }
+}
+
+impl Serialize for AddressReadable {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Address {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            deserializer
+                .deserialize_str(AddressReadableVisitor)
+                .map(|address_readable| address_readable.to_address())
+        } else {
+            deserializer.deserialize_bytes(AddressVisitor)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for AddressReadable {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(AddressReadableVisitor)
+    }
+}
+
+struct AddressVisitor;
+struct AddressReadableVisitor;
+
+impl<'de> Visitor<'de> for AddressVisitor {
+    type Value = Address;
+
+    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "Expecting an Address",)
+    }
+
+    fn visit_bytes<'a, E>(self, v: &'a [u8]) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        use chain_core::mempack::{ReadBuf, Readable};
+        let mut buf = ReadBuf::from(v);
+        match Self::Value::read(&mut buf) {
+            Err(err) => Err(E::custom(err)),
+            Ok(address) => Ok(address),
+        }
+    }
+}
+
+impl<'de> Visitor<'de> for AddressReadableVisitor {
+    type Value = AddressReadable;
+
+    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "Expecting an Address",)
+    }
+
+    fn visit_str<'a, E>(self, v: &'a str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        use std::str::FromStr;
+        match Self::Value::from_str(v) {
+            Err(err) => Err(E::custom(err)),
+            Ok(address) => Ok(address),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{Address, AddressReadable};
+
+    use bincode;
+    use serde_json;
+
+    quickcheck! {
+        fn address_encode_decode_bincode(address: Address) -> bool {
+            let encoded = bincode::serialize(&address).unwrap();
+            let decoded : Address = bincode::deserialize(&encoded).unwrap();
+
+            decoded == address
+        }
+        fn address_encode_decode_json(address: Address) -> bool {
+            let encoded = serde_json::to_string(&address).unwrap();
+            let decoded : Address= serde_json::from_str(&encoded).unwrap();
+
+            decoded == address
+        }
+
+        fn address_readable_encode_decode_bincode(address: AddressReadable) -> bool {
+            let encoded = bincode::serialize(&address).unwrap();
+            let decoded: AddressReadable = bincode::deserialize(&encoded).unwrap();
+
+            decoded == address
+        }
+        fn address_readable_encode_decode_json(address: AddressReadable) -> bool {
+            let encoded = serde_json::to_string(&address).unwrap();
+            let decoded:AddressReadable = serde_json::from_str(&encoded).unwrap();
+
+            decoded == address
+        }
+    }
+}

--- a/chain-addr/src/testing.rs
+++ b/chain-addr/src/testing.rs
@@ -1,0 +1,43 @@
+use crate::{KindType, Kind, Address, Discrimination, AddressReadable};
+use quickcheck::{Arbitrary, Gen};
+
+impl Arbitrary for Discrimination {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        match u8::arbitrary(g) % 2 {
+            0 => Discrimination::Production,
+            1 => Discrimination::Test,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Arbitrary for KindType {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        match u8::arbitrary(g) % 3 {
+            0 => KindType::Single,
+            1 => KindType::Group,
+            2 => KindType::Account,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Arbitrary for AddressReadable {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        AddressReadable::from_address(&Arbitrary::arbitrary(g))
+    }
+}
+impl Arbitrary for Address {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        let discrimination = Arbitrary::arbitrary(g);
+        let kind = match KindType::arbitrary(g) {
+            KindType::Single => Kind::Single(Arbitrary::arbitrary(g)),
+            KindType::Group => Kind::Group(
+                Arbitrary::arbitrary(g),
+                Arbitrary::arbitrary(g),
+            ),
+            KindType::Account => Kind::Account(Arbitrary::arbitrary(g))
+        };
+        Address(discrimination, kind)
+    }
+}

--- a/chain-crypto/Cargo.toml
+++ b/chain-crypto/Cargo.toml
@@ -15,10 +15,18 @@ digest = "^0.8"
 generic-array = "^0.12"
 rand = "0.6"
 ed25519-bip32 = { path = "../ed25519-bip32" }
+serde = { version = "1.0", optional = true }
+quickcheck = {version = "0.8", optional = true }
+rand_chacha = {version = "0.1", optional = true }
+cfg-if = "0.1"
 
 [dev-dependencies]
 quickcheck = "0.8"
 rand_chacha = "0.1"
+serde_json = "1.0"
+bincode = "1.1"
 
 [features]
 with-bench = []
+generic-serialization = [ "serde" ]
+property-test-api = [ "quickcheck", "rand_chacha" ]

--- a/chain-crypto/src/algorithms/ed25519.rs
+++ b/chain-crypto/src/algorithms/ed25519.rs
@@ -86,9 +86,10 @@ impl VerificationAlgorithm for Ed25519 {
     type Signature = Sig;
 
     const SIGNATURE_SIZE: usize = ed25519::SIGNATURE_LENGTH;
+    const SIGNATURE_BECH32_HRP: &'static str = "ed25519_signature";
 
     fn signature_from_bytes(data: &[u8]) -> Result<Self::Signature, SignatureError> {
-        if data.len() == ed25519::SIGNATURE_LENGTH {
+        if data.len() != ed25519::SIGNATURE_LENGTH {
             return Err(SignatureError::SizeInvalid);
         }
         let mut buf = [0; ed25519::SIGNATURE_LENGTH];

--- a/chain-crypto/src/algorithms/ed25519_derive.rs
+++ b/chain-crypto/src/algorithms/ed25519_derive.rs
@@ -70,6 +70,7 @@ impl VerificationAlgorithm for Ed25519Bip32 {
     type Signature = XSig;
 
     const SIGNATURE_SIZE: usize = ed25519_bip32::SIGNATURE_SIZE;
+    const SIGNATURE_BECH32_HRP: &'static str = "ed25519bip32_signature";
 
     fn signature_from_bytes(data: &[u8]) -> Result<Self::Signature, SignatureError> {
         let xsig = XSig::from_slice(data)?;

--- a/chain-crypto/src/algorithms/ed25519_extended.rs
+++ b/chain-crypto/src/algorithms/ed25519_extended.rs
@@ -76,6 +76,7 @@ impl VerificationAlgorithm for Ed25519Extended {
     type Signature = ei::Sig;
 
     const SIGNATURE_SIZE: usize = ed25519::SIGNATURE_LENGTH;
+    const SIGNATURE_BECH32_HRP: &'static str = "ed25519extended_signature";
 
     fn signature_from_bytes(data: &[u8]) -> Result<Self::Signature, SignatureError> {
         if data.len() != ed25519::SIGNATURE_LENGTH {

--- a/chain-crypto/src/algorithms/fakemmm.rs
+++ b/chain-crypto/src/algorithms/fakemmm.rs
@@ -77,6 +77,7 @@ impl VerificationAlgorithm for FakeMMM {
     type Signature = Sig;
 
     const SIGNATURE_SIZE: usize = ed25519::SIGNATURE_LENGTH;
+    const SIGNATURE_BECH32_HRP: &'static str = "fakemmm_signature";
 
     fn signature_from_bytes(data: &[u8]) -> Result<Self::Signature, SignatureError> {
         if data.len() != ed25519::SIGNATURE_LENGTH {

--- a/chain-crypto/src/hash.rs
+++ b/chain-crypto/src/hash.rs
@@ -8,6 +8,8 @@ use std::{error, fmt, result};
 use cryptoxide::blake2b::Blake2b;
 use cryptoxide::digest::Digest;
 use cryptoxide::sha3::Sha3;
+#[cfg(feature = "generic-serialization")]
+use serde;
 
 use crate::bech32::{self, Bech32};
 use crate::hex;
@@ -128,6 +130,71 @@ macro_rules! define_hash_object {
 
             fn to_bech32_str(&self) -> String {
                 bech32::to_bech32_from_bytes::<Self>(self.as_ref())
+            }
+        }
+
+        #[cfg(feature = "generic-serialization")]
+        impl serde::Serialize for $hash_ty {
+            #[inline]
+            fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                if serializer.is_human_readable() {
+                    serializer.serialize_str(&hex::encode(self.as_ref()))
+                } else {
+                    serializer.serialize_bytes(&self.as_ref())
+                }
+            }
+        }
+        #[cfg(feature = "generic-serialization")]
+        impl<'de> serde::Deserialize<'de> for $hash_ty {
+            fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct HashVisitor;
+                impl<'de> serde::de::Visitor<'de> for HashVisitor {
+                    type Value = $hash_ty;
+
+                    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+                        write!(fmt, "Expecting a Blake2b_256 hash (`Hash`)")
+                    }
+
+                    fn visit_str<'a, E>(self, v: &'a str) -> result::Result<Self::Value, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match Self::Value::from_str(&v) {
+                            Err(Error::InvalidHexEncoding(err)) => {
+                                Err(E::custom(format!("{}", err)))
+                            }
+                            Err(Error::InvalidHashSize(sz, _)) => {
+                                Err(E::invalid_length(sz, &"32 bytes"))
+                            }
+                            Ok(h) => Ok(h),
+                        }
+                    }
+
+                    fn visit_bytes<'a, E>(self, v: &'a [u8]) -> result::Result<Self::Value, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match Self::Value::try_from_slice(v) {
+                            Err(Error::InvalidHashSize(sz, _)) => {
+                                Err(E::invalid_length(sz, &"32 bytes"))
+                            }
+                            Err(err) => panic!("unexpected error: {}", err),
+                            Ok(h) => Ok(h),
+                        }
+                    }
+                }
+
+                if deserializer.is_human_readable() {
+                    deserializer.deserialize_str(HashVisitor)
+                } else {
+                    deserializer.deserialize_bytes(HashVisitor)
+                }
             }
         }
     };

--- a/chain-crypto/src/lib.rs
+++ b/chain-crypto/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(feature = "with-bench", feature(test))]
 
+#[macro_use]
+extern crate cfg_if;
+
 #[cfg(test)]
 #[cfg(feature = "with-bench")]
 extern crate test;
@@ -7,6 +10,17 @@ extern crate test;
 #[cfg(test)]
 #[macro_use]
 extern crate quickcheck;
+
+#[cfg(feature = "generic-serialization")]
+mod serde;
+
+cfg_if! {
+    if #[cfg(test)] {
+        mod testing;
+    } else if #[cfg(feature = "property-test-api")] {
+        mod testing;
+    }
+}
 
 pub mod algorithms;
 pub mod bech32;
@@ -26,4 +40,4 @@ pub use vrf::{
 };
 
 pub use algorithms::*;
-pub use hash::Blake2b256;
+pub use hash::{Blake2b224, Blake2b256, Sha3_256};

--- a/chain-crypto/src/serde.rs
+++ b/chain-crypto/src/serde.rs
@@ -1,0 +1,499 @@
+//! module to add serde serializer and deserializer to the
+//! different types defined here
+//!
+
+use crate::{
+    bech32::{Bech32 as _, Error as Bech32Error},
+    AsymmetricKey, PublicKey, PublicKeyError, SecretKey, SecretKeyError, Signature, SignatureError,
+    VerificationAlgorithm,
+};
+use serde::{
+    de::{Deserialize, Deserializer, Error, Visitor},
+    ser::{Serialize, Serializer},
+};
+use std::fmt;
+
+impl<A: AsymmetricKey> Serialize for SecretKey<A> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&self.to_bech32_str())
+        } else {
+            serializer.serialize_bytes(self.0.as_ref())
+        }
+    }
+}
+impl<A: AsymmetricKey> Serialize for PublicKey<A> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&self.to_bech32_str())
+        } else {
+            serializer.serialize_bytes(self.as_ref())
+        }
+    }
+}
+
+impl<T, A: VerificationAlgorithm> Serialize for Signature<T, A> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&self.to_bech32_str())
+        } else {
+            serializer.serialize_bytes(self.as_ref())
+        }
+    }
+}
+
+impl<'de, A> Deserialize<'de> for SecretKey<A>
+where
+    A: AsymmetricKey,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let secret_key_visitor = SecretKeyVisitor::new();
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_str(secret_key_visitor)
+        } else {
+            deserializer.deserialize_bytes(secret_key_visitor)
+        }
+    }
+}
+
+impl<'de, A> Deserialize<'de> for PublicKey<A>
+where
+    A: AsymmetricKey,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let public_key_visitor = PublicKeyVisitor::new();
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_str(public_key_visitor)
+        } else {
+            deserializer.deserialize_bytes(public_key_visitor)
+        }
+    }
+}
+
+impl<'de, T, A> Deserialize<'de> for Signature<T, A>
+where
+    A: VerificationAlgorithm,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let signature_visitor = SignatureVisitor::new();
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_str(signature_visitor)
+        } else {
+            deserializer.deserialize_bytes(signature_visitor)
+        }
+    }
+}
+
+struct SecretKeyVisitor<A: AsymmetricKey> {
+    _marker: std::marker::PhantomData<A>,
+}
+struct PublicKeyVisitor<A: AsymmetricKey> {
+    _marker: std::marker::PhantomData<A>,
+}
+struct SignatureVisitor<T, A: VerificationAlgorithm> {
+    _marker_1: std::marker::PhantomData<T>,
+    _marker_2: std::marker::PhantomData<A>,
+}
+impl<A: AsymmetricKey> SecretKeyVisitor<A> {
+    #[inline]
+    fn new() -> Self {
+        SecretKeyVisitor {
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+impl<A: AsymmetricKey> PublicKeyVisitor<A> {
+    #[inline]
+    fn new() -> Self {
+        PublicKeyVisitor {
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+impl<T, A: VerificationAlgorithm> SignatureVisitor<T, A> {
+    #[inline]
+    fn new() -> Self {
+        SignatureVisitor {
+            _marker_1: std::marker::PhantomData,
+            _marker_2: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<'de, A> Visitor<'de> for SecretKeyVisitor<A>
+where
+    A: AsymmetricKey,
+{
+    type Value = SecretKey<A>;
+
+    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            fmt,
+            "Expecting a secret key for algorithm {}",
+            A::SECRET_BECH32_HRP
+        )
+    }
+
+    fn visit_str<'a, E>(self, v: &'a str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        match Self::Value::try_from_bech32_str(&v) {
+            Err(Bech32Error::DataInvalid(err)) => Err(E::custom(format!("Invalid data: {}", err))),
+            Err(Bech32Error::HrpInvalid { expected, actual }) => Err(E::custom(format!(
+                "Invalid prefix: expected {} but was {}",
+                expected, actual
+            ))),
+            Err(Bech32Error::Bech32Malformed(err)) => {
+                Err(E::custom(format!("Invalid bech32: {}", err)))
+            }
+            Ok(key) => Ok(key),
+        }
+    }
+
+    fn visit_bytes<'a, E>(self, v: &'a [u8]) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        match Self::Value::from_binary(v) {
+            Err(SecretKeyError::SizeInvalid) => Err(E::custom(format!(
+                "Invalid size (expected: {}bytes)",
+                A::SECRET_KEY_SIZE
+            ))),
+            Err(SecretKeyError::StructureInvalid) => Err(E::custom("Invalid structure")),
+            Ok(key) => Ok(key),
+        }
+    }
+}
+
+impl<'de, A> Visitor<'de> for PublicKeyVisitor<A>
+where
+    A: AsymmetricKey,
+{
+    type Value = PublicKey<A>;
+
+    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            fmt,
+            "Expecting a public key for algorithm {}",
+            A::PUBLIC_BECH32_HRP
+        )
+    }
+
+    fn visit_str<'a, E>(self, v: &'a str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        match Self::Value::try_from_bech32_str(&v) {
+            Err(Bech32Error::DataInvalid(err)) => Err(E::custom(format!("Invalid data: {}", err))),
+            Err(Bech32Error::HrpInvalid { expected, actual }) => Err(E::custom(format!(
+                "Invalid prefix: expected {} but was {}",
+                expected, actual
+            ))),
+            Err(Bech32Error::Bech32Malformed(err)) => {
+                Err(E::custom(format!("Invalid bech32: {}", err)))
+            }
+            Ok(key) => Ok(key),
+        }
+    }
+
+    fn visit_bytes<'a, E>(self, v: &'a [u8]) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        match Self::Value::from_binary(v) {
+            Err(PublicKeyError::SizeInvalid) => Err(E::custom(format!(
+                "Invalid size (expected: {}bytes)",
+                A::PUBLIC_KEY_SIZE
+            ))),
+            Err(PublicKeyError::StructureInvalid) => Err(E::custom("Invalid structure")),
+            Ok(key) => Ok(key),
+        }
+    }
+}
+
+impl<'de, T, A> Visitor<'de> for SignatureVisitor<T, A>
+where
+    A: VerificationAlgorithm,
+{
+    type Value = Signature<T, A>;
+
+    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            fmt,
+            "Expecting a signature for algorithm {}",
+            A::SIGNATURE_BECH32_HRP
+        )
+    }
+
+    fn visit_str<'a, E>(self, v: &'a str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        match Self::Value::try_from_bech32_str(&v) {
+            Err(Bech32Error::DataInvalid(err)) => Err(E::custom(format!("Invalid data: {}", err))),
+            Err(Bech32Error::HrpInvalid { expected, actual }) => Err(E::custom(format!(
+                "Invalid prefix: expected {} but was {}",
+                expected, actual
+            ))),
+            Err(Bech32Error::Bech32Malformed(err)) => {
+                Err(E::custom(format!("Invalid bech32: {}", err)))
+            }
+            Ok(key) => Ok(key),
+        }
+    }
+
+    fn visit_bytes<'a, E>(self, v: &'a [u8]) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        match Self::Value::from_binary(v) {
+            Err(SignatureError::SizeInvalid) => Err(E::custom(format!(
+                "Invalid size (expected: {}bytes)",
+                A::PUBLIC_KEY_SIZE
+            ))),
+            Err(SignatureError::StructureInvalid) => Err(E::custom("Invalid structure")),
+            Ok(key) => Ok(key),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        algorithms::{Curve25519_2HashDH, Ed25519, Ed25519Bip32, Ed25519Extended, FakeMMM},
+        hash::{Blake2b224, Blake2b256},
+    };
+
+    use bincode;
+    use serde_json;
+
+    quickcheck! {
+        fn ed25519_secret_key_encode_decode_bincode(secret: SecretKey<Ed25519>) -> bool {
+            let encoded = bincode::serialize(&secret).unwrap();
+            let decoded : SecretKey<Ed25519> = bincode::deserialize(&encoded).unwrap();
+
+            secret.0.as_ref() == decoded.0.as_ref()
+        }
+        fn ed25519_secret_key_encode_decode_json(secret: SecretKey<Ed25519>) -> bool {
+            let encoded = serde_json::to_string(&secret).unwrap();
+            let decoded : SecretKey<Ed25519> = serde_json::from_str(&encoded).unwrap();
+
+            secret.0.as_ref() == decoded.0.as_ref()
+        }
+
+        fn ed25519bip32_secret_key_encode_decode_bincode(secret: SecretKey<Ed25519Bip32>) -> bool {
+            let encoded = bincode::serialize(&secret).unwrap();
+            let decoded : SecretKey<Ed25519Bip32> = bincode::deserialize(&encoded).unwrap();
+
+            secret.0.as_ref() == decoded.0.as_ref()
+        }
+        fn ed25519bip32_secret_key_encode_decode_json(secret: SecretKey<Ed25519Bip32>) -> bool {
+            let encoded = serde_json::to_string(&secret).unwrap();
+            let decoded : SecretKey<Ed25519Bip32> = serde_json::from_str(&encoded).unwrap();
+
+            secret.0.as_ref() == decoded.0.as_ref()
+        }
+
+        fn ed25519extended_secret_key_encode_decode_bincode(secret: SecretKey<Ed25519Extended>) -> bool {
+            let encoded = bincode::serialize(&secret).unwrap();
+            let decoded : SecretKey<Ed25519Extended> = bincode::deserialize(&encoded).unwrap();
+
+            secret.0.as_ref() == decoded.0.as_ref()
+        }
+        fn ed25519extended_secret_key_encode_decode_json(secret: SecretKey<Ed25519Extended>) -> bool {
+            let encoded = serde_json::to_string(&secret).unwrap();
+            let decoded : SecretKey<Ed25519Extended> = serde_json::from_str(&encoded).unwrap();
+
+            secret.0.as_ref() == decoded.0.as_ref()
+        }
+
+        fn fakemmm_secret_key_encode_decode_bincode(secret: SecretKey<FakeMMM>) -> bool {
+            let encoded = bincode::serialize(&secret).unwrap();
+            let decoded : SecretKey<FakeMMM> = bincode::deserialize(&encoded).unwrap();
+
+            secret.0.as_ref() == decoded.0.as_ref()
+        }
+        fn fakemmm_secret_key_encode_decode_json(secret: SecretKey<FakeMMM>) -> bool {
+            let encoded = serde_json::to_string(&secret).unwrap();
+            let decoded : SecretKey<FakeMMM> = serde_json::from_str(&encoded).unwrap();
+
+            secret.0.as_ref() == decoded.0.as_ref()
+        }
+
+        fn curve25519_2hashdh_secret_key_encode_decode_bincode(secret: SecretKey<Curve25519_2HashDH>) -> bool {
+            let encoded = bincode::serialize(&secret).unwrap();
+            let decoded : SecretKey<Curve25519_2HashDH> = bincode::deserialize(&encoded).unwrap();
+
+            secret.0.as_ref() == decoded.0.as_ref()
+        }
+        fn curve25519_2hashdh_secret_key_encode_decode_json(secret: SecretKey<Curve25519_2HashDH>) -> bool {
+            let encoded = serde_json::to_string(&secret).unwrap();
+            let decoded : SecretKey<Curve25519_2HashDH> = serde_json::from_str(&encoded).unwrap();
+
+            secret.0.as_ref() == decoded.0.as_ref()
+        }
+
+        fn ed25519_public_key_encode_decode_bincode(public: PublicKey<Ed25519>) -> bool {
+            let encoded = bincode::serialize(&public).unwrap();
+            let decoded : PublicKey<Ed25519> = bincode::deserialize(&encoded).unwrap();
+
+            public.0.as_ref() == decoded.0.as_ref()
+        }
+        fn ed25519_public_key_encode_decode_json(public: PublicKey<Ed25519>) -> bool {
+            let encoded = serde_json::to_string(&public).unwrap();
+            let decoded : PublicKey<Ed25519> = serde_json::from_str(&encoded).unwrap();
+
+            public.0.as_ref() == decoded.0.as_ref()
+        }
+
+        fn ed25519bip32_public_key_encode_decode_bincode(public: PublicKey<Ed25519Bip32>) -> bool {
+            let encoded = bincode::serialize(&public).unwrap();
+            let decoded : PublicKey<Ed25519Bip32> = bincode::deserialize(&encoded).unwrap();
+
+            public.0.as_ref() == decoded.0.as_ref()
+        }
+        fn ed25519bip32_public_key_encode_decode_json(public: PublicKey<Ed25519Bip32>) -> bool {
+            let encoded = serde_json::to_string(&public).unwrap();
+            let decoded : PublicKey<Ed25519Bip32> = serde_json::from_str(&encoded).unwrap();
+
+            public.0.as_ref() == decoded.0.as_ref()
+        }
+
+        fn ed25519extended_public_key_encode_decode_bincode(public: PublicKey<Ed25519Extended>) -> bool {
+            let encoded = bincode::serialize(&public).unwrap();
+            let decoded : PublicKey<Ed25519Extended> = bincode::deserialize(&encoded).unwrap();
+
+            public.0.as_ref() == decoded.0.as_ref()
+        }
+        fn ed25519extended_public_key_encode_decode_json(public: PublicKey<Ed25519Extended>) -> bool {
+            let encoded = serde_json::to_string(&public).unwrap();
+            let decoded : PublicKey<Ed25519Extended> = serde_json::from_str(&encoded).unwrap();
+
+            public.0.as_ref() == decoded.0.as_ref()
+        }
+
+        fn fakemmm_public_key_encode_decode_bincode(public: PublicKey<FakeMMM>) -> bool {
+            let encoded = bincode::serialize(&public).unwrap();
+            let decoded : PublicKey<FakeMMM> = bincode::deserialize(&encoded).unwrap();
+
+            public.0.as_ref() == decoded.0.as_ref()
+        }
+        fn fakemmm_public_key_encode_decode_json(public: PublicKey<FakeMMM>) -> bool {
+            let encoded = serde_json::to_string(&public).unwrap();
+            let decoded : PublicKey<FakeMMM> = serde_json::from_str(&encoded).unwrap();
+
+            public.0.as_ref() == decoded.0.as_ref()
+        }
+
+        fn curve25519_2hashdh_public_key_encode_decode_bincode(public: PublicKey<Curve25519_2HashDH>) -> bool {
+            let encoded = bincode::serialize(&public).unwrap();
+            let decoded : PublicKey<Curve25519_2HashDH> = bincode::deserialize(&encoded).unwrap();
+
+            public.0.as_ref() == decoded.0.as_ref()
+        }
+        fn curve25519_2hashdh_public_key_encode_decode_json(public: PublicKey<Curve25519_2HashDH>) -> bool {
+            let encoded = serde_json::to_string(&public).unwrap();
+            let decoded : PublicKey<Curve25519_2HashDH> = serde_json::from_str(&encoded).unwrap();
+
+            public.0.as_ref() == decoded.0.as_ref()
+        }
+
+        fn ed25519_signature_key_encode_decode_bincode(signature: Signature<Vec<u8>, Ed25519>) -> bool {
+            let encoded = bincode::serialize(&signature).unwrap();
+            let decoded : Signature<Vec<u8>, Ed25519> = bincode::deserialize(&encoded).unwrap();
+
+            signature.as_ref() == decoded.as_ref()
+        }
+        fn ed25519_signature_key_encode_decode_json(signature: Signature<Vec<u8>, Ed25519>) -> bool {
+            let encoded = serde_json::to_string(&signature).unwrap();
+            let decoded : Signature<Vec<u8>, Ed25519> = serde_json::from_str(&encoded).unwrap();
+
+            signature.as_ref() == decoded.as_ref()
+        }
+
+        fn ed25519bip32_signature_key_encode_decode_bincode(signature: Signature<Vec<u8>, Ed25519Bip32>) -> bool {
+            let encoded = bincode::serialize(&signature).unwrap();
+            let decoded : Signature<Vec<u8>, Ed25519Bip32> = bincode::deserialize(&encoded).unwrap();
+
+            signature.as_ref() == decoded.as_ref()
+        }
+        fn ed25519bip32_signature_key_encode_decode_json(signature: Signature<Vec<u8>, Ed25519Bip32>) -> bool {
+            let encoded = serde_json::to_string(&signature).unwrap();
+            let decoded : Signature<Vec<u8>, Ed25519Bip32> = serde_json::from_str(&encoded).unwrap();
+
+            signature.as_ref() == decoded.as_ref()
+        }
+
+        fn ed25519extended_signature_key_encode_decode_bincode(signature: Signature<Vec<u8>, Ed25519Extended>) -> bool {
+            let encoded = bincode::serialize(&signature).unwrap();
+            let decoded : Signature<Vec<u8>, Ed25519Extended> = bincode::deserialize(&encoded).unwrap();
+
+            signature.as_ref() == decoded.as_ref()
+        }
+        fn ed25519extended_signature_key_encode_decode_json(signature: Signature<Vec<u8>, Ed25519Extended>) -> bool {
+            let encoded = serde_json::to_string(&signature).unwrap();
+            let decoded : Signature<Vec<u8>, Ed25519Extended> = serde_json::from_str(&encoded).unwrap();
+
+            signature.as_ref() == decoded.as_ref()
+        }
+
+        fn fakemmm_signature_key_encode_decode_bincode(signature: Signature<Vec<u8>, FakeMMM>) -> bool {
+            let encoded = bincode::serialize(&signature).unwrap();
+            let decoded : Signature<Vec<u8>, FakeMMM> = bincode::deserialize(&encoded).unwrap();
+
+            signature.as_ref() == decoded.as_ref()
+        }
+        fn fakemmm_signature_key_encode_decode_json(signature: Signature<Vec<u8>, FakeMMM>) -> bool {
+            let encoded = serde_json::to_string(&signature).unwrap();
+            let decoded : Signature<Vec<u8>, FakeMMM> = serde_json::from_str(&encoded).unwrap();
+
+            signature.as_ref() == decoded.as_ref()
+        }
+
+        fn hash_blake2b_224_encode_decode_bincode(hash: Blake2b224) -> bool {
+            let encoded = bincode::serialize(&hash).unwrap();
+            let decoded : Blake2b224 = bincode::deserialize(&encoded).unwrap();
+
+            hash.as_ref() == decoded.as_ref()
+        }
+        fn hash_blake2b_224_encode_decode_json(hash: Blake2b224) -> bool {
+            let encoded = serde_json::to_string(&hash).unwrap();
+            let decoded : Blake2b224 = serde_json::from_str(&encoded).unwrap();
+
+            hash.as_ref() == decoded.as_ref()
+        }
+
+        fn hash_blake2b_256_encode_decode_bincode(hash: Blake2b256) -> bool {
+            let encoded = bincode::serialize(&hash).unwrap();
+            let decoded : Blake2b256 = bincode::deserialize(&encoded).unwrap();
+
+            hash.as_ref() == decoded.as_ref()
+        }
+        fn hash_blake2b_256_encode_decode_json(hash: Blake2b256) -> bool {
+            let encoded = serde_json::to_string(&hash).unwrap();
+            let decoded : Blake2b256 = serde_json::from_str(&encoded).unwrap();
+
+            hash.as_ref() == decoded.as_ref()
+        }
+    }
+}

--- a/chain-crypto/src/sign.rs
+++ b/chain-crypto/src/sign.rs
@@ -29,6 +29,7 @@ pub trait VerificationAlgorithm: key::AsymmetricKey {
     type Signature: AsRef<[u8]> + Clone;
 
     const SIGNATURE_SIZE: usize;
+    const SIGNATURE_BECH32_HRP: &'static str;
 
     fn verify_bytes(pubkey: &Self::Public, signature: &Self::Signature, msg: &[u8])
         -> Verification;
@@ -67,7 +68,7 @@ impl fmt::Display for SignatureError {
 impl std::error::Error for SignatureError {}
 
 impl<A: VerificationAlgorithm, T> Signature<T, A> {
-    pub fn from_bytes(sig: &[u8]) -> Result<Self, SignatureError> {
+    pub fn from_binary(sig: &[u8]) -> Result<Self, SignatureError> {
         Ok(Signature {
             signdata: A::signature_from_bytes(sig)?,
             phantom: PhantomData,
@@ -121,11 +122,11 @@ impl<T, A: VerificationAlgorithm> AsRef<[u8]> for Signature<T, A> {
 }
 
 impl<T, A: VerificationAlgorithm> Bech32 for Signature<T, A> {
-    const BECH32_HRP: &'static str = A::SECRET_BECH32_HRP;
+    const BECH32_HRP: &'static str = A::SIGNATURE_BECH32_HRP;
 
     fn try_from_bech32_str(bech32_str: &str) -> Result<Self, bech32::Error> {
         let bytes = bech32::try_from_bech32_to_bytes::<Self>(bech32_str)?;
-        Self::from_bytes(&bytes).map_err(bech32::Error::data_invalid)
+        Self::from_binary(&bytes).map_err(bech32::Error::data_invalid)
     }
 
     fn to_bech32_str(&self) -> String {
@@ -161,5 +162,21 @@ pub(crate) mod test {
 
         let signature = Signature::generate(&sk, &data);
         signature.verify(&pk_random, &data) == Verification::Failed
+    }
+
+    use quickcheck::{Arbitrary, Gen};
+
+    impl<T, A> Arbitrary for Signature<T, A>
+    where
+        A: VerificationAlgorithm + 'static,
+        A::Signature: Send,
+        T: Send + 'static,
+    {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            let bytes: Vec<_> = std::iter::repeat_with(|| u8::arbitrary(g))
+                .take(A::SIGNATURE_SIZE)
+                .collect();
+            Signature::from_binary(&bytes).unwrap()
+        }
     }
 }

--- a/chain-crypto/src/testing.rs
+++ b/chain-crypto/src/testing.rs
@@ -1,0 +1,74 @@
+use super::*;
+
+use quickcheck::{Arbitrary, Gen};
+use rand::SeedableRng;
+use rand_chacha::ChaChaRng;
+
+pub fn arbitrary_public_key<A: AsymmetricKey, G: Gen>(g: &mut G) -> PublicKey<A> {
+    arbitrary_secret_key(g).to_public()
+}
+
+pub fn arbitrary_secret_key<A, G>(g: &mut G) -> SecretKey<A>
+where
+    A: AsymmetricKey,
+    G: Gen,
+{
+    let rng = ChaChaRng::seed_from_u64(Arbitrary::arbitrary(g));
+    SecretKey::generate(rng)
+}
+
+impl<A> Arbitrary for PublicKey<A>
+where
+    A: AsymmetricKey + 'static,
+    A::Public: Send,
+{
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        arbitrary_public_key(g)
+    }
+}
+impl<A> Arbitrary for SecretKey<A>
+where
+    A: AsymmetricKey + 'static,
+    A::Secret: Send,
+{
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        arbitrary_secret_key(g)
+    }
+}
+impl<A> Arbitrary for KeyPair<A>
+where
+    A: AsymmetricKey + 'static,
+    A::Secret: Send,
+    A::Public: Send,
+{
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        let secret_key = SecretKey::arbitrary(g);
+        KeyPair::from(secret_key)
+    }
+}
+
+impl Arbitrary for Blake2b224 {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        let bytes: Vec<_> = std::iter::repeat_with(|| u8::arbitrary(g))
+            .take(Self::HASH_SIZE)
+            .collect();
+        Self::try_from_slice(&bytes).unwrap()
+    }
+}
+impl Arbitrary for Blake2b256 {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        let bytes: Vec<_> = std::iter::repeat_with(|| u8::arbitrary(g))
+            .take(Self::HASH_SIZE)
+            .collect();
+        Self::try_from_slice(&bytes).unwrap()
+    }
+}
+
+impl Arbitrary for Sha3_256 {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        let bytes: Vec<_> = std::iter::repeat_with(|| u8::arbitrary(g))
+            .take(Self::HASH_SIZE)
+            .collect();
+        Self::try_from_slice(&bytes).unwrap()
+    }
+}

--- a/chain-impl-mockchain/Cargo.toml
+++ b/chain-impl-mockchain/Cargo.toml
@@ -10,11 +10,12 @@ authors = [ "Nicolas Di Prima <nicolas.diprima@iohk.io>"
 edition = "2018"
 
 [features]
-generic-serialization = [ "chain-addr/generic-serialization", "serde", "serde_derive" ]
+generic-serialization = [ "chain-addr/generic-serialization", "chain-crypto/generic-serialization", "cardano/generic-serialization", "serde", "serde_derive", "bech32" ]
 
 [dependencies]
 num-traits = "0.2"
 num-derive = "0.2"
+bech32 = { version = "0.6", optional = true }
 serde = { version = "^1.0", optional = true }
 serde_derive = { version = "^1.0", optional = true }
 chain-core = { path = "../chain-core" }
@@ -32,5 +33,6 @@ strum_macros = "0.15.0"
 quickcheck = "0.8"
 chain-core = { path = "../chain-core", features=["property-test-api"]}
 chain-addr = { path = "../chain-addr", features=["property-test-api"]}
+chain-crypto = { path = "../chain-crypto", features=["property-test-api"]}
 rand_chacha = "0.1"
 rand_core = "0.4"

--- a/chain-impl-mockchain/src/block/header.rs
+++ b/chain-impl-mockchain/src/block/header.rs
@@ -331,7 +331,7 @@ mod test {
 
     impl Arbitrary for BftProof {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
-            let sk = crate::key::test::arbitrary_secret_key(g);
+            let sk: chain_crypto::SecretKey<_> = Arbitrary::arbitrary(g);
             let pk = sk.to_public();
             let signature = chain_crypto::Signature::generate(&sk, &[0u8, 1, 2, 3]);
             BftProof {
@@ -358,7 +358,7 @@ mod test {
             };
 
             let kes_proof = {
-                let mut sk = crate::key::test::arbitrary_secret_key(g);
+                let mut sk = Arbitrary::arbitrary(g);
                 let signature = Signature::generate_update(&mut sk, &[0u8, 1, 2, 3]);
                 KESSignature(signature)
             };

--- a/chain-impl-mockchain/src/block/version.rs
+++ b/chain-impl-mockchain/src/block/version.rs
@@ -84,6 +84,7 @@ impl BlockVersion {
     Ord,
     Hash,
 )]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub enum ConsensusVersion {
     #[strum(to_string = "bft")]
     Bft = 1,

--- a/chain-impl-mockchain/src/certificate.rs
+++ b/chain-impl-mockchain/src/certificate.rs
@@ -7,7 +7,7 @@ use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 
 #[derive(Debug, Clone)]
-pub struct SignatureRaw(Vec<u8>);
+pub struct SignatureRaw(pub(crate) Vec<u8>);
 
 impl property::Serialize for SignatureRaw {
     type Error = std::io::Error;
@@ -29,6 +29,7 @@ impl Readable for SignatureRaw {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct Certificate {
     pub content: CertificateContent,
     pub signatures: Vec<SignatureRaw>,
@@ -109,6 +110,7 @@ where
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub enum CertificateContent {
     StakeKeyRegistration(StakeKeyRegistration),
     StakeKeyDeregistration(StakeKeyDeregistration),
@@ -193,6 +195,7 @@ impl Readable for Certificate {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct StakeKeyRegistration {
     pub stake_key_id: StakeKeyId,
 }
@@ -229,6 +232,7 @@ impl Readable for StakeKeyRegistration {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct StakeKeyDeregistration {
     pub stake_key_id: StakeKeyId,
 }
@@ -265,6 +269,7 @@ impl Readable for StakeKeyDeregistration {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct StakeDelegation {
     pub stake_key_id: StakeKeyId,
     pub pool_id: StakePoolId,
@@ -321,6 +326,7 @@ impl HasStakeKeyIds for StakePoolInfo {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct StakePoolRetirement {
     pub pool_id: StakePoolId,
     // TODO: add epoch when the retirement will take effect

--- a/chain-impl-mockchain/src/fee.rs
+++ b/chain-impl-mockchain/src/fee.rs
@@ -5,6 +5,7 @@ use chain_addr::Address;
 /// Linear fee using the basic affine formula
 /// `COEFFICIENT * bytes(COUNT(tx.inputs) + COUNT(tx.outputs)) + CONSTANT + CERTIFICATE*COUNT(certificates)`.
 #[derive(PartialEq, Eq, PartialOrd, Debug, Clone, Copy)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct LinearFee {
     pub constant: u64,
     pub coefficient: u64,

--- a/chain-impl-mockchain/src/leadership/bft.rs
+++ b/chain-impl-mockchain/src/leadership/bft.rs
@@ -18,6 +18,7 @@ pub type SIGNING_ALGORITHM = Ed25519Extended;
 pub type SigningKey = SecretKey<SIGNING_ALGORITHM>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct LeaderId(pub(crate) PublicKey<SIGNING_ALGORITHM>);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/chain-impl-mockchain/src/leadership/genesis/mod.rs
+++ b/chain-impl-mockchain/src/leadership/genesis/mod.rs
@@ -15,6 +15,7 @@ pub use vrfeval::Witness;
 
 /// Praos Leader consisting of the KES public key and VRF public key
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct GenesisPraosLeader {
     pub(crate) kes_public_key: PublicKey<FakeMMM>,
     pub(crate) vrf_public_key: PublicKey<Curve25519_2HashDH>,

--- a/chain-impl-mockchain/src/leadership/mod.rs
+++ b/chain-impl-mockchain/src/leadership/mod.rs
@@ -43,16 +43,19 @@ macro_rules! try_check {
     };
 }
 
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct BftLeader {
     pub sig_key: SecretKey<Ed25519Extended>,
 }
 
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct GenesisLeader {
     pub node_id: StakePoolId,
     pub sig_key: SecretKey<FakeMMM>,
     pub vrf_key: SecretKey<Curve25519_2HashDH>,
 }
 
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct Leader {
     pub bft_leader: Option<BftLeader>,
     pub genesis_leader: Option<GenesisLeader>,

--- a/chain-impl-mockchain/src/legacy.rs
+++ b/chain-impl-mockchain/src/legacy.rs
@@ -11,6 +11,7 @@ use chain_core::property::Serialize;
 use chain_crypto::{Ed25519Bip32, PublicKey};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct UtxoDeclaration {
     pub addrs: Vec<(OldAddress, Value)>,
 }

--- a/chain-impl-mockchain/src/lib.rs
+++ b/chain-impl-mockchain/src/lib.rs
@@ -2,6 +2,13 @@
 #[macro_use]
 extern crate quickcheck;
 
+#[cfg(feature = "generic-serialization")]
+#[macro_use]
+extern crate serde_derive;
+
+#[cfg(feature = "generic-serialization")]
+mod serde;
+
 pub mod account;
 pub mod block;
 pub mod certificate;
@@ -23,6 +30,3 @@ pub mod transaction;
 pub mod txbuilder;
 pub mod utxo;
 pub mod value;
-
-#[cfg(test)]
-mod tests {}

--- a/chain-impl-mockchain/src/message/initial.rs
+++ b/chain-impl-mockchain/src/message/initial.rs
@@ -5,7 +5,7 @@ use chain_core::property;
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(
     feature = "generic-serialization",
-    derive(serde_derive::Serialize, serde_derive::Deserialize),
+    derive(Serialize, Deserialize),
     serde(transparent)
 )]
 pub struct InitialEnts(Vec<ConfigParam>);

--- a/chain-impl-mockchain/src/message/mod.rs
+++ b/chain-impl-mockchain/src/message/mod.rs
@@ -18,6 +18,7 @@ use crate::{
 
 /// All possible messages recordable in the content
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub enum Message {
     Initial(InitialEnts),
     OldUtxoDeclaration(legacy::UtxoDeclaration),

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -262,7 +262,7 @@ mod test {
     use crate::message::{InitialEnts, Message};
     use chain_core::property::{Block as _, ChainLength as _, HasMessages as _};
     use chain_storage::store::BlockStore;
-    use quickcheck::StdGen;
+    use quickcheck::{Arbitrary, StdGen};
 
     fn apply_block(state: &Ledger, block: &Block) -> Ledger {
         if state.chain_length().0 != 0 {
@@ -278,7 +278,7 @@ mod test {
         let mut multiverse = Multiverse::new();
 
         let mut g = StdGen::new(rand::thread_rng(), 10);
-        let leader_key = crate::key::test::arbitrary_secret_key(&mut g);
+        let leader_key = Arbitrary::arbitrary(&mut g);
 
         let mut store = chain_storage::memory::MemoryBlockStore::new();
 

--- a/chain-impl-mockchain/src/serde.rs
+++ b/chain-impl-mockchain/src/serde.rs
@@ -1,0 +1,96 @@
+use crate::certificate::SignatureRaw;
+use serde::{
+    de::{Deserialize, Deserializer, Error, Visitor},
+    ser::{Error as _, Serialize, Serializer},
+};
+use std::fmt;
+
+const SIGNATURE_RAW_HRP: &'static str = "";
+
+impl Serialize for SignatureRaw {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            use bech32::{Bech32, ToBase32};
+
+            let string = Bech32::new(SIGNATURE_RAW_HRP.to_string(), self.0.to_base32())
+                .map_err(S::Error::custom)?
+                .to_string();
+
+            serializer.serialize_str(&string)
+        } else {
+            serializer.serialize_bytes(self.0.as_ref())
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SignatureRaw {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let visitor = BytesVisitor {
+            hrp: SIGNATURE_RAW_HRP,
+        };
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_str(visitor).map(SignatureRaw)
+        } else {
+            deserializer.deserialize_bytes(visitor).map(SignatureRaw)
+        }
+    }
+}
+
+/// helper for the generic serialization.
+///
+/// If encoding the data as a string: uses bech32;
+///
+/// If encoding the data as bytes, encode raw bytes
+///
+struct BytesVisitor {
+    hrp: &'static str,
+}
+
+impl<'de> Visitor<'de> for BytesVisitor {
+    type Value = Vec<u8>;
+
+    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            fmt,
+            "Expecting bytes or bech32 encoded bytes (with hrp: {})",
+            self.hrp,
+        )
+    }
+
+    fn visit_str<'a, E>(self, v: &'a str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        use bech32::{Bech32, FromBase32};
+        let bech32: Bech32 = v.parse().map_err(E::custom)?;
+
+        if bech32.hrp() != self.hrp {
+            return Err(Error::custom(format!(
+                "Invalid HRP ({}), expected: {}",
+                bech32.hrp(),
+                self.hrp
+            )));
+        }
+        Vec::<u8>::from_base32(bech32.data()).map_err(E::custom)
+    }
+
+    fn visit_bytes<'a, E>(self, v: &'a [u8]) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(v.to_owned())
+    }
+
+    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(v)
+    }
+}

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -13,6 +13,7 @@ use num_traits::FromPrimitive;
 // epoch boundary.
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct UpdateProposal {
     pub max_number_of_transactions_per_block: Option<u32>,
     pub bootstrap_key_slots_percentage: Option<u8>,

--- a/chain-impl-mockchain/src/stake/role.rs
+++ b/chain-impl-mockchain/src/stake/role.rs
@@ -6,14 +6,17 @@ use chain_crypto::{Ed25519Extended, PublicKey, SecretKey};
 
 /// Information related to a stake key
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct StakeKeyInfo {
     pub(crate) pool: Option<StakePoolId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct StakePoolId(Hash);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct StakePoolInfo {
     pub serial: u128,
     pub owners: Vec<StakeKeyId>,
@@ -34,6 +37,7 @@ impl StakePoolInfo {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct StakeKeyId(pub(crate) PublicKey<Ed25519Extended>);
 
 impl From<PublicKey<Ed25519Extended>> for StakeKeyId {
@@ -138,7 +142,7 @@ mod test {
 
     impl Arbitrary for StakeKeyId {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
-            StakeKeyId::from(&crate::key::test::arbitrary_secret_key(g))
+            StakeKeyId::from(&Arbitrary::arbitrary(g))
         }
     }
 

--- a/chain-impl-mockchain/src/transaction/mod.rs
+++ b/chain-impl-mockchain/src/transaction/mod.rs
@@ -16,6 +16,7 @@ pub use witness::*;
 /// Each transaction must be signed in order to be executed
 /// by the ledger. `SignedTransaction` represents such a transaction.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct AuthenticatedTransaction<OutAddress, Extra> {
     pub transaction: Transaction<OutAddress, Extra>,
     pub witnesses: Vec<Witness>,

--- a/chain-impl-mockchain/src/transaction/transaction.rs
+++ b/chain-impl-mockchain/src/transaction/transaction.rs
@@ -9,6 +9,7 @@ use chain_core::property;
 pub type TransactionId = Hash;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct NoExtra;
 
 impl property::Serialize for NoExtra {
@@ -33,6 +34,7 @@ impl Readable for NoExtra {
 /// Transaction, transaction maps old unspent tokens into the
 /// set of the new addresses.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct Transaction<OutAddress, Extra> {
     pub inputs: Vec<Input>,
     pub outputs: Vec<Output<OutAddress>>,

--- a/chain-impl-mockchain/src/transaction/transfer.rs
+++ b/chain-impl-mockchain/src/transaction/transfer.rs
@@ -13,6 +13,7 @@ const INPUT_PTR_SIZE: usize = 32;
 ///
 /// This uniquely refer to a specific source of value.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct Input {
     index_or_account: u8,
     pub value: Value,
@@ -62,7 +63,7 @@ impl Input {
     pub fn to_enum(&self) -> InputEnum {
         match self.get_type() {
             InputType::Account => {
-                let pk = PublicKey::from_bytes(&self.input_ptr)
+                let pk = PublicKey::from_binary(&self.input_ptr)
                     .expect("internal error in publickey type");
                 InputEnum::AccountInput(pk.into(), self.value)
             }
@@ -131,6 +132,7 @@ impl Readable for Input {
 /// Information how tokens are spent.
 /// A value of tokens is sent to the address.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct Output<Address> {
     pub address: Address,
     pub value: Value,

--- a/chain-impl-mockchain/src/transaction/witness.rs
+++ b/chain-impl-mockchain/src/transaction/witness.rs
@@ -15,6 +15,7 @@ use chain_crypto::{Ed25519Bip32, PublicKey, Signature, Verification};
 /// It's important that witness works with opaque structures
 /// and may not know the contents of the internal transaction.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub enum Witness {
     Utxo(SpendingSignature<TransactionId>),
     Account(SpendingSignature<TransactionIdSpendingCounter>),

--- a/chain-impl-mockchain/src/value.rs
+++ b/chain-impl-mockchain/src/value.rs
@@ -3,8 +3,8 @@ use chain_core::property;
 use std::ops;
 
 /// Unspent transaction value.
-#[cfg_attr(feature = "generic-serialization", derive(serde_derive::Serialize))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
 pub struct Value(pub u64);
 
 impl Value {


### PR DESCRIPTION
also update the CI to test the new added serde implementations

here, serde is added as an optional dependency. It not meant to be used to store the blockchain in a generic format (this would be a bad design choice as it will certainly store excessive metadata and will end up taking more and more storage).

The serde instances are used to standardise some interfaces that we will have on the side:

* REST API (json, ...);
* configuration files (yaml, ...);
* inter process (bincode, ...).