### PR TITLE
Made block streaming interruptible

### DIFF
--- a/exe-common/src/network/api.rs
+++ b/exe-common/src/network/api.rs
@@ -4,6 +4,12 @@ use cardano::{
 };
 use network::Result;
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum BlockReceivingFlag {
+    Continue,
+    Stop,
+}
+
 /// Api to abstract the network interaction and do the
 /// necessary operations
 pub trait Api {
@@ -30,7 +36,7 @@ pub trait Api {
         got_block: &mut F,
     ) -> Result<()>
     where
-        F: FnMut(&HeaderHash, &Block, &RawBlock) -> ();
+        F: FnMut(&HeaderHash, &Block, &RawBlock) -> BlockReceivingFlag;
 
     fn send_transaction(&mut self, txaux: TxAux) -> Result<bool>;
 }

--- a/exe-common/src/network/native.rs
+++ b/exe-common/src/network/native.rs
@@ -12,7 +12,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use network::api::{Api, BlockRef};
+use network::api::{Api, BlockReceivingFlag, BlockRef};
 use network::{Error, Result};
 
 /// native peer
@@ -92,7 +92,7 @@ impl Api for PeerPool {
         got_block: &mut F,
     ) -> Result<()>
     where
-        F: FnMut(&HeaderHash, &Block, &RawBlock) -> (),
+        F: FnMut(&HeaderHash, &Block, &RawBlock) -> BlockReceivingFlag,
     {
         match self.connections.get_mut(0) {
             None => panic!("We expect at lease one connection on any native peer"),
@@ -204,11 +204,13 @@ impl Api for OpenPeer {
         got_block: &mut F,
     ) -> Result<()>
     where
-        F: FnMut(&HeaderHash, &Block, &RawBlock) -> (),
+        F: FnMut(&HeaderHash, &Block, &RawBlock) -> BlockReceivingFlag,
     {
         if inclusive {
             let rblk = self.get_block(&from.hash)?;
-            got_block(&from.hash, &rblk.decode()?, &rblk);
+            if got_block(&from.hash, &rblk.decode()?, &rblk) == BlockReceivingFlag::Stop {
+                return Ok(());
+            }
         }
 
         stream_blocks(
@@ -217,8 +219,10 @@ impl Api for OpenPeer {
             to.hash.clone(),
             &mut |rblk| {
                 let blk = rblk.decode()?;
-                got_block(&blk.header().compute_hash(), &blk, &rblk);
-                Ok(())
+                match got_block(&blk.header().compute_hash(), &blk, &rblk) {
+                    BlockReceivingFlag::Continue => Ok(BlockStreamingFlag::Continue),
+                    BlockReceivingFlag::Stop => Ok(BlockStreamingFlag::Stop),
+                }
             },
         )?;
 

--- a/exe-common/src/network/ntt.rs
+++ b/exe-common/src/network/ntt.rs
@@ -1,7 +1,7 @@
 use futures::Future;
 use tokio::runtime::Runtime;
 
-use network::api::{Api, BlockRef};
+use network::api::{Api, BlockReceivingFlag, BlockRef};
 use network::{Error, Result};
 
 //to_socket_addr
@@ -70,7 +70,7 @@ impl Api for NetworkCore {
         _got_block: &mut F,
     ) -> Result<()>
     where
-        F: FnMut(&HeaderHash, &Block, &RawBlock) -> (),
+        F: FnMut(&HeaderHash, &Block, &RawBlock) -> BlockReceivingFlag,
     {
         unimplemented!("not yet ready")
     }

--- a/exe-common/src/network/peer.rs
+++ b/exe-common/src/network/peer.rs
@@ -76,7 +76,7 @@ impl Api for Peer {
         got_block: &mut F,
     ) -> Result<()>
     where
-        F: FnMut(&HeaderHash, &Block, &RawBlock) -> (),
+        F: FnMut(&HeaderHash, &Block, &RawBlock) -> BlockReceivingFlag,
     {
         match self {
             Peer::Native(peer) => peer.get_blocks(from, inclusive, to, got_block),

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -7,7 +7,11 @@ use cardano_storage::{
     pack, tag, types, Error, Storage,
 };
 use config::net;
-use network::{api::Api, api::BlockRef, Peer, Result};
+use network::{
+    api::{Api, BlockReceivingFlag, BlockRef},
+    Peer,
+    Result
+};
 use std::mem;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime};
@@ -250,6 +254,7 @@ fn net_sync_to<A: Api>(
                     unreachable!();
                 }
             }
+            return BlockReceivingFlag::Continue;
         },
     )?;
 

--- a/exe-common/src/sync.rs
+++ b/exe-common/src/sync.rs
@@ -9,8 +9,7 @@ use cardano_storage::{
 use config::net;
 use network::{
     api::{Api, BlockReceivingFlag, BlockRef},
-    Peer,
-    Result
+    Peer, Result,
 };
 use std::mem;
 use std::sync::{Arc, RwLock};

--- a/protocol/src/protocol.rs
+++ b/protocol/src/protocol.rs
@@ -546,6 +546,12 @@ pub mod command {
     use packet;
     use std::io::{Cursor, Read, Write};
 
+    #[derive(Debug, PartialEq)]
+    pub enum BlockStreamingFlag {
+        Continue,
+        Stop,
+    }
+
     pub trait Command<W: Read + Write> {
         type Output;
         fn command(&self, connection: &mut Connection<W>, id: LightId) -> Result<()>;
@@ -578,7 +584,7 @@ pub mod command {
         got_block: &mut F,
     ) -> Result<()>
     where
-        F: FnMut(cardano::block::RawBlock) -> Result<()>,
+        F: FnMut(cardano::block::RawBlock) -> Result<BlockStreamingFlag>,
     {
         let id = connection.new_light_connection()?;
 
@@ -602,7 +608,9 @@ pub mod command {
                     let position = msg.as_ref().position() as usize;
                     let raw_block = msg.as_ref().get_ref()[position..].to_vec();
                     let rblk = cardano::block::RawBlock::from_dat(raw_block);
-                    got_block(rblk)?;
+                    if got_block(rblk)? == BlockStreamingFlag::Stop {
+                        break;
+                    }
                 }
                 1 => {
                     return Err(Error::ServerError(msg.text()?));


### PR DESCRIPTION
Added internal functionality that allows to interrupt block-streaming when necessary. But it's not used for now. Required for later rollback processing.

Part of https://github.com/input-output-hk/rust-cardano/pull/693#issuecomment-494574901