### PR TITLE
network-grpc: URI path-and-query part is required

### DIFF
--- a/network-grpc/src/client/connect.rs
+++ b/network-grpc/src/client/connect.rs
@@ -74,6 +74,7 @@ where
                 match Uri::builder()
                     .scheme(origin.scheme.clone())
                     .authority(origin.authority.clone())
+                    .path_and_query("")
                     .build()
                 {
                     Ok(uri) => uri,


### PR DESCRIPTION
Fix a crash when connecting.