### PR TITLE
Extend init message config params

### DIFF
--- a/chain-impl-mockchain/src/config.rs
+++ b/chain-impl-mockchain/src/config.rs
@@ -1,16 +1,16 @@
 use crate::block::ConsensusVersion;
+use crate::leadership::bft::LeaderId;
+use crate::milli::Milli;
 use chain_addr::Discrimination;
 use chain_core::mempack::{ReadBuf, ReadError, Readable};
 use chain_core::packer::Codec;
 use chain_core::property;
+use chain_crypto::PublicKey;
+use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use std::fmt::{self, Display, Formatter};
 use std::io::{self, Write};
-use std::str::FromStr;
-
-/// Seconds elapsed since 1-Jan-1970 (unix time)
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub struct Block0Date(pub u64);
+use strum_macros::{AsRefStr, EnumIter, EnumString};
 
 /// Possible errors
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -45,21 +45,81 @@ pub enum ConfigParam {
     Block0Date(Block0Date),
     Discrimination(Discrimination),
     ConsensusVersion(ConsensusVersion),
+    SlotsPerEpoch(u64),
+    SlotDuration(u8),
+    EpochStabilityDepth(u32),
+    ConsensusLeaderId(LeaderId),
+    ConsensusGenesisPraosParamD(Milli),
+    ConsensusGenesisPraosParamF(Milli),
+}
+
+// Discriminants can NEVER be 1024 or higher
+#[derive(AsRefStr, Clone, Copy, Debug, EnumIter, EnumString, FromPrimitive, PartialEq)]
+enum Tag {
+    #[strum(to_string = "block0-date")]
+    Block0Date = 1,
+    #[strum(to_string = "discrimination")]
+    Discrimination = 2,
+    #[strum(to_string = "block0-consensus")]
+    ConsensusVersion = 3,
+    #[strum(to_string = "slots-per-epoch")]
+    SlotsPerEpoch = 4,
+    #[strum(to_string = "slot-duration")]
+    SlotDuration = 5,
+    #[strum(to_string = "epoch_stability_depth")]
+    EpochStabilityDepth = 6,
+    #[strum(to_string = "block0-consensus-leader")]
+    ConsensusLeaderId = 7,
+    #[strum(to_string = "genesis-praos-param-d")]
+    ConsensusGenesisPraosParamD = 8,
+    #[strum(to_string = "genesis-praos-param-f")]
+    ConsensusGenesisPraosParamF = 9,
+}
+
+impl<'a> From<&'a ConfigParam> for Tag {
+    fn from(config_param: &'a ConfigParam) -> Self {
+        match config_param {
+            ConfigParam::Block0Date(_) => Tag::Block0Date,
+            ConfigParam::Discrimination(_) => Tag::Discrimination,
+            ConfigParam::ConsensusVersion(_) => Tag::ConsensusVersion,
+            ConfigParam::SlotsPerEpoch(_) => Tag::SlotsPerEpoch,
+            ConfigParam::SlotDuration(_) => Tag::SlotDuration,
+            ConfigParam::EpochStabilityDepth(_) => Tag::EpochStabilityDepth,
+            ConfigParam::ConsensusLeaderId(_) => Tag::ConsensusLeaderId,
+            ConfigParam::ConsensusGenesisPraosParamD(_) => Tag::ConsensusGenesisPraosParamD,
+            ConfigParam::ConsensusGenesisPraosParamF(_) => Tag::ConsensusGenesisPraosParamF,
+        }
+    }
 }
 
 impl Readable for ConfigParam {
     fn read<'a>(buf: &mut ReadBuf<'a>) -> Result<Self, ReadError> {
         let taglen = TagLen(buf.get_u16()?);
         let bytes = buf.get_slice(taglen.get_len())?;
-        match taglen.get_tag() {
-            Block0Date::TAG => Block0Date::from_payload(bytes).map(ConfigParam::Block0Date),
-            Discrimination::TAG => {
-                Discrimination::from_payload(bytes).map(ConfigParam::Discrimination)
+        match taglen.get_tag().map_err(Into::into)? {
+            Tag::Block0Date => ConfigParamVariant::from_payload(bytes).map(ConfigParam::Block0Date),
+            Tag::Discrimination => {
+                ConfigParamVariant::from_payload(bytes).map(ConfigParam::Discrimination)
             }
-            ConsensusVersion::TAG => {
-                ConsensusVersion::from_payload(bytes).map(ConfigParam::ConsensusVersion)
+            Tag::ConsensusVersion => {
+                ConfigParamVariant::from_payload(bytes).map(ConfigParam::ConsensusVersion)
             }
-            _ => Err(Error::InvalidTag),
+            Tag::SlotsPerEpoch => {
+                ConfigParamVariant::from_payload(bytes).map(ConfigParam::SlotsPerEpoch)
+            }
+            Tag::SlotDuration => {
+                ConfigParamVariant::from_payload(bytes).map(ConfigParam::SlotDuration)
+            }
+            Tag::EpochStabilityDepth => {
+                ConfigParamVariant::from_payload(bytes).map(ConfigParam::EpochStabilityDepth)
+            }
+            Tag::ConsensusLeaderId => {
+                ConfigParamVariant::from_payload(bytes).map(ConfigParam::ConsensusLeaderId)
+            }
+            Tag::ConsensusGenesisPraosParamD => ConfigParamVariant::from_payload(bytes)
+                .map(ConfigParam::ConsensusGenesisPraosParamD),
+            Tag::ConsensusGenesisPraosParamF => ConfigParamVariant::from_payload(bytes)
+                .map(ConfigParam::ConsensusGenesisPraosParamF),
         }
         .map_err(Into::into)
     }
@@ -69,10 +129,17 @@ impl property::Serialize for ConfigParam {
     type Error = io::Error;
 
     fn serialize<W: Write>(&self, writer: W) -> Result<(), Self::Error> {
-        let (tag, bytes) = match self {
-            ConfigParam::Block0Date(data) => (Block0Date::TAG, data.to_payload()),
-            ConfigParam::Discrimination(data) => (Discrimination::TAG, data.to_payload()),
-            ConfigParam::ConsensusVersion(data) => (ConsensusVersion::TAG, data.to_payload()),
+        let tag = Tag::from(self);
+        let bytes = match self {
+            ConfigParam::Block0Date(data) => data.to_payload(),
+            ConfigParam::Discrimination(data) => data.to_payload(),
+            ConfigParam::ConsensusVersion(data) => data.to_payload(),
+            ConfigParam::SlotsPerEpoch(data) => data.to_payload(),
+            ConfigParam::SlotDuration(data) => data.to_payload(),
+            ConfigParam::EpochStabilityDepth(data) => data.to_payload(),
+            ConfigParam::ConsensusLeaderId(data) => data.to_payload(),
+            ConfigParam::ConsensusGenesisPraosParamD(data) => data.to_payload(),
+            ConfigParam::ConsensusGenesisPraosParamF(data) => data.to_payload(),
         };
         let taglen = TagLen::new(tag, bytes.len()).ok_or_else(|| {
             io::Error::new(
@@ -86,81 +153,22 @@ impl property::Serialize for ConfigParam {
     }
 }
 
-#[cfg(feature = "generic-serialization")]
-mod serde_impl {
-    use super::*;
-    use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
-
-    impl<'de> Deserialize<'de> for ConfigParam {
-        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-            let (tag, value) = <(String, String)>::deserialize(deserializer)?;
-            match &*tag {
-                Block0Date::NAME => Block0Date::from_cfg_str(&value).map(ConfigParam::Block0Date),
-                Discrimination::NAME => {
-                    Discrimination::from_cfg_str(&value).map(ConfigParam::Discrimination)
-                }
-                ConsensusVersion::NAME => {
-                    ConsensusVersion::from_cfg_str(&value).map(ConfigParam::ConsensusVersion)
-                }
-                _ => Err(Error::InvalidTag),
-            }
-            .map_err(D::Error::custom)
-        }
-    }
-
-    impl Serialize for ConfigParam {
-        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-            match self {
-                ConfigParam::Block0Date(data) => (Block0Date::NAME, data.to_cfg_string()),
-                ConfigParam::Discrimination(data) => (Discrimination::NAME, data.to_cfg_string()),
-                ConfigParam::ConsensusVersion(data) => {
-                    (ConsensusVersion::NAME, data.to_cfg_string())
-                }
-            }
-            .serialize(serializer)
-        }
-    }
-}
-
 trait ConfigParamVariant: Clone + Eq + PartialEq {
-    const TAG: Tag;
-    const NAME: &'static str;
-
     fn to_payload(&self) -> Vec<u8>;
-
     fn from_payload(payload: &[u8]) -> Result<Self, Error>;
-
-    fn to_cfg_string(&self) -> String;
-    fn from_cfg_str(s: &str) -> Result<Self, Error>;
 }
+
+/// Seconds elapsed since 1-Jan-1970 (unix time)
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct Block0Date(pub u64);
 
 impl ConfigParamVariant for Block0Date {
-    const TAG: Tag = Tag::new(1);
-    const NAME: &'static str = "block0-date";
-
     fn to_payload(&self) -> Vec<u8> {
-        let mut out = Vec::new();
-        out.extend_from_slice(&self.0.to_be_bytes());
-        out
+        self.0.to_payload()
     }
 
     fn from_payload(payload: &[u8]) -> Result<Self, Error> {
-        if payload.len() != 8 {
-            return Err(Error::SizeInvalid);
-        };
-        let mut bytes = [0u8; 8];
-        bytes.copy_from_slice(payload);
-        let v = u64::from_be_bytes(bytes);
-        Ok(Block0Date(v))
-    }
-
-    fn to_cfg_string(&self) -> String {
-        format!("{}", self.0).to_string()
-    }
-
-    fn from_cfg_str(s: &str) -> Result<Self, Error> {
-        let v = u64::from_str(s).map_err(|_| Error::UnknownString(s.to_string()))?;
-        Ok(Block0Date(v))
+        u64::from_payload(payload).map(Block0Date)
     }
 }
 
@@ -168,9 +176,6 @@ const VAL_PROD: u8 = 1;
 const VAL_TEST: u8 = 2;
 
 impl ConfigParamVariant for Discrimination {
-    const TAG: Tag = Tag::new(2);
-    const NAME: &'static str = "discrimination";
-
     fn to_payload(&self) -> Vec<u8> {
         match self {
             Discrimination::Production => vec![VAL_PROD],
@@ -188,27 +193,9 @@ impl ConfigParamVariant for Discrimination {
             _ => Err(Error::StructureInvalid),
         }
     }
-
-    fn to_cfg_string(&self) -> String {
-        match self {
-            Discrimination::Production => "production".to_string(),
-            Discrimination::Test => "test".to_string(),
-        }
-    }
-
-    fn from_cfg_str(s: &str) -> Result<Self, Error> {
-        match s {
-            "production" => Ok(Discrimination::Production),
-            "test" => Ok(Discrimination::Test),
-            _ => Err(Error::UnknownString(s.to_string())),
-        }
-    }
 }
 
 impl ConfigParamVariant for ConsensusVersion {
-    const TAG: Tag = Tag::new(3);
-    const NAME: &'static str = "block0-consensus";
-
     fn to_payload(&self) -> Vec<u8> {
         (*self as u16).to_be_bytes().to_vec()
     }
@@ -222,23 +209,70 @@ impl ConfigParamVariant for ConsensusVersion {
         let integer = u16::from_be_bytes(bytes);
         ConsensusVersion::from_u16(integer).ok_or(Error::StructureInvalid)
     }
+}
 
-    fn to_cfg_string(&self) -> String {
-        format!("{}", self)
+impl ConfigParamVariant for LeaderId {
+    fn to_payload(&self) -> Vec<u8> {
+        self.as_ref().to_vec()
     }
 
-    fn from_cfg_str(s: &str) -> Result<Self, Error> {
-        s.parse().map_err(|_| Error::UnknownString(s.to_string()))
+    fn from_payload(payload: &[u8]) -> Result<Self, Error> {
+        PublicKey::from_binary(payload)
+            .map(Into::into)
+            .map_err(|_| Error::SizeInvalid)
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-struct Tag(u16);
+impl ConfigParamVariant for u8 {
+    fn to_payload(&self) -> Vec<u8> {
+        vec![*self]
+    }
 
-impl Tag {
-    pub const fn new(tag: u16) -> Self {
-        // validate that it's less than 1024 when const fns support ifs
-        Tag(tag)
+    fn from_payload(payload: &[u8]) -> Result<Self, Error> {
+        match payload.len() {
+            1 => Ok(payload[0]),
+            _ => Err(Error::SizeInvalid),
+        }
+    }
+}
+
+impl ConfigParamVariant for u64 {
+    fn to_payload(&self) -> Vec<u8> {
+        self.to_be_bytes().to_vec()
+    }
+
+    fn from_payload(payload: &[u8]) -> Result<Self, Error> {
+        let mut bytes = Self::default().to_ne_bytes();
+        if payload.len() != bytes.len() {
+            return Err(Error::SizeInvalid);
+        };
+        bytes.copy_from_slice(payload);
+        Ok(Self::from_be_bytes(bytes))
+    }
+}
+
+impl ConfigParamVariant for u32 {
+    fn to_payload(&self) -> Vec<u8> {
+        self.to_be_bytes().to_vec()
+    }
+
+    fn from_payload(payload: &[u8]) -> Result<Self, Error> {
+        let mut bytes = Self::default().to_ne_bytes();
+        if payload.len() != bytes.len() {
+            return Err(Error::SizeInvalid);
+        };
+        bytes.copy_from_slice(payload);
+        Ok(Self::from_be_bytes(bytes))
+    }
+}
+
+impl ConfigParamVariant for Milli {
+    fn to_payload(&self) -> Vec<u8> {
+        self.into_millis().to_payload()
+    }
+
+    fn from_payload(payload: &[u8]) -> Result<Self, Error> {
+        u64::from_payload(payload).map(Milli::from_millis)
     }
 }
 
@@ -250,18 +284,18 @@ const MAXIMUM_LEN: usize = 64;
 impl TagLen {
     pub fn new(tag: Tag, len: usize) -> Option<Self> {
         if len < MAXIMUM_LEN {
-            Some(TagLen(tag.0 << 6 | len as u16))
+            Some(TagLen((tag as u16) << 6 | len as u16))
         } else {
             None
         }
     }
 
-    pub fn get_tag(self) -> Tag {
-        Tag::new(self.0 >> 6)
-    }
-
     pub fn get_len(self) -> usize {
         (self.0 & 0b11_1111) as usize
+    }
+
+    pub fn get_tag(self) -> Result<Tag, Error> {
+        FromPrimitive::from_u16(self.0 >> 6).ok_or(Error::InvalidTag)
     }
 }
 
@@ -269,13 +303,14 @@ impl TagLen {
 mod test {
     use super::*;
     use quickcheck::{Arbitrary, Gen, TestResult};
+    use strum::IntoEnumIterator;
 
     quickcheck! {
         fn tag_len_computation_correct(tag: Tag, len: usize) -> TestResult {
             let len = len % MAXIMUM_LEN;
             let tag_len = TagLen::new(tag, len).unwrap();
 
-            assert_eq!(tag, tag_len.get_tag(), "Invalid tag");
+            assert_eq!(Ok(tag), tag_len.get_tag(), "Invalid tag");
             assert_eq!(len, tag_len.get_len(), "Invalid len");
             TestResult::passed()
         }
@@ -283,7 +318,8 @@ mod test {
 
     impl Arbitrary for Tag {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
-            Tag::new(u16::arbitrary(g) % 1024)
+            let idx = usize::arbitrary(g) % Tag::iter().count();
+            Tag::iter().nth(idx).unwrap()
         }
     }
 
@@ -295,10 +331,15 @@ mod test {
 
     impl Arbitrary for ConfigParam {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
-            match u8::arbitrary(g) % 3 {
+            match u8::arbitrary(g) % 8 {
                 0 => ConfigParam::Block0Date(Arbitrary::arbitrary(g)),
                 1 => ConfigParam::Discrimination(Arbitrary::arbitrary(g)),
                 2 => ConfigParam::ConsensusVersion(Arbitrary::arbitrary(g)),
+                3 => ConfigParam::SlotsPerEpoch(Arbitrary::arbitrary(g)),
+                4 => ConfigParam::SlotDuration(Arbitrary::arbitrary(g)),
+                5 => ConfigParam::ConsensusLeaderId(Arbitrary::arbitrary(g)),
+                6 => ConfigParam::ConsensusGenesisPraosParamD(Arbitrary::arbitrary(g)),
+                7 => ConfigParam::ConsensusGenesisPraosParamF(Arbitrary::arbitrary(g)),
                 _ => unreachable!(),
             }
         }

--- a/chain-impl-mockchain/src/lib.rs
+++ b/chain-impl-mockchain/src/lib.rs
@@ -11,6 +11,7 @@ pub mod config;
 mod date;
 pub mod legacy;
 pub mod message;
+pub mod milli;
 // #[cfg(test)]
 // pub mod environment;
 pub mod error;

--- a/chain-impl-mockchain/src/milli.rs
+++ b/chain-impl-mockchain/src/milli.rs
@@ -1,0 +1,124 @@
+use std::str::FromStr;
+use std::{fmt, iter};
+
+const MILLI_MULTIPLIER: u64 = 1000;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Milli(u64);
+
+impl Milli {
+    pub fn from_millis(value: u64) -> Self {
+        Milli(value)
+    }
+
+    pub fn into_millis(self) -> u64 {
+        self.0
+    }
+}
+
+impl FromStr for Milli {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err("Input string empty".to_string());
+        }
+        let mut parts = s.splitn(2, '.');
+        let integrals_iter = parts.next().unwrap_or("").chars();
+        let millis_iter = parts
+            .next()
+            .unwrap_or("")
+            .chars()
+            .chain(iter::repeat('0'))
+            .take(3);
+        integrals_iter
+            .chain(millis_iter)
+            .collect::<String>()
+            .parse()
+            .map(Milli)
+            .map_err(|_| "Failed to parse milli".to_string())
+    }
+}
+
+impl fmt::Display for Milli {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "{}.{:0>3}",
+            self.0 / MILLI_MULTIPLIER,
+            self.0 % MILLI_MULTIPLIER
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quickcheck::{Arbitrary, Gen, TestResult};
+
+    fn assert_from_str(input: &str, expected_milli: u64) {
+        let expected = Milli::from_millis(expected_milli);
+
+        let result = Milli::from_str(input);
+
+        let actual = result.expect(&format!("Failed to parse for input {}", input));
+        assert_eq!(actual, expected, "Invalid result for input {}", input);
+    }
+
+    fn refute_from_str(input: &str) {
+        let result = Milli::from_str(input);
+
+        assert!(result.is_err(), "Parsing did not fail for input {}", input);
+    }
+
+    #[test]
+    fn from_str() {
+        refute_from_str("");
+        refute_from_str("X");
+        assert_from_str("0", 0);
+        assert_from_str("1", 1000);
+        assert_from_str(".", 0);
+        assert_from_str("1.", 1000);
+        assert_from_str(".1", 100);
+        assert_from_str(".100", 100);
+        assert_from_str(".001", 1);
+        assert_from_str(".0009", 0);
+        assert_from_str("0.1", 100);
+        assert_from_str("1.1", 1100);
+        refute_from_str("999999999999999999999999999999999");
+        refute_from_str("99999999999999999999999999999.999");
+        assert_from_str(".99999999999999999999999999999999", 999);
+    }
+
+    fn assert_display(milli: u64, expected: &str) {
+        let target = Milli::from_millis(milli);
+
+        let actual = target.to_string();
+
+        assert_eq!(actual, expected, "Invalid result for milli {}", milli);
+    }
+
+    #[test]
+    fn display() {
+        assert_display(0, "0.000");
+        assert_display(1, "0.001");
+        assert_display(100, "0.100");
+        assert_display(1000, "1.000");
+        assert_display(1001, "1.001");
+    }
+
+    quickcheck! {
+        fn milli_print_parse_cycle(milli: Milli) -> TestResult {
+            let result = milli.to_string().parse();
+
+            assert_eq!(result, Ok(milli));
+            TestResult::passed()
+        }
+    }
+
+    impl Arbitrary for Milli {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            Milli::from_millis(u64::arbitrary(g))
+        }
+    }
+}

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -254,13 +254,15 @@ impl Multiverse<Ledger> {
 
 #[cfg(test)]
 mod test {
-
     use super::Multiverse;
     use crate::block::{Block, BlockBuilder, ConsensusVersion};
-    use crate::config::ConfigParam;
+    use crate::config::{Block0Date, ConfigParam};
+    use crate::leadership::bft::LeaderId;
     use crate::ledger::Ledger;
     use crate::message::{InitialEnts, Message};
+    use chain_addr::Discrimination;
     use chain_core::property::{Block as _, ChainLength as _, HasMessages as _};
+    use chain_crypto::SecretKey;
     use chain_storage::store::BlockStore;
     use quickcheck::{Arbitrary, StdGen};
 
@@ -284,7 +286,13 @@ mod test {
 
         let mut genesis_block = BlockBuilder::new();
         let mut ents = InitialEnts::new();
+        ents.push(ConfigParam::Discrimination(Discrimination::Test));
         ents.push(ConfigParam::ConsensusVersion(ConsensusVersion::Bft));
+        let leader_pub_key = SecretKey::generate(rand::thread_rng()).to_public();
+        ents.push(ConfigParam::ConsensusLeaderId(LeaderId::from(
+            leader_pub_key,
+        )));
+        ents.push(ConfigParam::Block0Date(Block0Date(0)));
         genesis_block.message(Message::Initial(ents));
         let genesis_block = genesis_block.make_genesis_block();
         let genesis_state = Ledger::new(genesis_block.id(), genesis_block.messages()).unwrap();

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -169,7 +169,7 @@ pub struct Settings {
     pub allow_account_creation: bool,
     pub linear_fees: Arc<LinearFee>,
     pub slot_duration: u8,
-    pub epoch_stability_depth: usize,
+    pub epoch_stability_depth: u32,
 }
 
 pub const SLOTS_PERCENTAGE_RANGE: u8 = 100;
@@ -222,7 +222,7 @@ impl Settings {
             new_state.slot_duration = slot_duration;
         }
         if let Some(epoch_stability_depth) = update.epoch_stability_depth {
-            new_state.epoch_stability_depth = epoch_stability_depth as usize;
+            new_state.epoch_stability_depth = epoch_stability_depth;
         }
         new_state
     }


### PR DESCRIPTION
This adds functionality required by https://github.com/input-output-hk/rust-cardano/issues/610