### PR TITLE
IOHKCRB-34 Sign transaction example

### DIFF
--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -106,12 +106,15 @@ typedef struct cardano_xprv cardano_xprv;
 */
 typedef struct cardano_xpub cardano_xpub;
 
+/*!
+* BIP32 private to private derivation
+*/
 cardano_xprv *cardano_xprv_derive(cardano_xprv *xprv, uint32_t index); 
 
 /*!
 * Free the associated memory
 */
-cardano_xpub *cardano_xprv_delete(cardano_xprv *privkey);
+void cardano_xprv_delete(cardano_xprv *privkey);
 
 /*!
 * Get the associated cardano_xpub
@@ -139,7 +142,7 @@ cardano_result cardano_xprv_from_bytes(uint8_t *bytes, cardano_xprv **xprv_out);
 /*!
 * Free the associated memory
 */
-cardano_xpub *cardano_xpub_delete(cardano_xpub *pubkey);
+void cardano_xpub_delete(cardano_xpub *pubkey);
 
 /*************/
 /* addresses */
@@ -185,7 +188,12 @@ cardano_result cardano_wallet_new(const uint8_t * const entropy_ptr, unsigned lo
 */
 void cardano_wallet_delete(cardano_wallet *);
 
-
+/*!
+* Get the wallet root xprv
+* \param [in] wallet_ptr a wallet constructed with `cardano_wallet_new()`
+* Call `cardano_xprv_delete` to deallocate the memory 
+* \sa cardano_xprv_delete()
+*/
 cardano_xprv *cardano_wallet_root_key(cardano_wallet *wallet_ptr);
 
 /*!

--- a/cardano-c/cardano.h
+++ b/cardano-c/cardano.h
@@ -106,6 +106,8 @@ typedef struct cardano_xprv cardano_xprv;
 */
 typedef struct cardano_xpub cardano_xpub;
 
+cardano_xprv *cardano_xprv_derive(cardano_xprv *xprv, uint32_t index); 
+
 /*!
 * Free the associated memory
 */
@@ -182,6 +184,9 @@ cardano_result cardano_wallet_new(const uint8_t * const entropy_ptr, unsigned lo
 * Free the memory of a wallet allocated with `cardano_wallet_new`
 */
 void cardano_wallet_delete(cardano_wallet *);
+
+
+cardano_xprv *cardano_wallet_root_key(cardano_wallet *wallet_ptr);
 
 /*!
 * \brief Create a new account, the account is given an alias and an index.
@@ -271,6 +276,16 @@ typedef struct cardano_txid {
 */
 void cardano_signed_transaction_txid(
     cardano_signed_transaction *txaux,
+    cardano_txid_t *out_txid
+);
+
+/*! \brief Get the transaction id
+* \param [in] tx
+* \param [out] out_txid
+* \relates cardano_transaction
+*/
+void cardano_transaction_txid(
+    cardano_transaction *tx,
     cardano_txid_t *out_txid
 );
 

--- a/cardano-c/examples/.gitignore
+++ b/cardano-c/examples/.gitignore
@@ -1,0 +1,1 @@
+signed_transaction

--- a/cardano-c/examples/Makefile
+++ b/cardano-c/examples/Makefile
@@ -1,0 +1,11 @@
+CC=gcc
+CFLAGS=-I.
+LIB = ../../target/debug/libcardano_c.a
+
+signed_transaction: signed_transaction.c $(LIB)
+	$(CC) -o signed_transaction signed_transaction.c $(LIB) -lpthread -lm -ldl
+
+.PHONY: clean
+
+clean:
+	rm signed_transaction

--- a/cardano-c/examples/signed_transaction.c
+++ b/cardano-c/examples/signed_transaction.c
@@ -1,0 +1,178 @@
+#include "../cardano.h"
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+
+/*
+Example of transaction generation an signing from the testnet
+Two addresses are generated from the given mnemonics, in this case:
+
+    - 2cWKMJemoBaiCnmPjDEhmPwDR9HhxtsLmzr4eHQNiQfBsRQ8sJnR94xGF5t8De5iBApqY
+    - 2cWKMJemoBajYE5NxbHPzhuYy9KCXxqbkeFPdN1h5koATAhm2HqruhNwMdBKKmgCscBWw
+
+The first one is used as the source address and is assumed that it has funds
+of '1194911488' lovelaces in the output 0 of the transaction with id:
+
+    "0090614e19a5fb74c41e4ac57e25ec0d41d44a55884eba14882ea8a403e59c24"
+
+The output is written to a file with the resulting transaction id as the name
+*/
+
+//Protocol magic for testnet
+static const uint32_t PROTOCOL_MAGIC = 1097911063;
+const uint32_t BIP44_SOFT_UPPER_BOUND = 0x80000000;
+
+int main(int argc, char *argv)
+{
+    char *MNEMONICS = "crowd captain hungry tray powder motor coast oppose month shed parent mystery torch resemble index";
+
+    /*Retrieve entropy from mnemonics*/
+    cardano_entropy entropy;
+    uint32_t bytes;
+    cardano_bip39_error_t entropy_rc = cardano_entropy_from_english_mnemonics(MNEMONICS, &entropy, &bytes);
+
+    /*Check that the mnemonics were actually valid*/
+    assert(entropy_rc == BIP39_SUCCESS);
+
+    /*Create a wallet with the given entropy*/
+    char *password = "";
+    cardano_wallet *wallet;
+    cardano_result wallet_rc = cardano_wallet_new(entropy, bytes, password, strlen(password), &wallet);
+
+    assert(wallet_rc == CARDANO_RESULT_SUCCESS);
+
+    /*Create an account*/
+    const char *alias = "Awesome Account";
+    unsigned int index = 0;
+    cardano_account *account = cardano_account_create(wallet, alias, index);
+
+    /*Create an internal address*/
+    enum
+    {
+        NUMBER_OF_ADDRESSES = 2,
+    };
+    char *addresses[NUMBER_OF_ADDRESSES];
+    const int IS_INTERNAL = 0;
+    const unsigned int FROM_INDEX = 0;
+    cardano_account_generate_addresses(
+        account,
+        IS_INTERNAL,
+        FROM_INDEX,
+        NUMBER_OF_ADDRESSES,
+        addresses,
+        PROTOCOL_MAGIC
+    );
+
+    printf("%s\n%s\n", addresses[0], addresses[1]);
+
+    /*Get the root key*/
+    cardano_xprv *root_key = cardano_wallet_root_key(wallet);
+
+    /*Get a transaction builder*/
+    cardano_transaction_builder *txbuilder = cardano_transaction_builder_new();
+
+    /*
+    Derive the private key to sign the transaction according to the 
+    bip44 derivation path
+    */
+
+    //Derive the xprv of the account
+
+    cardano_xprv *account_xprv = cardano_xprv_derive(
+        root_key,
+        BIP44_SOFT_UPPER_BOUND | 0
+    );
+
+    //BIP44 derivation path. 
+    //0: External address
+    cardano_xprv *external_address_level = cardano_xprv_derive(account_xprv, 0);
+
+    //Derive the xprv of the first address
+    cardano_xprv *input_xprv = cardano_xprv_derive(external_address_level, 0);
+
+    //Byte representation is required for signing
+    uint8_t *input_xprv_bytes = cardano_xprv_to_bytes(input_xprv);
+
+    //Add the input
+
+    /*The transaction with the unspent*/
+    char *hex_unspent_txid = "0090614e19a5fb74c41e4ac57e25ec0d41d44a55884eba14882ea8a403e59c24";
+
+    /*Parse the hex representation of txid*/
+    uint8_t unspent_txid[32];
+
+    for (size_t i = 0; i < sizeof unspent_txid; i++) {
+        sscanf(hex_unspent_txid + (i*2), "%2hhx", unspent_txid + i);
+    }
+
+    cardano_txoptr *input = cardano_transaction_output_ptr_new(unspent_txid, 0);
+
+    uint64_t input_funds = 1194911488;
+    if (cardano_transaction_builder_add_input(txbuilder, input, input_funds)
+     != CARDANO_RESULT_SUCCESS)
+    {
+        printf("Error adding input\n");
+        return 1;
+    }
+
+    //Transfer to the second generated address
+    cardano_address *to_address = cardano_address_import_base58(addresses[1]);
+    cardano_txoutput *output = cardano_transaction_output_new(to_address, 80000);
+
+    cardano_transaction_builder_add_output(txbuilder, output);
+
+    //Add the source address as change address
+    cardano_address *change_addr = cardano_address_import_base58(addresses[0]);
+    if (cardano_transaction_builder_add_change_addr(txbuilder, change_addr)
+    != CARDANO_RESULT_SUCCESS) {
+        printf("Error adding change address\n");
+        return 1;
+    }
+
+    cardano_transaction *tx;
+    if (cardano_transaction_builder_finalize(txbuilder, &tx) != CARDANO_RESULT_SUCCESS)
+    {
+        printf("Error when finalizing transaction\n");
+        return 1;
+    }
+
+    cardano_txid_t txid;
+    cardano_transaction_txid(tx, &txid);
+
+    cardano_transaction_finalized *tf = cardano_transaction_finalized_new(tx);
+
+    if (cardano_transaction_finalized_add_witness(tf, input_xprv_bytes, PROTOCOL_MAGIC, txid.bytes)
+        != CARDANO_RESULT_SUCCESS)
+    {
+        printf("Couldn't add witness\n");
+        return 1;
+    }
+    cardano_xprv_bytes_delete(input_xprv_bytes);
+
+    cardano_signed_transaction *txaux;
+    if (cardano_transaction_finalized_output(tf, &txaux) != CARDANO_RESULT_SUCCESS)
+    {
+        printf("Error in finalized output\n");
+        return 1;
+    }
+
+    uint8_t *serialized_bytes;
+    size_t serialized_size;
+    if(cardano_signed_transaction_serialize(txaux, &serialized_bytes, &serialized_size) 
+    != CARDANO_RESULT_SUCCESS) {
+        printf("Error when serializing the transaction\n");
+        return 1;
+    }
+
+    //Print the resulting txid in hexadecimal notation
+    char txid_str[sizeof(txid) * 2 + 1];
+    for (unsigned int j = 0; j < sizeof(txid); ++j)
+    {
+        sprintf(txid_str + (j*2), "%02x", txid.bytes[j]);
+    }
+
+    //Write the binary encoded transaction to file
+    FILE *file = fopen(txid_str, "w");
+    fwrite(serialized_bytes, sizeof(uint8_t), serialized_size, file);
+    fclose(file);
+}

--- a/cardano-c/src/transaction.rs
+++ b/cardano-c/src/transaction.rs
@@ -235,7 +235,7 @@ pub extern "C" fn cardano_transaction_finalized_add_witness(
     let txid_slice = unsafe { slice::from_raw_parts(c_txid, TxId::HASH_SIZE) };
     let txid = TxId::try_from_slice(txid_slice).unwrap();
 
-    let witness = TxInWitness::new(protocol_magic, xprv, &txid);
+    let witness = TxInWitness::new_extended_pk(protocol_magic, xprv, &txid);
     if let Ok(()) = tf.add_witness(witness) {
         CardanoTransactionErrorCode::success()
     } else {

--- a/cardano-c/src/transaction.rs
+++ b/cardano-c/src/transaction.rs
@@ -197,6 +197,13 @@ pub extern "C" fn cardano_transaction_builder_finalize(
 }
 
 #[no_mangle]
+pub extern "C" fn cardano_transaction_txid(tx: TransactionPtr, out: *mut u8) {
+    let tx = unsafe { tx.as_mut() }.expect("Not a NULL PTR");
+    let slice = unsafe { slice::from_raw_parts_mut(out, 32) };
+    slice.copy_from_slice(tx.id().as_hash_bytes());
+}
+
+#[no_mangle]
 pub extern "C" fn cardano_transaction_delete(tx: TransactionPtr) {
     unsafe { Box::from_raw(tx) };
 }

--- a/cardano-c/src/wallet.rs
+++ b/cardano-c/src/wallet.rs
@@ -2,6 +2,7 @@ use cardano::address;
 use cardano::bip;
 use cardano::config::ProtocolMagic;
 use cardano::hdwallet;
+use cardano::hdwallet::XPrv;
 use cardano::wallet::bip44;
 use cardano::wallet::scheme::Wallet;
 
@@ -9,7 +10,7 @@ use std::os::raw::c_char;
 use std::{ffi, ptr, slice};
 
 use address::ffi_address_to_base58;
-use types::{AccountPtr, CardanoResult, WalletPtr};
+use types::{AccountPtr, CardanoResult, WalletPtr, XPrvPtr};
 
 /* ******************************************************************************* *
  *                                  Wallet object                                  *
@@ -57,6 +58,13 @@ pub extern "C" fn cardano_wallet_new(
 #[no_mangle]
 pub extern "C" fn cardano_wallet_delete(wallet_ptr: WalletPtr) {
     unsafe { Box::from_raw(wallet_ptr) };
+}
+
+#[no_mangle]
+pub extern "C" fn cardano_wallet_root_key(wallet_ptr: WalletPtr) -> XPrvPtr {
+    let wallet = unsafe { wallet_ptr.as_mut() }.expect("Not a NULL PTR");
+    let xprv: Box<XPrv> = Box::new((***wallet).clone());
+    Box::into_raw(xprv)
 }
 
 /* ******************************************************************************* *


### PR DESCRIPTION
# Summary

## Example
Add full example of creating a wallet, a transaction, signing it an serializing it. For the testnet.
Add Makefile for building the example.

## Add two functions 
- `cardano_wallet_root_key`
- `cardano_transaction_txid`

The first one is to be able to derive the private keys for signing.
The second one is because it is needed for the witness and the only way of getting it right now is for a tx already signed.

## Add to the header
Add `cardano_xprv_derive` to the header (it was implemented but not exported)
