### PR TITLE
Replace trait Deserialize with trait Readable in network protocols

### DIFF
--- a/chain-core/src/mempack.rs
+++ b/chain-core/src/mempack.rs
@@ -165,10 +165,8 @@ impl<'a> ReadBuf<'a> {
     }
 }
 
-pub trait Readable {
-    fn read<'a>(buf: &mut ReadBuf<'a>) -> Result<Self, ReadError>
-    where
-        Self: Sized;
+pub trait Readable: Sized {
+    fn read<'a>(buf: &mut ReadBuf<'a>) -> Result<Self, ReadError>;
 }
 
 macro_rules! read_prim_impl {

--- a/chain-core/src/property.rs
+++ b/chain-core/src/property.rs
@@ -52,7 +52,7 @@ pub trait ChainLength: Eq + Ord + Clone + Debug {
 pub trait TransactionId: Eq + Hash + Debug {}
 
 /// Trait identifying the block header type.
-pub trait Header: Serialize + Deserialize {
+pub trait Header: Serialize {
     /// The block header id.
     type Id: BlockId;
 

--- a/chain-impl-mockchain/src/block/header.rs
+++ b/chain-impl-mockchain/src/block/header.rs
@@ -268,14 +268,6 @@ impl Readable for Header {
     }
 }
 
-impl property::Deserialize for Header {
-    type Error = std::io::Error;
-    fn deserialize<R: std::io::BufRead>(reader: R) -> Result<Self, Self::Error> {
-        let raw = HeaderRaw::deserialize(reader)?;
-        read_from_raw(raw.as_ref())
-    }
-}
-
 impl property::Header for Header {
     type Id = HeaderHash;
     type Date = BlockDate;

--- a/network-core/src/gossip.rs
+++ b/network-core/src/gossip.rs
@@ -1,4 +1,4 @@
-use chain_core::property::{Deserialize, Serialize};
+use chain_core::{mempack, property};
 
 use std::{
     iter::{DoubleEndedIterator, FromIterator, FusedIterator},
@@ -7,10 +7,10 @@ use std::{
 };
 
 /// Marker trait for the type representing a node ID.
-pub trait NodeId: Clone + Serialize + Deserialize {}
+pub trait NodeId: Clone + property::Serialize + mempack::Readable {}
 
 /// Abstract trait for data types representing gossip about network nodes.
-pub trait Node: Serialize + Deserialize {
+pub trait Node: property::Serialize + mempack::Readable {
     /// Type that represents the node identifier in the gossip message.
     type Id: NodeId;
 

--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -3,7 +3,10 @@
 use super::P2pService;
 use crate::error::Error;
 
-use chain_core::property::{Block, BlockDate, BlockId, Deserialize, HasHeader, Header, Serialize};
+use chain_core::{
+    mempack,
+    property::{Block, BlockDate, BlockId, HasHeader, Header, Serialize},
+};
 
 use futures::prelude::*;
 
@@ -11,7 +14,7 @@ use futures::prelude::*;
 /// providing access to block data.
 pub trait BlockService: P2pService {
     /// The block identifier type for the blockchain.
-    type BlockId: BlockId + Serialize + Deserialize;
+    type BlockId: BlockId + Serialize + mempack::Readable;
 
     /// The block date type for the blockchain.
     type BlockDate: BlockDate + ToString;
@@ -20,7 +23,7 @@ pub trait BlockService: P2pService {
     type Block: Block<Id = Self::BlockId, Date = Self::BlockDate> + HasHeader<Header = Self::Header>;
 
     /// The type representing metadata header of a block.
-    type Header: Header<Id = Self::BlockId, Date = Self::BlockDate> + Serialize;
+    type Header: Header<Id = Self::BlockId, Date = Self::BlockDate> + Serialize + mempack::Readable;
 
     /// The type of asynchronous futures returned by method `tip`.
     ///

--- a/network-core/src/server/content.rs
+++ b/network-core/src/server/content.rs
@@ -3,7 +3,10 @@
 use super::P2pService;
 use crate::error::Error;
 
-use chain_core::property::{Deserialize, Message, MessageId, Serialize};
+use chain_core::{
+    mempack,
+    property::{Message, MessageId, Serialize},
+};
 
 use futures::prelude::*;
 
@@ -12,10 +15,10 @@ use futures::prelude::*;
 /// together as messages.
 pub trait ContentService: P2pService {
     /// The data type to represent messages constituting a block.
-    type Message: Message + Serialize;
+    type Message: Message + Serialize + mempack::Readable;
 
     /// The message identifier type for the blockchain.
-    type MessageId: MessageId + Serialize + Deserialize;
+    type MessageId: MessageId + Serialize + mempack::Readable;
 
     /// The type of asynchronous futures returned by method `propose_transactions`.
     type ProposeTransactionsFuture: Future<

--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -33,39 +33,39 @@ pub use connect::{Connect, ConnectError, ConnectFuture};
 /// so that, should the implementation requrements change, only these trait
 /// definitions and blanket implementations need to be modified.
 pub mod chain_bounds {
-    use chain_core::property;
+    use chain_core::{mempack, property};
 
-    pub trait BlockId: property::BlockId + property::Deserialize
+    pub trait BlockId: property::BlockId + mempack::Readable
     // Alas, bounds on associated types of the supertrait do not have
     // the desired effect:
     // https://github.com/rust-lang/rust/issues/32722
     //
     // where
-    //    <Self as property::Deserialize>::Error: Send + Sync,
+    //    <Self as mempack::Readable>::Error: Send + Sync,
     {
     }
 
-    impl<T> BlockId for T where T: property::BlockId + property::Deserialize {}
+    impl<T> BlockId for T where T: property::BlockId + mempack::Readable {}
 
     pub trait BlockDate: property::BlockDate + property::FromStr {}
 
     impl<T> BlockDate for T where T: property::BlockDate + property::FromStr {}
 
-    pub trait Header: property::Header + property::Deserialize {}
+    pub trait Header: property::Header + mempack::Readable {}
 
     impl<T> Header for T
     where
-        T: property::Header + property::Deserialize,
+        T: property::Header + mempack::Readable,
         <T as property::Header>::Id: BlockId,
         <T as property::Header>::Date: BlockDate,
     {
     }
 
-    pub trait Block: property::Block + property::HasHeader + property::Deserialize {}
+    pub trait Block: property::Block + property::HasHeader + mempack::Readable {}
 
     impl<T> Block for T
     where
-        T: property::Block + property::HasHeader + property::Deserialize,
+        T: property::Block + property::HasHeader + mempack::Readable,
         <T as property::Block>::Id: BlockId,
         <T as property::Block>::Date: BlockDate,
         <T as property::HasHeader>::Header: Header,

--- a/network-ntt/src/gossip.rs
+++ b/network-ntt/src/gossip.rs
@@ -1,6 +1,6 @@
 //! Compatibility stubs for network-core gossip traits
 
-use chain_core::property;
+use chain_core::{mempack, property};
 use network_core::gossip as core_gossip;
 
 use std::io;
@@ -20,6 +20,12 @@ impl property::Deserialize for NodeId {
     type Error = io::Error;
 
     fn deserialize<R: std::io::BufRead>(_reader: R) -> Result<Self, Self::Error> {
+        unimplemented!()
+    }
+}
+
+impl mempack::Readable for NodeId {
+    fn read<'a>(_buf: &mut mempack::ReadBuf<'a>) -> Result<Self, mempack::ReadError> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
It seems `Readable` is what the cool kids use these days, and the impl of `Deserialize` for mockchain's `Header` was wrong anyway as it expected the length-prefixed format, contrary to what `Serialize` produces for the same type.