### PR TITLE
Minimize tower dependencies

### DIFF
--- a/network-grpc/Cargo.toml
+++ b/network-grpc/Cargo.toml
@@ -19,9 +19,10 @@ http = "0.1.16"
 h2 = "0.1.11"
 prost = "0.5"
 tokio = "0.1"
-tower = { git = "https://github.com/tower-rs/tower" }
 tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 tower-request-modifier = { git = "https://github.com/tower-rs/tower-http" }
+tower-service = "0.2"
+tower-util = { git = "https://github.com/tower-rs/tower" }
 
 [dependencies.tower-grpc]
 git = "https://github.com/tower-rs/tower-grpc"

--- a/network-grpc/src/client/connect.rs
+++ b/network-grpc/src/client/connect.rs
@@ -7,9 +7,10 @@ use futures::future::Executor;
 use futures::prelude::*;
 use futures::try_ready;
 use http::uri::{self, Uri};
-use tower::{MakeConnection, MakeService, Service};
 use tower_grpc::BoxBody;
 use tower_h2::client::Background;
+use tower_service::Service;
+use tower_util::{MakeConnection, MakeService};
 
 use std::{error::Error, fmt, mem};
 


### PR DESCRIPTION
It may be OK for an application to depend on the batteries-included
tower crate, but the library should be conservative in pulling in
dependencies. Replace the dependency on tower with individual
crates providing the functionality.