### PR TITLE
Update tower-grpc dependency

### DIFF
--- a/network-grpc/Cargo.toml
+++ b/network-grpc/Cargo.toml
@@ -26,8 +26,9 @@ tower-util = "0.1"
 
 [dependencies.tower-grpc]
 git = "https://github.com/tower-rs/tower-grpc"
-rev = "597f56ce0eb47267a17cebe4b0120a713c12a3c0"
+rev = "b67569b5aace78595b2813b25ab7feacc28311b7"
 
 [build-dependencies.tower-grpc-build]
 git = "https://github.com/tower-rs/tower-grpc"
-rev = "597f56ce0eb47267a17cebe4b0120a713c12a3c0"
+rev = "b67569b5aace78595b2813b25ab7feacc28311b7"
+features = ["tower-h2"]


### PR DESCRIPTION
tower-grpc-build now requires HTTP stack selection feature to generate support code for the stack.
Will fix input-output-hk/jormungandr#323.