### PR TITLE
network-grpc: Rename serialize_to_vec

### DIFF
--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -2,7 +2,7 @@ mod connect;
 
 use crate::{
     convert::{
-        decode_node_id, encode_node_id, error_from_grpc, serialize_to_vec, FromProtobuf,
+        decode_node_id, encode_node_id, error_from_grpc, serialize_to_repeated_bytes, FromProtobuf,
         IntoProtobuf,
     },
     gen::{self, node::client as gen_client},
@@ -313,14 +313,14 @@ where
     }
 
     fn pull_blocks_to_tip(&mut self, from: &[P::BlockId]) -> Self::PullBlocksToTipFuture {
-        let from = serialize_to_vec(from).unwrap();
+        let from = serialize_to_repeated_bytes(from).unwrap();
         let req = gen::node::PullBlocksToTipRequest { from };
         let future = self.service.pull_blocks_to_tip(Request::new(req));
         ResponseStreamFuture::new(future)
     }
 
     fn get_blocks(&mut self, ids: &[P::BlockId]) -> Self::GetBlocksFuture {
-        let ids = serialize_to_vec(ids).unwrap();
+        let ids = serialize_to_repeated_bytes(ids).unwrap();
         let req = gen::node::BlockIds { ids };
         let future = self.service.get_blocks(Request::new(req));
         ResponseStreamFuture::new(future)

--- a/network-grpc/src/convert.rs
+++ b/network-grpc/src/convert.rs
@@ -161,7 +161,7 @@ where
     }
 }
 
-pub fn serialize_to_vec<T>(values: &[T]) -> Result<Vec<Vec<u8>>, tower_grpc::Status>
+pub fn serialize_to_repeated_bytes<T>(values: &[T]) -> Result<Vec<Vec<u8>>, tower_grpc::Status>
 where
     T: property::Serialize,
 {
@@ -213,7 +213,7 @@ where
     T: Node + property::Serialize,
 {
     fn into_message(self) -> Result<gen::node::Gossip, tower_grpc::Status> {
-        let nodes = serialize_to_vec(self.nodes())?;
+        let nodes = serialize_to_repeated_bytes(self.nodes())?;
         Ok(gen::node::Gossip { nodes })
     }
 }


### PR DESCRIPTION
Rename to `serialize_to_repeated_bytes` to harmonize with names of the other utilities, intended to be mnemonic with respect to the .proto syntax.