### PR TITLE
chain-addr: allow configurable address prefixes

### DIFF
--- a/chain-addr/build.rs
+++ b/chain-addr/build.rs
@@ -7,6 +7,9 @@ fn main() {
     let production_prefix = option_env!("PRODUCTION_ADDRESS_PREFIX").unwrap_or("ca");
     let test_prefix = option_env!("TEST_ADDRESS_PREFIX").unwrap_or("ta");
 
-    println!("cargo:rustc-env=PRODUCTION_ADDRESS_PREFIX={}", production_prefix);
+    println!(
+        "cargo:rustc-env=PRODUCTION_ADDRESS_PREFIX={}",
+        production_prefix
+    );
     println!("cargo:rustc-env=TEST_ADDRESS_PREFIX={}", test_prefix);
 }

--- a/chain-addr/build.rs
+++ b/chain-addr/build.rs
@@ -1,0 +1,12 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+fn main() {
+    let production_prefix = option_env!("PRODUCTION_ADDRESS_PREFIX").unwrap_or("ca");
+    let test_prefix = option_env!("TEST_ADDRESS_PREFIX").unwrap_or("ta");
+
+    println!("cargo:rustc-env=PRODUCTION_ADDRESS_PREFIX={}", production_prefix);
+    println!("cargo:rustc-env=TEST_ADDRESS_PREFIX={}", test_prefix);
+}

--- a/chain-addr/src/lib.rs
+++ b/chain-addr/src/lib.rs
@@ -275,7 +275,6 @@ fn is_valid_data(bytes: &[u8]) -> Result<(Discrimination, KindType), Error> {
 pub struct AddressReadable(String);
 
 impl AddressReadable {
-
     const PRODUCTION_ADDRESS_PREFIX: &'static str = env!("PRODUCTION_ADDRESS_PREFIX");
     const TEST_ADDRESS_PREFIX: &'static str = env!("TEST_ADDRESS_PREFIX");
 

--- a/chain-addr/src/lib.rs
+++ b/chain-addr/src/lib.rs
@@ -275,8 +275,9 @@ fn is_valid_data(bytes: &[u8]) -> Result<(Discrimination, KindType), Error> {
 pub struct AddressReadable(String);
 
 impl AddressReadable {
-    const PRODUCTION_PREFIX: &'static str = "ca";
-    const TEST_PREFIX: &'static str = "ta";
+
+    const PRODUCTION_ADDRESS_PREFIX: &'static str = env!("PRODUCTION_ADDRESS_PREFIX");
+    const TEST_ADDRESS_PREFIX: &'static str = env!("TEST_ADDRESS_PREFIX");
 
     pub fn as_string(&self) -> &str {
         &self.0
@@ -286,9 +287,9 @@ impl AddressReadable {
     pub fn from_string(s: &str) -> Result<Self, Error> {
         use std::str::FromStr;
         let r = Bech32::from_str(s)?;
-        let expected_discrimination = if r.hrp() == Self::PRODUCTION_PREFIX {
+        let expected_discrimination = if r.hrp() == Self::PRODUCTION_ADDRESS_PREFIX {
             Discrimination::Production
-        } else if r.hrp() == Self::TEST_PREFIX {
+        } else if r.hrp() == Self::TEST_ADDRESS_PREFIX {
             Discrimination::Test
         } else {
             return Err(Error::InvalidPrefix);
@@ -305,8 +306,8 @@ impl AddressReadable {
     pub fn from_address(addr: &Address) -> Self {
         let v = ToBase32::to_base32(&addr.to_bytes());
         let prefix = match addr.0 {
-            Discrimination::Production => Self::PRODUCTION_PREFIX.to_string(),
-            Discrimination::Test => Self::TEST_PREFIX.to_string(),
+            Discrimination::Production => Self::PRODUCTION_ADDRESS_PREFIX.to_string(),
+            Discrimination::Test => Self::TEST_ADDRESS_PREFIX.to_string(),
         };
         let r = Bech32::new(prefix, v).unwrap();
         AddressReadable(r.to_string())

--- a/chain-addr/src/testing.rs
+++ b/chain-addr/src/testing.rs
@@ -1,4 +1,4 @@
-use crate::{KindType, Kind, Address, Discrimination, AddressReadable};
+use crate::{Address, AddressReadable, Discrimination, Kind, KindType};
 use quickcheck::{Arbitrary, Gen};
 
 impl Arbitrary for Discrimination {
@@ -32,11 +32,8 @@ impl Arbitrary for Address {
         let discrimination = Arbitrary::arbitrary(g);
         let kind = match KindType::arbitrary(g) {
             KindType::Single => Kind::Single(Arbitrary::arbitrary(g)),
-            KindType::Group => Kind::Group(
-                Arbitrary::arbitrary(g),
-                Arbitrary::arbitrary(g),
-            ),
-            KindType::Account => Kind::Account(Arbitrary::arbitrary(g))
+            KindType::Group => Kind::Group(Arbitrary::arbitrary(g), Arbitrary::arbitrary(g)),
+            KindType::Account => Kind::Account(Arbitrary::arbitrary(g)),
         };
         Address(discrimination, kind)
     }


### PR DESCRIPTION
set by editing the relevant environment variables:

`$ TESTING_ADDRESS_PREFIX=teo PRODUCTION_ADDRESS_PREFIX=ceo cargo test`

The address tests will inevitably fail as they are configured
for ca & ta prefixes. This is an acceptable tradeoff.