### PR TITLE
Remove boxing and dynamic dispatch from traits featuring iterators

### DIFF
--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -161,22 +161,19 @@ pub trait Message: Serialize + Deserialize {
     fn id(&self) -> Self::Id;
 }
 
-/// Accessor to messages within a block
-pub trait HasMessages {
+/// Accessor to messages within a block.
+///
+/// This trait has a lifetime parameter and is normally implemented by
+/// reference types.
+pub trait HasMessages<'a> {
     /// The type of messages in this block.
-    type Message;
+    type Message: 'a + Message;
+
+    /// Iterator over block's messages.
+    type Messages: 'a + Iterator<Item = &'a Self::Message>;
 
     /// Returns an iterator over the messages in the block.
-    ///
-    /// Note that the iterator is dynamically allocated, and the iterator's
-    /// `next` method is invoked via dynamic dispatch. The method
-    /// `for_each_transaction` provides a statically monomorphised
-    /// alternative.
-    fn messages<'a>(&'a self) -> Box<Iterator<Item = &Self::Message> + 'a>;
-
-    fn for_each_message<F>(&self, f: F)
-    where
-        F: FnMut(&Self::Message);
+    fn messages(self) -> Self::Messages;
 }
 
 /// define a transaction within the blockchain. This transaction can be used

--- a/chain-impl-mockchain/src/block/mod.rs
+++ b/chain-impl-mockchain/src/block/mod.rs
@@ -4,6 +4,8 @@ use crate::message::{Message, MessageRaw};
 use chain_core::mempack::read_from_raw;
 use chain_core::property::{self, Serialize};
 
+use std::slice;
+
 mod builder;
 //mod cstruct;
 mod header;
@@ -159,17 +161,11 @@ impl property::Deserialize for Block {
     }
 }
 
-impl property::HasMessages for Block {
+impl<'a> property::HasMessages<'a> for &'a Block {
     type Message = Message;
-    fn messages<'a>(&'a self) -> Box<Iterator<Item = &Message> + 'a> {
-        Box::new(self.contents.iter())
-    }
-
-    fn for_each_message<F>(&self, mut f: F)
-    where
-        F: FnMut(&Self::Message),
-    {
-        self.contents.iter().for_each(|msg| f(msg))
+    type Messages = slice::Iter<'a, Message>;
+    fn messages(self) -> Self::Messages {
+        self.contents.0.iter()
     }
 }
 

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -13,6 +13,8 @@ use std::sync::Arc;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 
+use std::iter;
+
 #[derive(Clone, Debug)]
 pub struct UpdateState {
     // Note: we use a BTreeMap to ensure that proposals are processed
@@ -309,11 +311,10 @@ pub struct UpdateProposalWithProposer {
     pub proposer_id: UpdateVoterId,
 }
 
-impl HasPublicKeys for UpdateProposalWithProposer {
-    fn public_keys<'a>(
-        &'a self,
-    ) -> Box<ExactSizeIterator<Item = &PublicKey<Ed25519Extended>> + 'a> {
-        Box::new(std::iter::once(&self.proposer_id.0))
+impl<'a> HasPublicKeys<'a> for &'a UpdateProposalWithProposer {
+    type PublicKeys = iter::Once<&'a PublicKey<Ed25519Extended>>;
+    fn public_keys(self) -> Self::PublicKeys {
+        std::iter::once(&self.proposer_id.0)
     }
 }
 
@@ -390,11 +391,10 @@ pub struct UpdateVote {
     pub voter_id: UpdateVoterId,
 }
 
-impl HasPublicKeys for UpdateVote {
-    fn public_keys<'a>(
-        &'a self,
-    ) -> Box<ExactSizeIterator<Item = &PublicKey<Ed25519Extended>> + 'a> {
-        Box::new(std::iter::once(&self.voter_id.0))
+impl<'a> HasPublicKeys<'a> for &'a UpdateVote {
+    type PublicKeys = iter::Once<&'a PublicKey<Ed25519Extended>>;
+    fn public_keys(self) -> Self::PublicKeys {
+        std::iter::once(&self.voter_id.0)
     }
 }
 


### PR DESCRIPTION
Found another way to specify `HasMessages` that does not require allocations or dynamic dispatch.
An internal trait in mockchain that used boxed trait object has also been simplified to just return slice references.