### PR TITLE
AddressReadable prints AddressReadable("<addr>")

### DIFF
--- a/chain-addr/src/lib.rs
+++ b/chain-addr/src/lib.rs
@@ -324,7 +324,7 @@ impl AddressReadable {
 
 impl ToString for AddressReadable {
     fn to_string(&self) -> String {
-        self.0.clone()
+        self.0.as_str().to_string().clone()
     }
 }
 


### PR DESCRIPTION
This fix ensures the actual output is "\<addr\>".