### PR TITLE
Basic update proposal handling

### DIFF
--- a/chain-impl-mockchain/src/certificate.rs
+++ b/chain-impl-mockchain/src/certificate.rs
@@ -2,12 +2,12 @@ use crate::key::SpendingSecretKey;
 use crate::stake::{StakeKeyId, StakePoolId, StakePoolInfo};
 use chain_core::mempack::{read_vec, ReadBuf, ReadError, Readable};
 use chain_core::property;
-use chain_crypto::{Ed25519Extended, SecretKey, Verification};
+use chain_crypto::{Ed25519Extended, PublicKey, SecretKey, Verification};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 
 #[derive(Debug, Clone)]
-pub struct SignatureRaw(Vec<u8>);
+pub struct SignatureRaw(pub Vec<u8>);
 
 impl property::Serialize for SignatureRaw {
     type Error = std::io::Error;
@@ -75,13 +75,17 @@ impl Certificate {
 
 /// Keep an information how to extract public keys from
 /// the certificate.
-trait HasStakeKeyIds {
-    fn public_keys<'a>(&'a self) -> Box<ExactSizeIterator<Item = &StakeKeyId> + 'a>;
+pub(crate) trait HasPublicKeys {
+    fn public_keys<'a>(&'a self)
+        -> Box<ExactSizeIterator<Item = &PublicKey<Ed25519Extended>> + 'a>;
 }
 
-fn verify_certificate<C>(certificate: &C, raw_signatures: &[SignatureRaw]) -> Verification
+pub(crate) fn verify_certificate<C>(
+    certificate: &C,
+    raw_signatures: &[SignatureRaw],
+) -> Verification
 where
-    C: HasStakeKeyIds + property::Serialize,
+    C: HasPublicKeys + property::Serialize,
 {
     use crate::key::{deserialize_signature, verify_signature};
     let signatures = raw_signatures.iter();
@@ -95,8 +99,7 @@ where
             let mut reader = ReadBuf::from(&signature.0);
             match deserialize_signature(&mut reader) {
                 Ok(signature) => {
-                    if verify_signature(&signature, &owner.0, &certificate) == Verification::Failed
-                    {
+                    if verify_signature(&signature, &owner, &certificate) == Verification::Failed {
                         return Verification::Failed;
                     }
                 }
@@ -202,9 +205,11 @@ impl StakeKeyRegistration {
     }
 }
 
-impl HasStakeKeyIds for StakeKeyRegistration {
-    fn public_keys<'a>(&'a self) -> Box<ExactSizeIterator<Item = &StakeKeyId> + 'a> {
-        Box::new(std::iter::once(&self.stake_key_id))
+impl HasPublicKeys for StakeKeyRegistration {
+    fn public_keys<'a>(
+        &'a self,
+    ) -> Box<ExactSizeIterator<Item = &PublicKey<Ed25519Extended>> + 'a> {
+        Box::new(std::iter::once(&self.stake_key_id.0))
     }
 }
 
@@ -238,9 +243,11 @@ impl StakeKeyDeregistration {
     }
 }
 
-impl HasStakeKeyIds for StakeKeyDeregistration {
-    fn public_keys<'a>(&'a self) -> Box<ExactSizeIterator<Item = &StakeKeyId> + 'a> {
-        Box::new(std::iter::once(&self.stake_key_id))
+impl HasPublicKeys for StakeKeyDeregistration {
+    fn public_keys<'a>(
+        &'a self,
+    ) -> Box<ExactSizeIterator<Item = &PublicKey<Ed25519Extended>> + 'a> {
+        Box::new(std::iter::once(&self.stake_key_id.0))
     }
 }
 
@@ -277,9 +284,11 @@ impl StakeDelegation {
     }
 }
 
-impl HasStakeKeyIds for StakeDelegation {
-    fn public_keys<'a>(&'a self) -> Box<ExactSizeIterator<Item = &StakeKeyId> + 'a> {
-        Box::new(std::iter::once(&self.stake_key_id))
+impl HasPublicKeys for StakeDelegation {
+    fn public_keys<'a>(
+        &'a self,
+    ) -> Box<ExactSizeIterator<Item = &PublicKey<Ed25519Extended>> + 'a> {
+        Box::new(std::iter::once(&self.stake_key_id.0))
     }
 }
 
@@ -312,9 +321,11 @@ impl StakePoolInfo {
     }
 }
 
-impl HasStakeKeyIds for StakePoolInfo {
-    fn public_keys<'a>(&'a self) -> Box<ExactSizeIterator<Item = &StakeKeyId> + 'a> {
-        Box::new(self.owners.iter())
+impl HasPublicKeys for StakePoolInfo {
+    fn public_keys<'a>(
+        &'a self,
+    ) -> Box<ExactSizeIterator<Item = &PublicKey<Ed25519Extended>> + 'a> {
+        Box::new(self.owners.iter().map(|x| &x.0))
     }
 }
 
@@ -334,9 +345,11 @@ impl StakePoolRetirement {
     }
 }
 
-impl HasStakeKeyIds for StakePoolRetirement {
-    fn public_keys<'a>(&'a self) -> Box<ExactSizeIterator<Item = &StakeKeyId> + 'a> {
-        Box::new(self.pool_info.owners.iter())
+impl HasPublicKeys for StakePoolRetirement {
+    fn public_keys<'a>(
+        &'a self,
+    ) -> Box<ExactSizeIterator<Item = &PublicKey<Ed25519Extended>> + 'a> {
+        Box::new(self.pool_info.owners.iter().map(|x| &x.0))
     }
 }
 

--- a/chain-impl-mockchain/src/ledger.rs
+++ b/chain-impl-mockchain/src/ledger.rs
@@ -221,10 +221,10 @@ impl Ledger {
 
         new_ledger.chain_length = self.chain_length.next();
 
-        // If we entered a new epoch, then delete expired update
-        // proposals and apply accepted update proposals.
-        // FIXME: do this at an epoch boundary; need to know current date.
-        let (updates, settings) = new_ledger.updates.process_proposals(new_ledger.settings);
+        let (updates, settings) =
+            new_ledger
+                .updates
+                .process_proposals(new_ledger.settings, new_ledger.date, date);
         new_ledger.updates = updates;
         new_ledger.settings = settings;
 
@@ -237,7 +237,7 @@ impl Ledger {
                 }
                 Message::UpdateProposal(update_proposal) => {
                     new_ledger =
-                        new_ledger.apply_update_proposal(content.id(), &update_proposal)?;
+                        new_ledger.apply_update_proposal(content.id(), &update_proposal, date)?;
                 }
                 Message::UpdateVote(vote) => {
                     new_ledger = new_ledger.apply_update_vote(&vote)?;
@@ -280,10 +280,11 @@ impl Ledger {
         mut self,
         proposal_id: setting::UpdateProposalId,
         proposal: &setting::SignedUpdateProposal,
+        cur_date: BlockDate,
     ) -> Result<Self, Error> {
-        self.updates = self
-            .updates
-            .apply_proposal(proposal_id, proposal, &self.settings)?;
+        self.updates =
+            self.updates
+                .apply_proposal(proposal_id, proposal, &self.settings, cur_date)?;
         Ok(self)
     }
 

--- a/chain-impl-mockchain/src/ledger.rs
+++ b/chain-impl-mockchain/src/ledger.rs
@@ -1,7 +1,7 @@
 //! Mockchain ledger. Ledger exists in order to update the
 //! current state and verify transactions.
 
-use crate::block::{ChainLength, ConsensusVersion, HeaderHash};
+use crate::block::{BlockDate, ChainLength, ConsensusVersion, HeaderHash};
 use crate::config::{self, Block0Date, ConfigParam};
 use crate::fee::LinearFee;
 use crate::leadership::bft::LeaderId;
@@ -46,6 +46,7 @@ pub struct Ledger {
     pub(crate) updates: setting::UpdateState,
     pub(crate) delegation: DelegationState,
     pub(crate) static_params: Arc<LedgerStaticParameters>,
+    pub(crate) date: BlockDate,
     pub(crate) chain_length: ChainLength,
 }
 
@@ -211,6 +212,7 @@ impl Ledger {
         &'a self,
         ledger_params: &LedgerParameters,
         contents: I,
+        date: BlockDate,
     ) -> Result<Self, Error>
     where
         I: IntoIterator<Item = &'a Message>,
@@ -246,6 +248,9 @@ impl Ledger {
                 }
             }
         }
+
+        new_ledger.date = date;
+
         Ok(new_ledger)
     }
 
@@ -659,6 +664,7 @@ impl EmptyLedgerBuilder {
             updates: setting::UpdateState::new(),
             delegation: DelegationState::new(),
             static_params: Arc::new(static_params),
+            date: BlockDate::first(),
             chain_length: ChainLength(0),
         })
     }

--- a/chain-impl-mockchain/src/ledger.rs
+++ b/chain-impl-mockchain/src/ledger.rs
@@ -176,8 +176,10 @@ impl Ledger {
                     // We assume here that the initial block contains
                     // a single update proposal with the initial
                     // settings, which we apply immediately without
-                    // requiring any votes.
-                    ledger = ledger.apply_update(&update_proposal)?;
+                    // requiring any votes. FIXME: check the
+                    // signature? Doesn't really matter, we have to
+                    // trust block 0 anyway.
+                    ledger = ledger.apply_update(&update_proposal.proposal.proposal)?;
                     ledger_params = ledger.get_ledger_parameters();
                 }
                 Message::UpdateVote(vote) => {
@@ -226,7 +228,7 @@ impl Ledger {
                 }
                 Message::UpdateProposal(update_proposal) => {
                     // FIXME
-                    new_ledger = new_ledger.apply_update(&update_proposal)?;
+                    new_ledger = new_ledger.apply_update(&update_proposal.proposal.proposal)?;
                 }
                 Message::UpdateVote(vote) => {
                     new_ledger = new_ledger.apply_update_vote(&vote)?;

--- a/chain-impl-mockchain/src/ledger.rs
+++ b/chain-impl-mockchain/src/ledger.rs
@@ -219,6 +219,13 @@ impl Ledger {
 
         new_ledger.chain_length = self.chain_length.next();
 
+        // If we entered a new epoch, then delete expired update
+        // proposals and apply accepted update proposals.
+        // FIXME: do this at an epoch boundary; need to know current date.
+        let (updates, settings) = new_ledger.updates.process_proposals(new_ledger.settings);
+        new_ledger.updates = updates;
+        new_ledger.settings = settings;
+
         for content in contents {
             match content {
                 Message::Initial(_) => return Err(Error::Block0OnlyMessageReceived),

--- a/chain-impl-mockchain/src/ledger.rs
+++ b/chain-impl-mockchain/src/ledger.rs
@@ -88,6 +88,7 @@ pub enum Error {
     ExpectingUtxoWitness,
     ExpectingInitialMessage,
     CertificateInvalidSignature,
+    Update(setting::Error),
 }
 
 impl From<utxo::Error> for Error {
@@ -111,6 +112,12 @@ impl From<DelegationError> for Error {
 impl From<config::Error> for Error {
     fn from(e: config::Error) -> Self {
         Error::Config(e)
+    }
+}
+
+impl From<setting::Error> for Error {
+    fn from(e: setting::Error) -> Self {
+        Error::Update(e)
     }
 }
 
@@ -222,7 +229,7 @@ impl Ledger {
                     new_ledger = new_ledger.apply_update(&update_proposal)?;
                 }
                 Message::UpdateVote(vote) => {
-                    // FIXME
+                    new_ledger = new_ledger.apply_update_vote(&vote)?;
                 }
                 Message::Certificate(authenticated_cert_tx) => {
                     new_ledger =
@@ -252,6 +259,11 @@ impl Ledger {
 
     pub fn apply_update(mut self, update: &setting::UpdateProposal) -> Result<Self, Error> {
         self.settings = self.settings.apply(update);
+        Ok(self)
+    }
+
+    pub fn apply_update_vote(mut self, vote: &setting::UpdateVote) -> Result<Self, Error> {
+        self.updates = self.updates.apply_vote(vote)?;
         Ok(self)
     }
 

--- a/chain-impl-mockchain/src/ledger.rs
+++ b/chain-impl-mockchain/src/ledger.rs
@@ -265,7 +265,7 @@ impl Ledger {
     }
 
     pub fn apply_update_vote(mut self, vote: &setting::SignedUpdateVote) -> Result<Self, Error> {
-        self.updates = self.updates.apply_vote(vote)?;
+        self.updates = self.updates.apply_vote(vote, &self.settings)?;
         Ok(self)
     }
 

--- a/chain-impl-mockchain/src/ledger.rs
+++ b/chain-impl-mockchain/src/ledger.rs
@@ -262,7 +262,7 @@ impl Ledger {
         Ok(self)
     }
 
-    pub fn apply_update_vote(mut self, vote: &setting::UpdateVote) -> Result<Self, Error> {
+    pub fn apply_update_vote(mut self, vote: &setting::SignedUpdateVote) -> Result<Self, Error> {
         self.updates = self.updates.apply_vote(vote)?;
         Ok(self)
     }

--- a/chain-impl-mockchain/src/message/mod.rs
+++ b/chain-impl-mockchain/src/message/mod.rs
@@ -24,7 +24,7 @@ pub enum Message {
     Transaction(AuthenticatedTransaction<Address, NoExtra>),
     Certificate(AuthenticatedTransaction<Address, certificate::Certificate>),
     UpdateProposal(setting::UpdateProposal),
-    UpdateVote(setting::UpdateVote),
+    UpdateVote(setting::SignedUpdateVote),
 }
 
 /// Tag enumeration of all known message
@@ -86,7 +86,9 @@ impl Message {
             Some(MessageTag::UpdateProposal) => {
                 setting::UpdateProposal::read(buf).map(Message::UpdateProposal)
             }
-            Some(MessageTag::UpdateVote) => setting::UpdateVote::read(buf).map(Message::UpdateVote),
+            Some(MessageTag::UpdateVote) => {
+                setting::SignedUpdateVote::read(buf).map(Message::UpdateVote)
+            }
             None => Err(ReadError::UnknownTag(tag as u32)),
         }
     }

--- a/chain-impl-mockchain/src/message/mod.rs
+++ b/chain-impl-mockchain/src/message/mod.rs
@@ -23,7 +23,7 @@ pub enum Message {
     OldUtxoDeclaration(legacy::UtxoDeclaration),
     Transaction(AuthenticatedTransaction<Address, NoExtra>),
     Certificate(AuthenticatedTransaction<Address, certificate::Certificate>),
-    UpdateProposal(setting::UpdateProposal),
+    UpdateProposal(setting::SignedUpdateProposal),
     UpdateVote(setting::SignedUpdateVote),
 }
 
@@ -84,7 +84,7 @@ impl Message {
                 AuthenticatedTransaction::read(buf).map(Message::Certificate)
             }
             Some(MessageTag::UpdateProposal) => {
-                setting::UpdateProposal::read(buf).map(Message::UpdateProposal)
+                setting::SignedUpdateProposal::read(buf).map(Message::UpdateProposal)
             }
             Some(MessageTag::UpdateVote) => {
                 setting::SignedUpdateVote::read(buf).map(Message::UpdateVote)

--- a/chain-impl-mockchain/src/message/mod.rs
+++ b/chain-impl-mockchain/src/message/mod.rs
@@ -23,7 +23,8 @@ pub enum Message {
     OldUtxoDeclaration(legacy::UtxoDeclaration),
     Transaction(AuthenticatedTransaction<Address, NoExtra>),
     Certificate(AuthenticatedTransaction<Address, certificate::Certificate>),
-    Update(setting::UpdateProposal),
+    UpdateProposal(setting::UpdateProposal),
+    UpdateVote(setting::UpdateVote),
 }
 
 /// Tag enumeration of all known message
@@ -33,7 +34,8 @@ pub(super) enum MessageTag {
     OldUtxoDeclaration = 1,
     Transaction = 2,
     Certificate = 3,
-    Update = 4,
+    UpdateProposal = 4,
+    UpdateVote = 5,
 }
 
 impl Message {
@@ -44,7 +46,8 @@ impl Message {
             Message::OldUtxoDeclaration(_) => MessageTag::OldUtxoDeclaration,
             Message::Transaction(_) => MessageTag::Transaction,
             Message::Certificate(_) => MessageTag::Certificate,
-            Message::Update(_) => MessageTag::Update,
+            Message::UpdateProposal(_) => MessageTag::UpdateProposal,
+            Message::UpdateVote(_) => MessageTag::UpdateVote,
         }
     }
 
@@ -60,7 +63,8 @@ impl Message {
             Message::OldUtxoDeclaration(s) => s.serialize(&mut codec).unwrap(),
             Message::Transaction(signed) => signed.serialize(&mut codec).unwrap(),
             Message::Certificate(signed) => signed.serialize(&mut codec).unwrap(),
-            Message::Update(proposal) => proposal.serialize(&mut codec).unwrap(),
+            Message::UpdateProposal(proposal) => proposal.serialize(&mut codec).unwrap(),
+            Message::UpdateVote(vote) => vote.serialize(&mut codec).unwrap(),
         }
         MessageRaw(codec.into_inner())
     }
@@ -79,7 +83,10 @@ impl Message {
             Some(MessageTag::Certificate) => {
                 AuthenticatedTransaction::read(buf).map(Message::Certificate)
             }
-            Some(MessageTag::Update) => setting::UpdateProposal::read(buf).map(Message::Update),
+            Some(MessageTag::UpdateProposal) => {
+                setting::UpdateProposal::read(buf).map(Message::UpdateProposal)
+            }
+            Some(MessageTag::UpdateVote) => setting::UpdateVote::read(buf).map(Message::UpdateVote),
             None => Err(ReadError::UnknownTag(tag as u32)),
         }
     }
@@ -117,12 +124,13 @@ mod test {
 
     impl Arbitrary for Message {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
-            match g.next_u32() % 5 {
+            match g.next_u32() % 6 {
                 0 => Message::Initial(Arbitrary::arbitrary(g)),
                 1 => Message::OldUtxoDeclaration(Arbitrary::arbitrary(g)),
                 2 => Message::Transaction(Arbitrary::arbitrary(g)),
                 3 => Message::Certificate(Arbitrary::arbitrary(g)),
-                _ => Message::Update(Arbitrary::arbitrary(g)),
+                4 => Message::UpdateProposal(Arbitrary::arbitrary(g)),
+                _ => Message::UpdateVote(Arbitrary::arbitrary(g)),
             }
         }
     }

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -8,7 +8,7 @@
 
 use crate::block::ChainLength;
 use crate::ledger::Ledger;
-use chain_core::property::{BlockId as _, HasMessages as _};
+use chain_core::property::{Block as _, BlockId as _, HasMessages as _};
 use chain_storage::store::BlockStore;
 use std::collections::{hash_map::Entry, BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, RwLock};
@@ -243,7 +243,11 @@ impl Multiverse<Ledger> {
         for hash in blocks_to_apply.iter().rev() {
             let block = store.get_block(&hash).unwrap().0;
             state = state
-                .apply_block(&state.get_ledger_parameters(), block.messages())
+                .apply_block(
+                    &state.get_ledger_parameters(),
+                    block.messages(),
+                    block.date(),
+                )
                 .unwrap();
             // FIXME: add the intermediate states to memory?
         }
@@ -271,7 +275,11 @@ mod test {
             assert_eq!(state.chain_length().0 + 1, block.chain_length().0);
         }
         state
-            .apply_block(&state.get_ledger_parameters(), block.messages())
+            .apply_block(
+                &state.get_ledger_parameters(),
+                block.messages(),
+                block.date(),
+            )
             .unwrap()
     }
 

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -229,7 +229,7 @@ impl Multiverse<Ledger> {
             }
 
             let cur_block_info = store.get_block_info(&cur_hash).unwrap();
-            blocks_to_apply.push(k.clone());
+            blocks_to_apply.push(cur_hash.clone());
             cur_hash = cur_block_info.parent_id();
         };
 

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -248,6 +248,7 @@ impl Multiverse<Ledger> {
                     &state.get_ledger_parameters(),
                     block.messages(),
                     block.date(),
+                    block.chain_length(),
                 )
                 .unwrap();
             // FIXME: add the intermediate states to memory?
@@ -280,6 +281,7 @@ mod test {
                 &state.get_ledger_parameters(),
                 block.messages(),
                 block.date(),
+                block.chain_length(),
             )
             .unwrap()
     }

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -235,8 +235,9 @@ impl Multiverse<Ledger> {
 
         /*
         println!(
-            "applying {} blocks to reconstruct state",
-            blocks_to_apply.len()
+            "applying {} blocks to reconstruct state at {}",
+            blocks_to_apply.len(),
+            k
         );
         */
 
@@ -303,6 +304,7 @@ mod test {
         ents.push(ConfigParam::Block0Date(Block0Date(0)));
         genesis_block.message(Message::Initial(ents));
         let genesis_block = genesis_block.make_genesis_block();
+        let mut date = genesis_block.date();
         let genesis_state = Ledger::new(genesis_block.id(), genesis_block.messages()).unwrap();
         assert_eq!(genesis_state.chain_length().0, 0);
         store.put_block(&genesis_block).unwrap();
@@ -316,9 +318,12 @@ mod test {
             let mut block = BlockBuilder::new();
             block.chain_length(state.chain_length.next());
             block.parent(parent);
+            date = date.next();
+            block.date(date);
             let block = block.make_bft_block(&leader_key);
             state = apply_block(&state, &block);
             assert_eq!(state.chain_length().0, i);
+            assert_eq!(state.date, block.date());
             store.put_block(&block).unwrap();
             _root = Some(multiverse.add(block.id(), state.clone()));
             multiverse.gc();

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -502,7 +502,7 @@ mod test {
 
     impl Arbitrary for UpdateProposal {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
-            UpdateProposal {
+            Self {
                 max_number_of_transactions_per_block: Arbitrary::arbitrary(g),
                 bootstrap_key_slots_percentage: Arbitrary::arbitrary(g),
                 consensus_version: Arbitrary::arbitrary(g),
@@ -515,10 +515,38 @@ mod test {
         }
     }
 
+    impl Arbitrary for UpdateProposalWithProposer {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            Self {
+                proposal: Arbitrary::arbitrary(g),
+                proposer_id: Arbitrary::arbitrary(g),
+            }
+        }
+    }
+
+    impl Arbitrary for SignedUpdateProposal {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            Self {
+                proposal: Arbitrary::arbitrary(g),
+                signature: Arbitrary::arbitrary(g),
+            }
+        }
+    }
+
     impl Arbitrary for UpdateVote {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
-            UpdateVote {
+            Self {
                 proposal_id: Arbitrary::arbitrary(g),
+                voter_id: Arbitrary::arbitrary(g),
+            }
+        }
+    }
+
+    impl Arbitrary for SignedUpdateVote {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            Self {
+                vote: Arbitrary::arbitrary(g),
+                signature: Arbitrary::arbitrary(g),
             }
         }
     }


### PR DESCRIPTION
Changes of note:

* Update proposals now need to be signed by a BFT leader.

* Adds a `UpdateVote` message type that must be signed by a BFT leader and registers a positive vote for a proposal. Proposal IDs are the message ID of the `UpdateProposal`.

* When proposals reach a majority, they become active at the start of the next epoch. (This should be changed.) If they don't get a majority after `Setting::proposal_expiration` epochs, they're expired.

* `Ledger::apply_block()` now checks the date and chain length of the incoming block.

* Fixes a critical bug in `Multiverse::get_from_storage()`.