### PR TITLE
network: Change client APIs to receive node ID

### DIFF
--- a/network-core/src/client.rs
+++ b/network-core/src/client.rs
@@ -2,3 +2,12 @@
 
 pub mod block;
 pub mod gossip;
+
+use crate::gossip::NodeId;
+
+/// Base trait for the client services that use node identifiers to
+/// distinguish subscription streams.
+pub trait P2pService {
+    /// Network node identifier.
+    type NodeId: NodeId;
+}

--- a/network-core/src/client/block.rs
+++ b/network-core/src/client/block.rs
@@ -1,3 +1,4 @@
+use super::P2pService;
 use crate::error::Error;
 
 use chain_core::property::{Block, HasHeader};
@@ -6,7 +7,7 @@ use futures::prelude::*;
 
 /// Interface for the blockchain node service responsible for
 /// providing access to blocks.
-pub trait BlockService {
+pub trait BlockService: P2pService {
     /// The type of blockchain block served by this service.
     type Block: Block + HasHeader;
 
@@ -55,9 +56,12 @@ pub trait BlockService {
 
     /// The type of asynchronous futures returned by method `block_subscription`.
     ///
-    /// The future resolves to a stream that will be used by the protocol
-    /// implementation to produce a subscription stream.
-    type BlockSubscriptionFuture: Future<Item = Self::BlockSubscription, Error = Error>;
+    /// The future resolves to a stream of blocks sent by the remote node
+    /// and the identifier of the node in the network.
+    type BlockSubscriptionFuture: Future<
+        Item = (Self::BlockSubscription, Self::NodeId),
+        Error = Error,
+    >;
 
     /// The type of an asynchronous stream that provides notifications
     /// of blocks created or accepted by the remote node.

--- a/network-core/src/client/gossip.rs
+++ b/network-core/src/client/gossip.rs
@@ -1,3 +1,4 @@
+use super::P2pService;
 use crate::{
     error::Error,
     gossip::{Gossip, Node},
@@ -5,8 +6,8 @@ use crate::{
 
 use futures::prelude::*;
 
-pub trait GossipService {
-    type Node: Node;
+pub trait GossipService: P2pService {
+    type Node: Node<Id = Self::NodeId>;
 
     /// The type of an asynchronous stream that provides node gossip messages
     /// sent by the peer.
@@ -14,9 +15,12 @@ pub trait GossipService {
 
     /// The type of asynchronous futures returned by method `gossip_subscription`.
     ///
-    /// The future resolves to a stream that will be used by the protocol
-    /// implementation to produce a subscription stream.
-    type GossipSubscriptionFuture: Future<Item = Self::GossipSubscription, Error = Error>;
+    /// The future resolves to a stream of gossip messages sent by the remote node
+    /// and the identifier of the node in the network.
+    type GossipSubscriptionFuture: Future<
+        Item = (Self::GossipSubscription, Self::NodeId),
+        Error = Error,
+    >;
 
     /// Establishes a bidirectional stream of notifications for gossip
     /// messages.

--- a/network-grpc/src/lib.rs
+++ b/network-grpc/src/lib.rs
@@ -1,4 +1,6 @@
 extern crate chain_core;
+#[macro_use]
+extern crate futures;
 extern crate prost;
 extern crate tower_grpc;
 extern crate tower_h2;

--- a/network-ntt/src/gossip.rs
+++ b/network-ntt/src/gossip.rs
@@ -1,0 +1,27 @@
+//! Compatibility stubs for network-core gossip traits
+
+use chain_core::property;
+use network_core::gossip as core_gossip;
+
+use std::io;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct NodeId(protocol::protocol::NodeId);
+
+impl property::Serialize for NodeId {
+    type Error = io::Error;
+
+    fn serialize<W: std::io::Write>(&self, _writer: W) -> Result<(), Self::Error> {
+        unimplemented!()
+    }
+}
+
+impl property::Deserialize for NodeId {
+    type Error = io::Error;
+
+    fn deserialize<R: std::io::BufRead>(_reader: R) -> Result<Self, Self::Error> {
+        unimplemented!()
+    }
+}
+
+impl core_gossip::NodeId for NodeId {}

--- a/network-ntt/src/lib.rs
+++ b/network-ntt/src/lib.rs
@@ -10,4 +10,5 @@ extern crate protocol_tokio as protocol;
 extern crate futures;
 
 pub mod client;
+pub mod gossip;
 pub mod server;


### PR DESCRIPTION
The subscription futures now resolve to a tuple consisting of the stream and the node identifier.