### PR TITLE
[IOHKCRB-31] C Binding for serializing signed transaction

### DIFF
--- a/cardano-c/Cargo.toml
+++ b/cardano-c/Cargo.toml
@@ -16,3 +16,4 @@ crate-type = ["staticlib" ]
 
 [dependencies]
 cardano = { path = "../cardano" }
+cbor_event = "^2.1.1"

--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -212,11 +212,12 @@ void cardano_account_delete(cardano_account *account);
 * \param [in] from_index  
 * \param [in] num_indices
 * \param [out] addresses_ptr array of strings consisting of the base58 representation of the addresses
+* \param [in] protocol_magic
 * \returns the number of generated addresses
 * \sa cardano_address_import_base58()
 * \sa cardano_address_delete() 
 */
-unsigned long cardano_account_generate_addresses(cardano_account *account, int internal, unsigned int from_index, unsigned long num_indices, char *addresses_ptr[]);
+unsigned long cardano_account_generate_addresses(cardano_account *account, int internal, unsigned int from_index, unsigned long num_indices, char *addresses_ptr[], uint32_t protocol_magic);
 void cardano_account_delete_addresses(char *addresses_ptr[], unsigned long length);
 
 /****************/

--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -314,6 +314,23 @@ void cardano_signed_transaction_get_outputs(
     size_t *outputs_size
 );
 
+/*! \brief Encode a cardano_signed_transaction as CBOR 
+* \param [in] txaux a cardano signed transaction
+* \param [out] out_ptr pointer to the serialized data
+* \param [out] out_size size of the encoded data
+* \sa cardano_signed_transaction_serialized_delete()
+*/
+cardano_result cardano_signed_transaction_serialize(
+    cardano_signed_transaction *txaux,
+    uint8_t **out_ptr,
+    size_t *out_size);
+
+/*! \brief Release the memory allocated by cardano_signed_transaction_serialize()
+* \param [in] pointer
+* \param [in] size
+*/
+void cardano_signed_transaction_serialized_delete(uint8_t *pointer, size_t size);
+
 /*! \brief Release the memory allocated by `cardano_transaction_signed_get_outputs`
 */
 void cardano_signed_transaction_delete_outputs(cardano_txoutput *outputs[], size_t size);

--- a/cardano-c/examples/README.md
+++ b/cardano-c/examples/README.md
@@ -33,7 +33,7 @@ enum
 char *address[NUMBER_OF_ADDRESSES];
 const int IS_INTERNAL = 1;
 const unsigned int FROM_INDEX = 0;
-cardano_account_generate_addresses(account, IS_INTERNAL, FROM_INDEX, NUMBER_OF_ADDRESSES, address);
+cardano_account_generate_addresses(account, IS_INTERNAL, FROM_INDEX, NUMBER_OF_ADDRESSES, address, PROTOCOL_MAGIC);
 
 /*
     ...

--- a/cardano-c/test/test.c
+++ b/cardano-c/test/test.c
@@ -11,6 +11,7 @@ void test_can_create_address(void)
 {
     static const char *alias = "Test Wallet";
     static char *address[1];
+    static uint32_t PROTOCOL_MAGIC = 1;
     size_t NUMBER_OF_ADDRESSES = sizeof(address) / sizeof(char *);
 
     cardano_wallet *wallet;
@@ -27,7 +28,7 @@ void test_can_create_address(void)
 
     TEST_ASSERT_MESSAGE(account, "The account creation failed");
 
-    cardano_account_generate_addresses(account, 0, 0, NUMBER_OF_ADDRESSES, address);
+    cardano_account_generate_addresses(account, 0, 0, NUMBER_OF_ADDRESSES, address, PROTOCOL_MAGIC);
 
     TEST_ASSERT_MESSAGE(!cardano_address_is_valid(address[0]), "The generated address is invalid");
 

--- a/cardano-c/test/test_transaction.c
+++ b/cardano-c/test/test_transaction.c
@@ -35,7 +35,7 @@ void setUp()
     char *addresses[2];
     size_t NUMBER_OF_ADDRESSES = sizeof(addresses) / sizeof(char *);
 
-    int rc = cardano_account_generate_addresses(account, 0, 0, NUMBER_OF_ADDRESSES, addresses);
+    int rc = cardano_account_generate_addresses(account, 0, 0, NUMBER_OF_ADDRESSES, addresses, PROTOCOL_MAGIC);
 
     input_address = cardano_address_import_base58(addresses[0]);
     output_address = cardano_address_import_base58(addresses[1]);


### PR DESCRIPTION
# Summary

- Fix: Add missing parameter in generate addresses function (protocol magic)
- Add cbor serializing function for serializing txAux

# Motivation
To post a transaction to the http bridge, is necessary to serialize it and encode it in base 64.