### PR TITLE
chain-crypto: vanity fix as crypto naming convention is verbose

### DIFF
--- a/chain-crypto/src/algorithms/ed25519.rs
+++ b/chain-crypto/src/algorithms/ed25519.rs
@@ -47,8 +47,8 @@ impl AsymmetricKey for Ed25519 {
     type Secret = Priv;
     type Public = Pub;
 
-    const SECRET_BECH32_HRP: &'static str = "ed25519_secret";
-    const PUBLIC_BECH32_HRP: &'static str = "ed25519_public";
+    const SECRET_BECH32_HRP: &'static str = "ed25519_sk";
+    const PUBLIC_BECH32_HRP: &'static str = "ed25519_pk";
 
     const SECRET_KEY_SIZE: usize = ed25519::SEED_LENGTH;
     const PUBLIC_KEY_SIZE: usize = ed25519::PUBLIC_KEY_LENGTH;
@@ -86,7 +86,7 @@ impl VerificationAlgorithm for Ed25519 {
     type Signature = Sig;
 
     const SIGNATURE_SIZE: usize = ed25519::SIGNATURE_LENGTH;
-    const SIGNATURE_BECH32_HRP: &'static str = "ed25519_signature";
+    const SIGNATURE_BECH32_HRP: &'static str = "ed25519_sig";
 
     fn signature_from_bytes(data: &[u8]) -> Result<Self::Signature, SignatureError> {
         if data.len() != ed25519::SIGNATURE_LENGTH {

--- a/chain-crypto/src/algorithms/ed25519_derive.rs
+++ b/chain-crypto/src/algorithms/ed25519_derive.rs
@@ -30,8 +30,8 @@ impl AsymmetricKey for Ed25519Bip32 {
     type Secret = XPrv;
     type Public = XPub;
 
-    const SECRET_BECH32_HRP: &'static str = "ed25519bip32_secret";
-    const PUBLIC_BECH32_HRP: &'static str = "ed25519bip32_public";
+    const SECRET_BECH32_HRP: &'static str = "xprv";
+    const PUBLIC_BECH32_HRP: &'static str = "xpub";
 
     const SECRET_KEY_SIZE: usize = XPRV_SIZE;
     const PUBLIC_KEY_SIZE: usize = XPUB_SIZE;
@@ -70,7 +70,7 @@ impl VerificationAlgorithm for Ed25519Bip32 {
     type Signature = XSig;
 
     const SIGNATURE_SIZE: usize = ed25519_bip32::SIGNATURE_SIZE;
-    const SIGNATURE_BECH32_HRP: &'static str = "ed25519bip32_signature";
+    const SIGNATURE_BECH32_HRP: &'static str = "xsig";
 
     fn signature_from_bytes(data: &[u8]) -> Result<Self::Signature, SignatureError> {
         let xsig = XSig::from_slice(data)?;

--- a/chain-crypto/src/algorithms/ed25519_extended.rs
+++ b/chain-crypto/src/algorithms/ed25519_extended.rs
@@ -32,8 +32,8 @@ impl AsymmetricKey for Ed25519Extended {
     type Secret = ExtendedPriv;
     type Public = ei::Pub;
 
-    const SECRET_BECH32_HRP: &'static str = "ed25519extended_secret";
-    const PUBLIC_BECH32_HRP: &'static str = "ed25519extended_public";
+    const SECRET_BECH32_HRP: &'static str = "ed25519e_sk";
+    const PUBLIC_BECH32_HRP: &'static str = "ed25519e_pk";
 
     const SECRET_KEY_SIZE: usize = ed25519::PRIVATE_KEY_LENGTH;
     const PUBLIC_KEY_SIZE: usize = ed25519::PUBLIC_KEY_LENGTH;
@@ -76,7 +76,7 @@ impl VerificationAlgorithm for Ed25519Extended {
     type Signature = ei::Sig;
 
     const SIGNATURE_SIZE: usize = ed25519::SIGNATURE_LENGTH;
-    const SIGNATURE_BECH32_HRP: &'static str = "ed25519extended_signature";
+    const SIGNATURE_BECH32_HRP: &'static str = "ed25519e_sig";
 
     fn signature_from_bytes(data: &[u8]) -> Result<Self::Signature, SignatureError> {
         if data.len() != ed25519::SIGNATURE_LENGTH {

--- a/chain-crypto/src/algorithms/fakemmm.rs
+++ b/chain-crypto/src/algorithms/fakemmm.rs
@@ -38,8 +38,8 @@ impl AsymmetricKey for FakeMMM {
     type Secret = Priv;
     type Public = Pub;
 
-    const SECRET_BECH32_HRP: &'static str = "fakemmm_secret";
-    const PUBLIC_BECH32_HRP: &'static str = "fakemmm_public";
+    const SECRET_BECH32_HRP: &'static str = "fakemmm_sk";
+    const PUBLIC_BECH32_HRP: &'static str = "fakemmm_pk";
 
     const SECRET_KEY_SIZE: usize = ed25519::SEED_LENGTH;
     const PUBLIC_KEY_SIZE: usize = ed25519::PUBLIC_KEY_LENGTH;
@@ -77,7 +77,7 @@ impl VerificationAlgorithm for FakeMMM {
     type Signature = Sig;
 
     const SIGNATURE_SIZE: usize = ed25519::SIGNATURE_LENGTH;
-    const SIGNATURE_BECH32_HRP: &'static str = "fakemmm_signature";
+    const SIGNATURE_BECH32_HRP: &'static str = "fakemmm_sig";
 
     fn signature_from_bytes(data: &[u8]) -> Result<Self::Signature, SignatureError> {
         if data.len() != ed25519::SIGNATURE_LENGTH {

--- a/chain-crypto/src/algorithms/vrf/mod.rs
+++ b/chain-crypto/src/algorithms/vrf/mod.rs
@@ -12,8 +12,8 @@ impl AsymmetricKey for Curve25519_2HashDH {
     type Secret = vrf::SecretKey;
     type Public = vrf::PublicKey;
 
-    const SECRET_BECH32_HRP: &'static str = "curve25519_2hashdh_secret";
-    const PUBLIC_BECH32_HRP: &'static str = "curve25519_2hashdh_public";
+    const SECRET_BECH32_HRP: &'static str = "vrf_sk";
+    const PUBLIC_BECH32_HRP: &'static str = "vrf_pk";
 
     const SECRET_KEY_SIZE: usize = vrf::SECRET_SIZE;
     const PUBLIC_KEY_SIZE: usize = vrf::PUBLIC_SIZE;


### PR DESCRIPTION
These are the renames:

`ed25519bip32_secret` -> `xprv`
`ed25519bip32_public` -> `xpub`
`ed25519bip32_signature` -> `xsig`

`ed25519extended_secret` -> `ed25519e_sk`
`ed25519extended_public` ->  `ed25519e_pk`
`ed25519extended_signature` -> `ed25519e_sig`

`ed25519_secret` -> `ed25519_sk`
`ed25519_public` -> `ed25519_pk`
`ed25519_signature` -> `ed25519_sig`

`curve25519_2hashdh_secret` -> `vrf_sk`
`curve25519_2hashdh_public` -> `vrf_pk`

`fakemmm_secret` -> `fakemmm_sk`
`fakemmm_public` -> `fakemmm_pk`
`fakemmm_signature` -> `fakemmm_sig`