### PR TITLE
Redistribute the block's fee to the account

### DIFF
--- a/chain-impl-mockchain/src/account.rs
+++ b/chain-impl-mockchain/src/account.rs
@@ -173,6 +173,12 @@ impl Ledger {
             .map_err(|e| e.into())
     }
 
+    /// check if an account already exits
+    #[inline]
+    pub fn exists(&self, account: &Identifier) -> bool {
+        self.0.contains_key(account)
+    }
+
     /// Remove an account from this ledger
     ///
     /// If the account still have value > 0, then error

--- a/chain-impl-mockchain/src/block/header.rs
+++ b/chain-impl-mockchain/src/block/header.rs
@@ -135,8 +135,17 @@ impl Header {
         HeaderHash::hash_bytes(&bytes[..])
     }
 
+    #[inline]
     pub fn proof(&self) -> &Proof {
         &self.proof
+    }
+
+    #[inline]
+    pub fn get_stakepool_id(&self) -> Option<&StakePoolId> {
+        match self.proof() {
+            Proof::GenesisPraos(proof) => Some(&proof.node_id),
+            _ => None,
+        }
     }
 }
 

--- a/chain-impl-mockchain/src/ledger.rs
+++ b/chain-impl-mockchain/src/ledger.rs
@@ -367,7 +367,12 @@ impl Ledger {
             CertificateApplyOutput::None => {}
             CertificateApplyOutput::CreateAccount(stake_key_id) => {
                 let account = stake_key_id.0.clone().into();
-                self.accounts = self.accounts.add_account(&account, Value::zero())?;
+                if !self.accounts.exists(&account) {
+                    self.accounts = self.accounts.add_account(&account, Value::zero())?;
+                } else {
+                    // it is possible the account already exists, in this case
+                    // we don't need to do anything
+                }
             }
         }
         Ok(())

--- a/chain-impl-mockchain/src/ledger.rs
+++ b/chain-impl-mockchain/src/ledger.rs
@@ -258,10 +258,10 @@ impl Ledger {
             });
         }
 
-        if date <= self.date {
+        if date <= new_ledger.date {
             return Err(Error::NonMonotonicDate {
                 block_date: date,
-                chain_date: self.date,
+                chain_date: new_ledger.date,
             });
         }
 

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -247,6 +247,7 @@ impl Multiverse<Ledger> {
                 .apply_block(
                     &state.get_ledger_parameters(),
                     block.messages(),
+                    block.header.get_stakepool_id(),
                     block.date(),
                     block.chain_length(),
                 )
@@ -280,6 +281,7 @@ mod test {
             .apply_block(
                 &state.get_ledger_parameters(),
                 block.messages(),
+                block.header.get_stakepool_id(),
                 block.date(),
                 block.chain_length(),
             )

--- a/chain-impl-mockchain/src/stake/delegation.rs
+++ b/chain-impl-mockchain/src/stake/delegation.rs
@@ -209,7 +209,8 @@ impl DelegationState {
                 output = CertificateApplyOutput::CreateAccount(reg.stake_key_id.clone());
             }
             CertificateContent::StakeKeyDeregistration(ref reg) => {
-                new_state = new_state.deregister_stake_key(&reg.stake_key_id)?
+                new_state = new_state.deregister_stake_key(&reg.stake_key_id)?;
+                // don't delete account
             }
             CertificateContent::StakePoolRegistration(ref reg) => {
                 new_state = new_state.register_stake_pool(reg.clone())?

--- a/chain-impl-mockchain/src/stake/distribution.rs
+++ b/chain-impl-mockchain/src/stake/distribution.rs
@@ -39,6 +39,10 @@ impl StakeDistribution {
         self.0.get(poolid).map(|psd| psd.total_stake)
     }
 
+    pub fn get_distribution(&self, stake_pool_id: &StakePoolId) -> Option<&PoolStakeDistribution> {
+        self.0.get(stake_pool_id)
+    }
+
     /// Place the stake pools on the interval [0, total_stake) (sorted
     /// by ID), then return the ID of the one containing 'point'
     /// (which must be in the interval). This is used to randomly

--- a/chain-impl-mockchain/src/value.rs
+++ b/chain-impl-mockchain/src/value.rs
@@ -18,6 +18,22 @@ impl Value {
     {
         values.fold(Ok(Value::zero()), |acc, v| acc? + v)
     }
+
+    #[inline]
+    pub fn checked_add(self, other: Self) -> Result<Self, ValueError> {
+        self.0
+            .checked_add(other.0)
+            .map(Value)
+            .ok_or(ValueError::Overflow)
+    }
+
+    #[inline]
+    pub fn checked_sub(self, other: Value) -> Result<Value, ValueError> {
+        self.0
+            .checked_sub(other.0)
+            .map(Value)
+            .ok_or(ValueError::NegativeAmount)
+    }
 }
 
 custom_error! {
@@ -31,10 +47,7 @@ impl ops::Add for Value {
     type Output = Result<Value, ValueError>;
 
     fn add(self, other: Value) -> Self::Output {
-        self.0
-            .checked_add(other.0)
-            .map(Value)
-            .ok_or(ValueError::Overflow)
+        self.checked_add(other)
     }
 }
 
@@ -42,10 +55,7 @@ impl ops::Sub for Value {
     type Output = Result<Value, ValueError>;
 
     fn sub(self, other: Value) -> Self::Output {
-        self.0
-            .checked_sub(other.0)
-            .map(Value)
-            .ok_or(ValueError::NegativeAmount)
+        self.checked_sub(other)
     }
 }
 

--- a/imhamt/src/operation.rs
+++ b/imhamt/src/operation.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InsertError {
     EntryExists,
 }
@@ -18,4 +18,10 @@ pub enum UpdateError<T> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReplaceError {
     KeyNotFound,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InsertOrUpdateError<T> {
+    Insert(InsertError),
+    Update(UpdateError<T>),
 }


### PR DESCRIPTION
redistribute the reward to the delegatees of the stake pool (only work for genesis for now).
We currently redistribute the same rewards to every delegatees, independently of the amount delegated (this will need refinement).

possible improvement is to make the reward state generic (so not only stake pool gets reward but other models too -- OBFT Nodes?);

relates to #427 