### PR TITLE
network: Add client method get_blocks

### DIFF
--- a/network-core/src/client/block.rs
+++ b/network-core/src/client/block.rs
@@ -44,6 +44,9 @@ pub trait BlockService: P2pService {
     /// implementation to produce a server-streamed response.
     type GetBlocksFuture: Future<Item = Self::GetBlocksStream, Error = Error>;
 
+    /// Retrieves the identified blocks in an asynchronous stream.
+    fn get_blocks(&mut self, ids: &[<Self::Block as Block>::Id]) -> Self::GetBlocksFuture;
+
     // The type of an asynchronous stream that provides block headers in
     // response to method `get_headers`.
     //type GetHeadersStream: Stream<Item = <Self::Block as Block>::Header, Error = Error>;

--- a/network-grpc/proto/node.proto
+++ b/network-grpc/proto/node.proto
@@ -15,13 +15,13 @@ message TipResponse {
 // Request to fetch the methods for blocks and headers.
 message BlockIds {
   // The identifiers of blocks for loading.
-  repeated bytes id = 1;
+  repeated bytes ids = 1;
 }
 
 // Request to fetch the methods for blocks and headers.
 message MessageIds {
   // The identifiers of blocks for loading.
-  repeated bytes id = 1;
+  repeated bytes ids = 1;
 }
 
 // Request message for method PullBlocksToTip.

--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -318,6 +318,13 @@ where
         ResponseStreamFuture::new(future)
     }
 
+    fn get_blocks(&mut self, ids: &[P::BlockId]) -> Self::GetBlocksFuture {
+        let ids = serialize_to_vec(ids).unwrap();
+        let req = gen::node::BlockIds { ids };
+        let future = self.service.get_blocks(Request::new(req));
+        ResponseStreamFuture::new(future)
+    }
+
     fn block_subscription<Out>(&mut self, outbound: Out) -> Self::BlockSubscriptionFuture
     where
         Out: Stream<Item = P::Header> + Send + 'static,

--- a/network-grpc/src/service.rs
+++ b/network-grpc/src/service.rs
@@ -356,7 +356,7 @@ where
 
     fn get_blocks(&mut self, req: Request<gen::node::BlockIds>) -> Self::GetBlocksFuture {
         let service = try_get_service!(self.inner.block_service());
-        let block_ids = match deserialize_vec(&req.get_ref().id) {
+        let block_ids = match deserialize_vec(&req.get_ref().ids) {
             Ok(block_ids) => block_ids,
             Err(e) => {
                 return ResponseFuture::error(error_into_grpc(e));
@@ -367,7 +367,7 @@ where
 
     fn get_headers(&mut self, req: Request<gen::node::BlockIds>) -> Self::GetHeadersFuture {
         let service = try_get_service!(self.inner.block_service());
-        let block_ids = match deserialize_vec(&req.get_ref().id) {
+        let block_ids = match deserialize_vec(&req.get_ref().ids) {
             Ok(block_ids) => block_ids,
             Err(e) => {
                 return ResponseFuture::error(error_into_grpc(e));
@@ -392,7 +392,7 @@ where
 
     fn get_messages(&mut self, req: Request<gen::node::MessageIds>) -> Self::GetMessagesFuture {
         let service = try_get_service!(self.inner.content_service());
-        let tx_ids = match deserialize_vec(&req.get_ref().id) {
+        let tx_ids = match deserialize_vec(&req.get_ref().ids) {
             Ok(tx_ids) => tx_ids,
             Err(e) => {
                 return ResponseFuture::error(error_into_grpc(e));

--- a/network-ntt/src/client.rs
+++ b/network-ntt/src/client.rs
@@ -198,6 +198,10 @@ where
         }
     }
 
+    fn get_blocks(&mut self, _ids: &[<Self::Block as Block>::Id]) -> Self::GetBlocksFuture {
+        unimplemented!()
+    }
+
     fn block_subscription<Out>(&mut self, _outbound: Out) -> Self::BlockSubscriptionFuture
     where
         Out: Stream<Item = T::Header>,


### PR DESCRIPTION
Needed to fetch the genesis block and later to implement block solicitation.