### PR TITLE
network: Redesign block subscription for upload

### DIFF
--- a/network-core/src/lib.rs
+++ b/network-core/src/lib.rs
@@ -8,3 +8,4 @@ pub mod client;
 pub mod server;
 
 pub mod gossip;
+pub mod subscription;

--- a/network-core/src/subscription.rs
+++ b/network-core/src/subscription.rs
@@ -1,0 +1,25 @@
+use chain_core::property::{Block, HasHeader};
+
+use std::fmt::{self, Debug};
+
+pub enum BlockEvent<B>
+where
+    B: Block + HasHeader,
+{
+    Announce(<B as HasHeader>::Header),
+    Solicit(Vec<<B as Block>::Id>),
+}
+
+impl<B> Debug for BlockEvent<B>
+where
+    B: Block + HasHeader,
+    <B as HasHeader>::Header: Debug,
+    <B as Block>::Id: Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            BlockEvent::Announce(header) => f.debug_tuple("Announce").field(header).finish(),
+            BlockEvent::Solicit(ids) => f.debug_tuple("Solicit").field(ids).finish(),
+        }
+    }
+}

--- a/network-grpc/proto/node.proto
+++ b/network-grpc/proto/node.proto
@@ -31,6 +31,9 @@ message PullBlocksToTipRequest {
   repeated bytes from = 1;
 }
 
+// Response message for method UploadBlocks.
+message UploadBlocksResponse {}
+
 // Representation of a block.
 message Block {
   // The serialized content of the block.
@@ -56,6 +59,17 @@ message Gossip {
   repeated bytes nodes = 2;
 }
 
+// Element of the subscription stream returned by BlockSubscription.
+message BlockEvent {
+  oneof item {
+    // Announcement of a new block, carrying the block's header.
+    Header announce = 1;
+    // Solicitation to upload identified blocks with a method call
+    // UploadBlocks.
+    BlockIds solicit = 2;
+  }
+}
+
 service Node {
   rpc Tip(TipRequest) returns (TipResponse);
   rpc GetBlocks(BlockIds) returns (stream Block) {
@@ -70,9 +84,13 @@ service Node {
 
   rpc PullBlocksToTip(PullBlocksToTipRequest) returns (stream Block);
 
+  // Uploads blocks to the service in response to a solicitation item
+  // received from the BlockSubscription response stream.
+  rpc UploadBlocks(stream Block) returns (UploadBlocksResponse);
+
   // Establishes a bidirectional stream to exchange information on new
   // blocks created or accepted by the peers.
-  rpc BlockSubscription(stream Header) returns (stream Header);
+  rpc BlockSubscription(stream Header) returns (stream BlockEvent);
 
   // Establishes a bidirectional stream to exchange information on new
   // messages created or accepted by the peers.

--- a/network-grpc/src/server.rs
+++ b/network-grpc/src/server.rs
@@ -28,6 +28,7 @@ use std::path::Path;
 pub struct Server<T, E>
 where
     T: Node + Clone,
+    <T::BlockService as BlockService>::Block: protocol_bounds::Block,
     <T::BlockService as BlockService>::Header: protocol_bounds::Header,
     <T::ContentService as ContentService>::Message: protocol_bounds::Message,
     <T::GossipService as GossipService>::Node: protocol_bounds::Node,
@@ -44,6 +45,7 @@ pub struct Connection<S, T, E>
 where
     S: AsyncRead + AsyncWrite,
     T: Node + Clone,
+    <T::BlockService as BlockService>::Block: protocol_bounds::Block,
     <T::BlockService as BlockService>::Header: protocol_bounds::Header,
     <T::ContentService as ContentService>::Message: protocol_bounds::Message,
     <T::GossipService as GossipService>::Node: protocol_bounds::Node,
@@ -61,6 +63,7 @@ impl<S, T, E> Future for Connection<S, T, E>
 where
     S: AsyncRead + AsyncWrite,
     T: Node + Clone + 'static,
+    <T::BlockService as BlockService>::Block: protocol_bounds::Block,
     <T::BlockService as BlockService>::Header: protocol_bounds::Header,
     <T::ContentService as ContentService>::Message: protocol_bounds::Message,
     <T::GossipService as GossipService>::Node: protocol_bounds::Node,
@@ -81,6 +84,7 @@ where
 impl<T, E> Server<T, E>
 where
     T: Node + Clone + 'static,
+    <T::BlockService as BlockService>::Block: protocol_bounds::Block,
     <T::BlockService as BlockService>::Header: protocol_bounds::Header,
     <T::ContentService as ContentService>::Message: protocol_bounds::Message,
     <T::GossipService as GossipService>::Node: protocol_bounds::Node,
@@ -155,6 +159,7 @@ type H2Error<T> = tower_h2::server::Error<gen_server::NodeServer<NodeService<T>>
 impl<T> From<H2Error<T>> for Error
 where
     T: Node + Clone,
+    <T::BlockService as BlockService>::Block: protocol_bounds::Block,
     <T::BlockService as BlockService>::Header: protocol_bounds::Header,
     <T::ContentService as ContentService>::Message: protocol_bounds::Message,
     <T::GossipService as GossipService>::Node: protocol_bounds::Node,

--- a/network-ntt/src/client.rs
+++ b/network-ntt/src/client.rs
@@ -5,6 +5,7 @@ use chain_core::property::{Block, HasHeader, Header};
 use network_core::{
     client::{block::BlockService, P2pService},
     error as core_error,
+    subscription::BlockEvent,
 };
 pub use protocol::protocol::ProtocolMagic;
 use protocol::{
@@ -171,7 +172,8 @@ where
     type PullBlocksToTipFuture = PullBlocksToTip<T>;
     type GetBlocksStream = RequestStream<T>;
     type GetBlocksFuture = RequestFuture<RequestStream<T>>;
-    type BlockSubscription = RequestStream<T::Header>;
+    type UploadBlocksFuture = RequestFuture<()>;
+    type BlockSubscription = RequestStream<BlockEvent<T>>;
     type BlockSubscriptionFuture = RequestFuture<(Self::BlockSubscription, NodeId)>;
 
     fn tip(&mut self) -> Self::TipFuture {
@@ -199,6 +201,13 @@ where
     }
 
     fn get_blocks(&mut self, _ids: &[<Self::Block as Block>::Id]) -> Self::GetBlocksFuture {
+        unimplemented!()
+    }
+
+    fn upload_blocks<S>(&mut self, _blocks: S) -> Self::UploadBlocksFuture
+    where
+        S: Stream<Item = Self::Block> + Send + 'static,
+    {
         unimplemented!()
     }
 


### PR DESCRIPTION
Block subscription stream now can retrieve solicitations for blocks from the client, which can fulfill the solictitation with client streaming method `UploadBlocks`.