### PR TITLE
small changes in APIs linked to time

### DIFF
--- a/chain-impl-mockchain/src/date.rs
+++ b/chain-impl-mockchain/src/date.rs
@@ -25,7 +25,7 @@ impl BlockDate {
 
     /// Get the slot following this one.
     pub fn next(&self, era: &TimeEra) -> BlockDate {
-        let epoch_duration = era.slots_per_epoch;
+        let epoch_duration = era.slots_per_epoch();
         assert!(self.slot_id < epoch_duration);
         if self.slot_id + 1 == epoch_duration {
             BlockDate {

--- a/chain-impl-mockchain/src/leadership/mod.rs
+++ b/chain-impl-mockchain/src/leadership/mod.rs
@@ -145,6 +145,18 @@ impl Leadership {
         }
     }
 
+    /// get the epoch associated to the `Leadership`
+    #[inline]
+    pub fn epoch(&self) -> Epoch {
+        self.epoch
+    }
+
+    /// get the TimeEra associated to the `Leadership`
+    #[inline]
+    pub fn era(&self) -> &TimeEra {
+        &self.era
+    }
+
     /// Verify whether this header has been produced by a leader that fits with the leadership
     ///
     pub fn verify(&self, block_header: &Header) -> Verification {

--- a/chain-impl-mockchain/src/ledger.rs
+++ b/chain-impl-mockchain/src/ledger.rs
@@ -68,6 +68,7 @@ pub enum Block0Error {
     InitialMessageDuplicatePraosActiveSlotsCoeff,
     InitialMessageNoDate,
     InitialMessageNoSlotDuration,
+    InitialMessageNoSlotsPerEpoch,
     InitialMessageNoDiscrimination,
     InitialMessageNoConsensusVersion,
     InitialMessageNoConsensusLeaderId,
@@ -190,6 +191,7 @@ impl Ledger {
         let mut block0_start_time = None;
         let mut slot_duration = None;
         let mut discrimination = None;
+        let mut slots_per_epoch = None;
 
         for param in init_ents.iter() {
             match param {
@@ -202,6 +204,9 @@ impl Ledger {
                 ConfigParam::SlotDuration(d) => {
                     slot_duration = Some(*d);
                 }
+                ConfigParam::SlotsPerEpoch(n) => {
+                    slots_per_epoch = Some(*n);
+                }
                 _ => regular_ents.push(param.clone()),
             }
         }
@@ -213,6 +218,8 @@ impl Ledger {
             discrimination.ok_or(Error::Block0(Block0Error::InitialMessageNoDiscrimination))?;
         let slot_duration =
             slot_duration.ok_or(Error::Block0(Block0Error::InitialMessageNoSlotDuration))?;
+        let slots_per_epoch =
+            slots_per_epoch.ok_or(Error::Block0(Block0Error::InitialMessageNoSlotsPerEpoch))?;
 
         let static_params = LedgerStaticParameters {
             block0_initial_hash,
@@ -225,8 +232,7 @@ impl Ledger {
         let tf = TimeFrame::new(timeline, SlotDuration::from_secs(slot_duration as u32));
         let slot0 = tf.slot0();
 
-        // TODO -- configurable slots per epoch
-        let era = TimeEra::new(slot0, Epoch(0), 21600);
+        let era = TimeEra::new(slot0, Epoch(0), slots_per_epoch);
 
         let settings = setting::Settings::new(era).apply(&regular_ents)?;
 
@@ -828,6 +834,7 @@ pub mod test {
         ie.push(ConfigParam::ConsensusGenesisPraosActiveSlotsCoeff(
             Milli::HALF,
         ));
+        ie.push(ConfigParam::SlotsPerEpoch(21600));
 
         let mut rng = rand::thread_rng();
         let (sk1, _pk1, user1_address) = make_key(&mut rng, &discrimination);

--- a/chain-impl-mockchain/src/ledger.rs
+++ b/chain-impl-mockchain/src/ledger.rs
@@ -226,7 +226,7 @@ impl Ledger {
         let slot0 = tf.slot0();
 
         // TODO -- configurable slots per epoch
-        let era = TimeEra::new_era(slot0, Epoch(0), 21600);
+        let era = TimeEra::new(slot0, Epoch(0), 21600);
 
         let settings = setting::Settings::new(era).apply(&regular_ents)?;
 

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -291,6 +291,7 @@ mod test {
 
     #[test]
     pub fn multiverse() {
+        const NUM_BLOCK_PER_EPOCH: u32 = 1000;
         let mut multiverse = Multiverse::new();
 
         let system_time = SystemTime::UNIX_EPOCH;
@@ -298,7 +299,7 @@ mod test {
         let tf = TimeFrame::new(timeline, SlotDuration::from_secs(10));
 
         let slot0 = tf.slot0();
-        let era = TimeEra::new_era(slot0, Epoch(0), 1000);
+        let era = TimeEra::new(slot0, Epoch(0), NUM_BLOCK_PER_EPOCH);
 
         let mut g = StdGen::new(rand::thread_rng(), 10);
         let leader_key = Arbitrary::arbitrary(&mut g);
@@ -316,6 +317,7 @@ mod test {
         ents.push(ConfigParam::ConsensusGenesisPraosActiveSlotsCoeff(
             Milli::HALF,
         ));
+        ents.push(ConfigParam::SlotsPerEpoch(NUM_BLOCK_PER_EPOCH));
         genesis_block.message(Message::Initial(ents));
         let genesis_block = genesis_block.make_genesis_block();
         let mut date = genesis_block.date();

--- a/chain-time/src/era.rs
+++ b/chain-time/src/era.rs
@@ -23,7 +23,7 @@ pub struct EpochPosition {
 pub struct TimeEra {
     epoch_start: Epoch,
     slot_start: Slot,
-    pub slots_per_epoch: u32,
+    slots_per_epoch: u32,
 }
 
 impl TimeEra {
@@ -34,6 +34,11 @@ impl TimeEra {
             slot_start,
             slots_per_epoch,
         }
+    }
+
+    /// retrieve the number of slots in an epoch during a given Epoch
+    pub fn slots_per_epoch(&self) -> u32 {
+        self.slots_per_epoch
     }
 
     /// Try to return the epoch/inner-epoch-slot associated.

--- a/chain-time/src/era.rs
+++ b/chain-time/src/era.rs
@@ -28,7 +28,7 @@ pub struct TimeEra {
 
 impl TimeEra {
     /// Set a new era to start on slot_start at epoch_start for a given slots per epoch.
-    pub fn new_era(slot_start: Slot, epoch_start: Epoch, slots_per_epoch: u32) -> Self {
+    pub fn new(slot_start: Slot, epoch_start: Epoch, slots_per_epoch: u32) -> Self {
         TimeEra {
             epoch_start,
             slot_start,
@@ -92,7 +92,7 @@ mod test {
         assert_eq!(slot2, Slot(4));
         assert_eq!(slot3, Slot(20));
 
-        let era = TimeEra::new_era(slot1, Epoch(2), 4);
+        let era = TimeEra::new(slot1, Epoch(2), 4);
 
         let p1 = era.from_slot_to_era(slot1).unwrap();
         let p2 = era.from_slot_to_era(slot2).unwrap();


### PR DESCRIPTION
also add the missing link to configure the number of blocks per epoch from the block0 (the config parameter was already there).