### PR TITLE
Deserialize strikes back

### DIFF
--- a/network-core/src/gossip.rs
+++ b/network-core/src/gossip.rs
@@ -1,4 +1,4 @@
-use chain_core::{mempack, property};
+use chain_core::property;
 
 use std::{
     iter::{DoubleEndedIterator, FromIterator, FusedIterator},
@@ -7,10 +7,10 @@ use std::{
 };
 
 /// Marker trait for the type representing a node ID.
-pub trait NodeId: Clone + property::Serialize + mempack::Readable {}
+pub trait NodeId: Clone + property::Serialize + property::Deserialize {}
 
 /// Abstract trait for data types representing gossip about network nodes.
-pub trait Node: property::Serialize + mempack::Readable {
+pub trait Node {
     /// Type that represents the node identifier in the gossip message.
     type Id: NodeId;
 

--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -3,10 +3,7 @@
 use super::P2pService;
 use crate::error::Error;
 
-use chain_core::{
-    mempack,
-    property::{Block, BlockDate, BlockId, HasHeader, Header, Serialize},
-};
+use chain_core::property::{Block, BlockDate, BlockId, HasHeader, Header};
 
 use futures::prelude::*;
 
@@ -14,16 +11,16 @@ use futures::prelude::*;
 /// providing access to block data.
 pub trait BlockService: P2pService {
     /// The block identifier type for the blockchain.
-    type BlockId: BlockId + Serialize + mempack::Readable;
+    type BlockId: BlockId;
 
     /// The block date type for the blockchain.
-    type BlockDate: BlockDate + ToString;
+    type BlockDate: BlockDate;
 
     /// The type representing a block on the blockchain.
     type Block: Block<Id = Self::BlockId, Date = Self::BlockDate> + HasHeader<Header = Self::Header>;
 
     /// The type representing metadata header of a block.
-    type Header: Header<Id = Self::BlockId, Date = Self::BlockDate> + Serialize + mempack::Readable;
+    type Header: Header<Id = Self::BlockId, Date = Self::BlockDate>;
 
     /// The type of asynchronous futures returned by method `tip`.
     ///

--- a/network-core/src/server/content.rs
+++ b/network-core/src/server/content.rs
@@ -3,10 +3,7 @@
 use super::P2pService;
 use crate::error::Error;
 
-use chain_core::{
-    mempack,
-    property::{Message, MessageId, Serialize},
-};
+use chain_core::property::{Message, MessageId};
 
 use futures::prelude::*;
 
@@ -15,10 +12,10 @@ use futures::prelude::*;
 /// together as messages.
 pub trait ContentService: P2pService {
     /// The data type to represent messages constituting a block.
-    type Message: Message + Serialize + mempack::Readable;
+    type Message: Message;
 
     /// The message identifier type for the blockchain.
-    type MessageId: MessageId + Serialize + mempack::Readable;
+    type MessageId: MessageId;
 
     /// The type of asynchronous futures returned by method `propose_transactions`.
     type ProposeTransactionsFuture: Future<

--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -82,7 +82,8 @@ pub trait ProtocolConfig {
     type Block: chain_bounds::Block
         + property::Block<Id = Self::BlockId, Date = Self::BlockDate>
         + property::HasHeader<Header = Self::Header>;
-    type Node: gossip::Node;
+    type Node: gossip::Node<Id = Self::NodeId> + property::Serialize + property::Deserialize;
+    type NodeId: gossip::NodeId + property::Serialize + property::Deserialize;
 }
 
 /// gRPC client for blockchain node.
@@ -192,7 +193,7 @@ where
 impl<T, Id, R> Future for SubscriptionFuture<T, Id, R>
 where
     R: prost::Message + Default,
-    Id: NodeId,
+    Id: NodeId + property::Deserialize,
 {
     type Item = (ResponseStream<T, R>, Id);
     type Error = core_error::Error;

--- a/network-grpc/src/convert.rs
+++ b/network-grpc/src/convert.rs
@@ -117,7 +117,7 @@ where
 
 impl<T> FromProtobuf<gen::node::Gossip> for Gossip<T>
 where
-    T: Node,
+    T: Node + property::Deserialize,
 {
     fn from_message(msg: gen::node::Gossip) -> Result<Gossip<T>, core_error::Error> {
         let nodes = deserialize_vec(&msg.nodes)?;
@@ -190,7 +190,7 @@ where
 
 impl<T> IntoProtobuf<gen::node::Gossip> for Gossip<T>
 where
-    T: Node,
+    T: Node + property::Serialize,
 {
     fn into_message(self) -> Result<gen::node::Gossip, tower_grpc::Status> {
         let nodes = serialize_to_vec(self.nodes())?;
@@ -200,7 +200,7 @@ where
 
 pub fn decode_node_id<Id>(metadata: &MetadataMap) -> Result<Id, core_error::Error>
 where
-    Id: NodeId,
+    Id: NodeId + property::Deserialize,
 {
     match metadata.get_bin(NODE_ID_HEADER) {
         None => Err(core_error::Error::new(
@@ -227,7 +227,7 @@ where
 
 pub fn encode_node_id<Id>(id: &Id, metadata: &mut MetadataMap) -> Result<(), Status>
 where
-    Id: NodeId,
+    Id: NodeId + property::Serialize,
 {
     let bytes = serialize_to_bytes(id)?;
     let val = BinaryMetadataValue::from_bytes(&bytes);

--- a/network-grpc/src/server.rs
+++ b/network-grpc/src/server.rs
@@ -1,4 +1,7 @@
-use crate::{gen::node::server as gen_server, service::NodeService};
+use crate::{
+    gen::node::server as gen_server,
+    service::{protocol_bounds, NodeService},
+};
 
 use network_core::server::{
     block::BlockService, content::ContentService, gossip::GossipService, Node,
@@ -25,9 +28,9 @@ use std::path::Path;
 pub struct Server<T, E>
 where
     T: Node + Clone,
-    <T::BlockService as BlockService>::Header: Send + 'static,
-    <T::ContentService as ContentService>::Message: Send + 'static,
-    <T::GossipService as GossipService>::Node: Send + 'static,
+    <T::BlockService as BlockService>::Header: protocol_bounds::Header,
+    <T::ContentService as ContentService>::Message: protocol_bounds::Message,
+    <T::GossipService as GossipService>::Node: protocol_bounds::Node,
 {
     h2: tower_h2::Server<
         gen_server::NodeServer<NodeService<T>>,
@@ -41,9 +44,9 @@ pub struct Connection<S, T, E>
 where
     S: AsyncRead + AsyncWrite,
     T: Node + Clone,
-    <T::BlockService as BlockService>::Header: Send + 'static,
-    <T::ContentService as ContentService>::Message: Send + 'static,
-    <T::GossipService as GossipService>::Node: Send + 'static,
+    <T::BlockService as BlockService>::Header: protocol_bounds::Header,
+    <T::ContentService as ContentService>::Message: protocol_bounds::Message,
+    <T::GossipService as GossipService>::Node: protocol_bounds::Node,
 {
     h2: tower_h2::server::Connection<
         S,
@@ -58,9 +61,9 @@ impl<S, T, E> Future for Connection<S, T, E>
 where
     S: AsyncRead + AsyncWrite,
     T: Node + Clone + 'static,
-    <T::BlockService as BlockService>::Header: Send + 'static,
-    <T::ContentService as ContentService>::Message: Send + 'static,
-    <T::GossipService as GossipService>::Node: Send + 'static,
+    <T::BlockService as BlockService>::Header: protocol_bounds::Header,
+    <T::ContentService as ContentService>::Message: protocol_bounds::Message,
+    <T::GossipService as GossipService>::Node: protocol_bounds::Node,
     E: Executor<
         tower_h2::server::Background<
             gen_server::node::ResponseFuture<NodeService<T>>,
@@ -78,9 +81,9 @@ where
 impl<T, E> Server<T, E>
 where
     T: Node + Clone + 'static,
-    <T::BlockService as BlockService>::Header: Send + 'static,
-    <T::ContentService as ContentService>::Message: Send + 'static,
-    <T::GossipService as GossipService>::Node: Send + 'static,
+    <T::BlockService as BlockService>::Header: protocol_bounds::Header,
+    <T::ContentService as ContentService>::Message: protocol_bounds::Message,
+    <T::GossipService as GossipService>::Node: protocol_bounds::Node,
     E: Executor<
             tower_h2::server::Background<
                 gen_server::node::ResponseFuture<NodeService<T>>,
@@ -152,9 +155,9 @@ type H2Error<T> = tower_h2::server::Error<gen_server::NodeServer<NodeService<T>>
 impl<T> From<H2Error<T>> for Error
 where
     T: Node + Clone,
-    <T::BlockService as BlockService>::Header: Send + 'static,
-    <T::ContentService as ContentService>::Message: Send + 'static,
-    <T::GossipService as GossipService>::Node: Send + 'static,
+    <T::BlockService as BlockService>::Header: protocol_bounds::Header,
+    <T::ContentService as ContentService>::Message: protocol_bounds::Message,
+    <T::GossipService as GossipService>::Node: protocol_bounds::Node,
 {
     fn from(err: H2Error<T>) -> Self {
         use tower_h2::server::Error::*;

--- a/network-grpc/src/service.rs
+++ b/network-grpc/src/service.rs
@@ -1,7 +1,7 @@
 use crate::{
     convert::{
-        decode_node_id, deserialize_vec, encode_node_id, error_from_grpc, error_into_grpc,
-        FromProtobuf, IntoProtobuf,
+        decode_node_id, deserialize_repeated_bytes, encode_node_id, error_from_grpc,
+        error_into_grpc, FromProtobuf, IntoProtobuf,
     },
     gen,
 };
@@ -381,7 +381,7 @@ where
 
     fn get_blocks(&mut self, req: Request<gen::node::BlockIds>) -> Self::GetBlocksFuture {
         let service = try_get_service!(self.inner.block_service());
-        let block_ids = match deserialize_vec(&req.get_ref().ids) {
+        let block_ids = match deserialize_repeated_bytes(&req.get_ref().ids) {
             Ok(block_ids) => block_ids,
             Err(e) => {
                 return ResponseFuture::error(error_into_grpc(e));
@@ -392,7 +392,7 @@ where
 
     fn get_headers(&mut self, req: Request<gen::node::BlockIds>) -> Self::GetHeadersFuture {
         let service = try_get_service!(self.inner.block_service());
-        let block_ids = match deserialize_vec(&req.get_ref().ids) {
+        let block_ids = match deserialize_repeated_bytes(&req.get_ref().ids) {
             Ok(block_ids) => block_ids,
             Err(e) => {
                 return ResponseFuture::error(error_into_grpc(e));
@@ -406,7 +406,7 @@ where
         req: Request<gen::node::PullBlocksToTipRequest>,
     ) -> Self::PullBlocksToTipFuture {
         let service = try_get_service!(self.inner.block_service());
-        let block_ids = match deserialize_vec(&req.get_ref().from) {
+        let block_ids = match deserialize_repeated_bytes(&req.get_ref().from) {
             Ok(block_ids) => block_ids,
             Err(e) => {
                 return ResponseFuture::error(error_into_grpc(e));
@@ -417,7 +417,7 @@ where
 
     fn get_messages(&mut self, req: Request<gen::node::MessageIds>) -> Self::GetMessagesFuture {
         let service = try_get_service!(self.inner.content_service());
-        let tx_ids = match deserialize_vec(&req.get_ref().ids) {
+        let tx_ids = match deserialize_repeated_bytes(&req.get_ref().ids) {
             Ok(tx_ids) => tx_ids,
             Err(e) => {
                 return ResponseFuture::error(error_into_grpc(e));

--- a/network-grpc/src/service.rs
+++ b/network-grpc/src/service.rs
@@ -6,6 +6,8 @@ use crate::{
     gen,
 };
 
+use chain_core::property;
+
 use network_core::{
     error as core_error,
     gossip::NodeId,
@@ -152,7 +154,7 @@ where
 
 impl<T, Id, F> Future for SubscriptionFuture<T, Id, F>
 where
-    Id: NodeId,
+    Id: NodeId + property::Serialize,
     F: Future<Error = core_error::Error>,
     F::Item: IntoProtobuf<T>,
 {
@@ -278,12 +280,35 @@ macro_rules! try_decode_node_id {
     };
 }
 
+pub mod protocol_bounds {
+    use chain_core::{mempack, property};
+    use network_core::gossip;
+
+    pub trait Header: property::Header + mempack::Readable + Send + 'static {}
+
+    impl<T> Header for T where T: property::Header + mempack::Readable + Send + 'static {}
+
+    pub trait Message: property::Message + mempack::Readable + Send + 'static {}
+
+    impl<T> Message for T where T: property::Message + mempack::Readable + Send + 'static {}
+
+    pub trait Node:
+        gossip::Node + property::Serialize + property::Deserialize + Send + 'static
+    {
+    }
+
+    impl<T> Node for T where
+        T: gossip::Node + property::Serialize + property::Deserialize + Send + 'static
+    {
+    }
+}
+
 impl<T> gen::node::server::Node for NodeService<T>
 where
     T: Node + Clone,
-    <T::BlockService as BlockService>::Header: Send + 'static,
-    <T::ContentService as ContentService>::Message: Send + 'static,
-    <T::GossipService as GossipService>::Node: Send + 'static,
+    <T::BlockService as BlockService>::Header: protocol_bounds::Header,
+    <T::ContentService as ContentService>::Message: protocol_bounds::Message,
+    <T::GossipService as GossipService>::Node: protocol_bounds::Node,
 {
     type TipFuture = ResponseFuture<
         gen::node::TipResponse,


### PR DESCRIPTION
Can't completely get rid of `Deserialize` in the network for the time being.
On the other hand, network-core should not require a particular way of marshalling and unmarshalling payloads: it's up to the protocol implementation to use `Deserialize`, `Readable`, `FromStr` etc. as necessary.