### PR TITLE
Replace Codec::from with Codec::new

### DIFF
--- a/chain-addr/src/lib.rs
+++ b/chain-addr/src/lib.rs
@@ -341,7 +341,7 @@ impl PropertySerialize for Address {
     fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
         use chain_core::packer::*;
         use std::io::Write;
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
 
         let first_byte = match self.0 {
             Discrimination::Production => self.to_kind_value(),
@@ -372,7 +372,7 @@ impl property::Deserialize for Address {
     fn deserialize<R: std::io::BufRead>(reader: R) -> Result<Self, Self::Error> {
         use chain_core::packer::*;
         use std::io::Read;
-        let mut codec = Codec::from(reader);
+        let mut codec = Codec::new(reader);
         // is_valid_data(bytes)?;
 
         let byte = codec.get_u8()?;

--- a/chain-core/src/packer.rs
+++ b/chain-core/src/packer.rs
@@ -7,6 +7,10 @@ const INITIAL_BUFFERED_CAPACITY: usize = 2048;
 
 pub struct Codec<I>(I);
 impl<I> Codec<I> {
+    pub fn new(inner: I) -> Self {
+        Codec(inner)
+    }
+
     pub fn into_inner(self) -> I {
         self.0
     }
@@ -169,12 +173,6 @@ impl<W: std::io::Write> std::io::Write for Buffered<W> {
     #[inline]
     fn flush(&mut self) -> std::io::Result<()> {
         self.1.flush()
-    }
-}
-impl<I> From<I> for Codec<I> {
-    #[inline]
-    fn from(inner: I) -> Self {
-        Codec(inner)
     }
 }
 impl<I: std::io::Write> std::ops::Deref for Buffered<I> {

--- a/chain-impl-mockchain/src/block/header.rs
+++ b/chain-impl-mockchain/src/block/header.rs
@@ -162,7 +162,7 @@ impl property::Serialize for Common {
         use chain_core::packer::Codec;
         use std::io::Write;
 
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
 
         codec.put_u16(self.any_block_version.into())?;
         codec.put_u32(self.block_content_size)?;

--- a/chain-impl-mockchain/src/block/headerraw.rs
+++ b/chain-impl-mockchain/src/block/headerraw.rs
@@ -17,7 +17,7 @@ impl property::Serialize for HeaderRaw {
         use chain_core::packer::*;
         use std::io::Write;
 
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
         //dbg!(self.0.len());
         codec.put_u16(self.0.len() as u16)?;
         codec.write_all(&self.0)?;
@@ -32,7 +32,7 @@ impl property::Deserialize for HeaderRaw {
         use chain_core::packer::Codec;
         use std::io::Read;
 
-        let mut codec = Codec::from(reader);
+        let mut codec = Codec::new(reader);
 
         let header_size = codec.get_u16()? as usize;
         //dbg!(header_size);

--- a/chain-impl-mockchain/src/certificate.rs
+++ b/chain-impl-mockchain/src/certificate.rs
@@ -15,7 +15,7 @@ impl property::Serialize for SignatureRaw {
     type Error = std::io::Error;
     fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
         use chain_core::packer::*;
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
         codec.put_u16(self.0.len() as u16)?;
         codec.into_inner().write_all(&self.0.as_ref())?;
         Ok(())
@@ -134,7 +134,7 @@ impl property::Serialize for Certificate {
     type Error = std::io::Error;
     fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
         use chain_core::packer::*;
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
         match &self.content {
             CertificateContent::StakeKeyRegistration(s) => {
                 codec.put_u8(CertificateTag::StakeKeyRegistration as u8)?;
@@ -220,7 +220,7 @@ impl property::Serialize for StakeKeyRegistration {
     type Error = std::io::Error;
     fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
         use chain_core::packer::*;
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
         self.stake_key_id.serialize(&mut codec)?;
         Ok(())
     }
@@ -258,7 +258,7 @@ impl property::Serialize for StakeKeyDeregistration {
     type Error = std::io::Error;
     fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
         use chain_core::packer::*;
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
         self.stake_key_id.serialize(&mut codec)?;
         Ok(())
     }
@@ -299,7 +299,7 @@ impl property::Serialize for StakeDelegation {
     type Error = std::io::Error;
     fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
         use chain_core::packer::*;
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
         self.stake_key_id.serialize(&mut codec)?;
         self.pool_id.serialize(&mut codec)?;
         Ok(())
@@ -366,7 +366,7 @@ impl property::Serialize for StakePoolRetirement {
     type Error = std::io::Error;
     fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
         use chain_core::packer::*;
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
         self.pool_id.serialize(&mut codec)?;
         self.pool_info.serialize(&mut codec)?;
         Ok(())

--- a/chain-impl-mockchain/src/config.rs
+++ b/chain-impl-mockchain/src/config.rs
@@ -147,7 +147,7 @@ impl property::Serialize for ConfigParam {
                 "initial ent payload too big".to_string(),
             )
         })?;
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
         codec.put_u16(taglen.0)?;
         codec.write_all(&bytes)
     }

--- a/chain-impl-mockchain/src/legacy.rs
+++ b/chain-impl-mockchain/src/legacy.rs
@@ -66,7 +66,7 @@ impl property::Serialize for UtxoDeclaration {
 
         assert!(self.addrs.len() < 255);
 
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
         codec.put_u8(self.addrs.len() as u8)?;
         for (b, v) in &self.addrs {
             v.serialize(&mut codec)?;

--- a/chain-impl-mockchain/src/message/mod.rs
+++ b/chain-impl-mockchain/src/message/mod.rs
@@ -56,7 +56,7 @@ impl Message {
         use chain_core::packer::*;
         use chain_core::property::Serialize;
         let v = Vec::new();
-        let mut codec = Codec::from(v);
+        let mut codec = Codec::new(v);
         codec.put_u8(self.get_tag() as u8).unwrap();
         match self {
             Message::Initial(i) => i.serialize(&mut codec).unwrap(),

--- a/chain-impl-mockchain/src/message/raw.rs
+++ b/chain-impl-mockchain/src/message/raw.rs
@@ -28,7 +28,7 @@ impl property::Deserialize for MessageRaw {
     type Error = std::io::Error;
     fn deserialize<R: std::io::BufRead>(reader: R) -> Result<Self, Self::Error> {
         use chain_core::packer::*;
-        let mut codec = Codec::from(reader);
+        let mut codec = Codec::new(reader);
         let size = codec.get_u16()?;
         let mut v = vec![0u8; size as usize];
         codec.into_inner().read_exact(&mut v)?;
@@ -41,7 +41,7 @@ impl property::Serialize for MessageRaw {
     fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
         use chain_core::packer::*;
 
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
         codec.put_u16(self.0.len() as u16)?;
         codec.into_inner().write_all(&self.0)?;
         Ok(())

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -199,7 +199,7 @@ impl property::Serialize for UpdateProposal {
     type Error = std::io::Error;
     fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
         use chain_core::packer::*;
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
         if let Some(max_number_of_transactions_per_block) =
             self.max_number_of_transactions_per_block
         {
@@ -322,7 +322,7 @@ impl property::Serialize for UpdateProposalWithProposer {
     type Error = std::io::Error;
     fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
         use chain_core::packer::*;
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
         self.proposal.serialize(&mut codec)?;
         self.proposer_id.serialize(&mut codec)?;
         Ok(())
@@ -368,7 +368,7 @@ impl property::Serialize for SignedUpdateProposal {
     type Error = std::io::Error;
     fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
         use chain_core::packer::*;
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
         self.proposal.serialize(&mut codec)?;
         self.signature.serialize(&mut codec)?;
         Ok(())
@@ -402,7 +402,7 @@ impl property::Serialize for UpdateVote {
     type Error = std::io::Error;
     fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
         use chain_core::packer::*;
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
         self.proposal_id.serialize(&mut codec)?;
         self.voter_id.serialize(&mut codec)?;
         Ok(())
@@ -441,7 +441,7 @@ impl property::Serialize for SignedUpdateVote {
     type Error = std::io::Error;
     fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
         use chain_core::packer::*;
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
         self.vote.serialize(&mut codec)?;
         self.signature.serialize(&mut codec)?;
         Ok(())

--- a/chain-impl-mockchain/src/stake/role.rs
+++ b/chain-impl-mockchain/src/stake/role.rs
@@ -101,7 +101,7 @@ impl property::Serialize for StakePoolInfo {
 
         use chain_core::packer::Codec;
 
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
         codec.put_u128(self.serial)?;
         codec.put_u8(self.owners.len() as u8)?;
         for o in &self.owners {

--- a/chain-impl-mockchain/src/transaction/transaction.rs
+++ b/chain-impl-mockchain/src/transaction/transaction.rs
@@ -85,7 +85,7 @@ impl<Extra: property::Serialize> Transaction<Address, Extra> {
         use chain_core::packer::*;
         use chain_core::property::Serialize;
 
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
         for input in self.inputs.iter() {
             input.serialize(&mut codec)?;
         }
@@ -103,7 +103,7 @@ impl<Extra: property::Serialize> Transaction<Address, Extra> {
         assert!(self.inputs.len() < 255);
         assert!(self.outputs.len() < 255);
 
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
 
         // store the number of inputs and outputs
         codec.put_u8(self.inputs.len() as u8)?;
@@ -127,7 +127,7 @@ impl<Extra: property::Deserialize> Transaction<Address, Extra> {
     ) -> Result<Self, Extra::Error> {
         use chain_core::packer::*;
         use chain_core::property::Deserialize as _;
-        let mut codec = Codec::from(reader);
+        let mut codec = Codec::new(reader);
 
         let mut inputs = Vec::with_capacity(num_inputs);
         let mut outputs = Vec::with_capacity(num_outputs);
@@ -154,7 +154,7 @@ impl<Extra: property::Deserialize> Transaction<Address, Extra> {
     pub fn deserialize_with_header<R: std::io::BufRead>(reader: R) -> Result<Self, Extra::Error> {
         use chain_core::packer::*;
 
-        let mut codec = Codec::from(reader);
+        let mut codec = Codec::new(reader);
 
         let num_inputs = codec.get_u8()? as usize;
         let num_outputs = codec.get_u8()? as usize;

--- a/chain-impl-mockchain/src/transaction/transfer.rs
+++ b/chain-impl-mockchain/src/transaction/transfer.rs
@@ -88,7 +88,7 @@ impl property::Serialize for Input {
     fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
         use chain_core::packer::*;
 
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
         codec.put_u8(self.index_or_account)?;
         self.value.serialize(&mut codec)?;
         codec.into_inner().write_all(&self.input_ptr)?;
@@ -102,7 +102,7 @@ impl property::Deserialize for Input {
     fn deserialize<R: std::io::BufRead>(reader: R) -> Result<Self, Self::Error> {
         use chain_core::packer::*;
 
-        let mut codec = Codec::from(reader);
+        let mut codec = Codec::new(reader);
         let index_or_account = codec.get_u8()?;
         let value = Value::deserialize(&mut codec)?;
         let mut input_ptr = [0; INPUT_PTR_SIZE];

--- a/chain-impl-mockchain/src/transaction/witness.rs
+++ b/chain-impl-mockchain/src/transaction/witness.rs
@@ -132,7 +132,7 @@ impl property::Serialize for Witness {
         use chain_core::packer::*;
         //use chain_core::property::Serialize;
 
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
         match self {
             Witness::OldUtxo(xpub, sig) => {
                 codec.put_u8(WITNESS_TAG_OLDUTXO)?;

--- a/chain-impl-mockchain/src/value.rs
+++ b/chain-impl-mockchain/src/value.rs
@@ -70,7 +70,7 @@ impl property::Deserialize for Value {
 
     fn deserialize<R: std::io::BufRead>(reader: R) -> Result<Self, Self::Error> {
         use chain_core::packer::*;
-        let mut codec = Codec::from(reader);
+        let mut codec = Codec::new(reader);
         codec.get_u64().map(Value)
     }
 }
@@ -84,7 +84,7 @@ impl property::Serialize for Value {
     type Error = std::io::Error;
     fn serialize<W: std::io::Write>(&self, writer: W) -> Result<(), Self::Error> {
         use chain_core::packer::*;
-        let mut codec = Codec::from(writer);
+        let mut codec = Codec::new(writer);
         codec.put_u64(self.0)
     }
 }


### PR DESCRIPTION
A blanket `From` impl from anything is weird and might result in unintended usage. It's better to have an intrinsic constructor method like so many other wrapper types do.