### PR TITLE
Add consensus state tracking in the ledger

### DIFF
--- a/chain-impl-mockchain/src/block/mod.rs
+++ b/chain-impl-mockchain/src/block/mod.rs
@@ -18,7 +18,7 @@ pub use self::builder::BlockBuilder;
 
 pub use self::header::{
     BftProof, BftSignature, BlockContentHash, BlockContentSize, BlockId, ChainLength, Common,
-    GenesisPraosProof, Header, HeaderHash, KESSignature, Proof,
+    GenesisPraosProof, Header, HeaderContentEvalContext, HeaderHash, KESSignature, Proof,
 };
 pub use self::headerraw::HeaderRaw;
 pub use self::version::*;

--- a/chain-impl-mockchain/src/leadership/genesis/mod.rs
+++ b/chain-impl-mockchain/src/leadership/genesis/mod.rs
@@ -11,8 +11,9 @@ use crate::{
 };
 use chain_crypto::Verification as SigningVerification;
 use chain_crypto::{Curve25519_2HashDH, PublicKey, SecretKey, SumEd25519_12};
-pub use vrfeval::{ActiveSlotsCoeff, ActiveSlotsCoeffError, Witness};
-use vrfeval::{Nonce, PercentStake, VrfEvaluator};
+pub(crate) use vrfeval::witness_to_nonce;
+pub use vrfeval::{ActiveSlotsCoeff, ActiveSlotsCoeffError, Nonce, Witness, WitnessOutput};
+use vrfeval::{PercentStake, VrfEvaluator};
 
 /// Praos Leader consisting of the KES public key and VRF public key
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -33,7 +34,7 @@ pub struct GenesisLeaderSelection {
 impl GenesisLeaderSelection {
     pub fn new(epoch: Epoch, ledger: &Ledger) -> Self {
         GenesisLeaderSelection {
-            epoch_nonce: Nonce::zero(),
+            epoch_nonce: ledger.settings.consensus_nonce.clone(),
             nodes: ledger.delegation.stake_pools.clone(),
             distribution: ledger.get_stake_distribution(),
             epoch,

--- a/chain-impl-mockchain/src/ledger.rs
+++ b/chain-impl-mockchain/src/ledger.rs
@@ -1,7 +1,9 @@
 //! Mockchain ledger. Ledger exists in order to update the
 //! current state and verify transactions.
 
-use crate::block::{BlockDate, ChainLength, ConsensusVersion, HeaderHash};
+use crate::block::{
+    BlockDate, ChainLength, ConsensusVersion, HeaderContentEvalContext, HeaderHash,
+};
 use crate::config::{self, ConfigParam};
 use crate::fee::{FeeAlgorithm, LinearFee};
 use crate::leadership::genesis::ActiveSlotsCoeffError;
@@ -319,6 +321,7 @@ impl Ledger {
         &'a self,
         ledger_params: &LedgerParameters,
         contents: I,
+        metadata: &HeaderContentEvalContext,
         date: BlockDate,
         chain_length: ChainLength,
     ) -> Result<Self, Error>
@@ -377,7 +380,10 @@ impl Ledger {
         }
 
         new_ledger.date = date;
-
+        metadata
+            .nonce
+            .as_ref()
+            .map(|n| new_ledger.settings.consensus_nonce.hash_with(n));
         Ok(new_ledger)
     }
 

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -8,14 +8,12 @@
 
 use crate::block::ChainLength;
 use crate::ledger::Ledger;
-use chain_core::property::{Block as _, BlockId as _, HasMessages as _};
+use chain_core::property::{BlockId as _, HasMessages as _};
 use chain_storage::store::BlockStore;
 use std::collections::{hash_map::Entry, BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 
 type BlockId = crate::key::Hash;
-
-//type StateLedger = crate::ledger::Ledger;
 
 //
 // The multiverse is characterized by a single origin and multiple state of a given time
@@ -249,8 +247,6 @@ impl Multiverse<Ledger> {
                     &state.get_ledger_parameters(),
                     block.messages(),
                     &header_meta,
-                    block.date(),
-                    block.chain_length(),
                 )
                 .unwrap();
             // FIXME: add the intermediate states to memory?
@@ -286,8 +282,6 @@ mod test {
                 &state.get_ledger_parameters(),
                 block.messages(),
                 &block.header.to_content_eval_context(),
-                block.date(),
-                block.chain_length(),
             )
             .unwrap()
     }

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -243,10 +243,12 @@ impl Multiverse<Ledger> {
 
         for hash in blocks_to_apply.iter().rev() {
             let block = store.get_block(&hash).unwrap().0;
+            let header_meta = block.header.to_content_eval_context();
             state = state
                 .apply_block(
                     &state.get_ledger_parameters(),
                     block.messages(),
+                    &header_meta,
                     block.date(),
                     block.chain_length(),
                 )
@@ -283,6 +285,7 @@ mod test {
             .apply_block(
                 &state.get_ledger_parameters(),
                 block.messages(),
+                &block.header.to_content_eval_context(),
                 block.date(),
                 block.chain_length(),
             )

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -4,7 +4,12 @@
 use crate::leadership::genesis::ActiveSlotsCoeff;
 use crate::milli::Milli;
 use crate::update::Error;
-use crate::{block::ConsensusVersion, config::ConfigParam, fee::LinearFee, leadership::bft};
+use crate::{
+    block::ConsensusVersion,
+    config::ConfigParam,
+    fee::LinearFee,
+    leadership::{bft, genesis},
+};
 use chain_time::era::TimeEra;
 use std::convert::TryFrom;
 use std::sync::Arc;
@@ -13,6 +18,7 @@ use std::sync::Arc;
 pub struct Settings {
     pub era: TimeEra,
     pub consensus_version: ConsensusVersion,
+    pub consensus_nonce: genesis::Nonce,
     pub slots_per_epoch: u32,
     pub slot_duration: u8,
     pub epoch_stability_depth: u32,
@@ -37,6 +43,7 @@ impl Settings {
         Self {
             era: era,
             consensus_version: ConsensusVersion::Bft,
+            consensus_nonce: genesis::Nonce::zero(),
             slots_per_epoch: 1,
             slot_duration: 10,         // 10 sec
             epoch_stability_depth: 10, // num of block


### PR DESCRIPTION
API-break: this add a new parameter to apply_block which need to come from the Block's header of the block whose content is getting applied