### PR TITLE
AddressReadable prints AddressReadable("<addr>")

### DIFF
--- a/chain-addr/src/lib.rs
+++ b/chain-addr/src/lib.rs
@@ -322,9 +322,9 @@ impl AddressReadable {
     }
 }
 
-impl ToString for AddressReadable {
-    fn to_string(&self) -> String {
-        self.0.clone()
+impl std::fmt::Display for AddressReadable {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 


### PR DESCRIPTION
This fix ensures the actual output is "\<addr\>".