### PR TITLE
network: Added method PullHeaders

### DIFF
--- a/network-core/src/client/block.rs
+++ b/network-core/src/client/block.rs
@@ -21,18 +21,37 @@ pub trait BlockService: P2pService {
 
     /// The type of an asynchronous stream that provides blocks in
     /// response to method `pull_blocks_to_tip`.
-    type PullBlocksToTipStream: Stream<Item = Self::Block, Error = Error>;
+    type PullBlocksStream: Stream<Item = Self::Block, Error = Error>;
 
     /// The type of asynchronous futures returned by method `pull_blocks_to_tip`.
     ///
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a server-streamed response.
-    type PullBlocksToTipFuture: Future<Item = Self::PullBlocksToTipStream, Error = Error>;
+    type PullBlocksToTipFuture: Future<Item = Self::PullBlocksStream, Error = Error>;
 
     fn pull_blocks_to_tip(
         &mut self,
         from: &[<Self::Block as Block>::Id],
     ) -> Self::PullBlocksToTipFuture;
+
+    /// The type of an asynchronous stream that provides block headers in
+    /// response to method `pull_headers`.
+    type PullHeadersStream: Stream<Item = <Self::Block as HasHeader>::Header, Error = Error>;
+
+    /// The type of asynchronous futures returned by method `pull_headers`.
+    ///
+    /// The future resolves to a stream that will be used by the protocol
+    /// implementation to produce a server-streamed response.
+    type PullHeadersFuture: Future<Item = Self::PullHeadersStream, Error = Error>;
+
+    /// Requests headers of blocks in the blockchain's chronological order,
+    /// in the range between one of the given starting points, and
+    /// the given ending point.
+    fn pull_headers(
+        &mut self,
+        from: &[<Self::Block as Block>::Id],
+        to: &<Self::Block as Block>::Id,
+    ) -> Self::PullHeadersFuture;
 
     /// The type of an asynchronous stream that provides blocks in
     /// response to method `get_blocks`.

--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -29,14 +29,22 @@ pub trait BlockService: P2pService {
     type TipFuture: Future<Item = Self::Header, Error = Error> + Send + 'static;
 
     /// The type of an asynchronous stream that provides blocks in
-    /// response to `pull_blocks_to_*` methods.
+    /// response to `pull_blocks*` methods.
     type PullBlocksStream: Stream<Item = Self::Block, Error = Error> + Send + 'static;
 
-    /// The type of asynchronous futures returned by `pull_blocks_to_*` methods.
+    /// The type of asynchronous futures returned by `pull_blocks` method.
     ///
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a server-streamed response.
     type PullBlocksFuture: Future<Item = Self::PullBlocksStream, Error = Error> + Send + 'static;
+
+    /// The type of asynchronous futures returned by `pull_blocks_to_tip` method.
+    ///
+    /// The future resolves to a stream that will be used by the protocol
+    /// implementation to produce a server-streamed response.
+    type PullBlocksToTipFuture: Future<Item = Self::PullBlocksStream, Error = Error>
+        + Send
+        + 'static;
 
     /// The type of an asynchronous stream that provides blocks in
     /// response to `get_blocks` method.
@@ -49,10 +57,10 @@ pub trait BlockService: P2pService {
     type GetBlocksFuture: Future<Item = Self::GetBlocksStream, Error = Error> + Send + 'static;
 
     /// The type of an asynchronous stream that provides block headers in
-    /// response to `pull_headers_to_*` methods.
+    /// response to `pull_headers*` methods.
     type PullHeadersStream: Stream<Item = Self::Header, Error = Error> + Send + 'static;
 
-    /// The type of asynchronous futures returned by `pull_headers_to*` methods.
+    /// The type of asynchronous futures returned by `pull_headers` method.
     ///
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a server-streamed response.
@@ -96,19 +104,16 @@ pub trait BlockService: P2pService {
 
     /// Get blocks, walking forward in a range between either of the given
     /// starting points, and the ending point.
-    fn pull_blocks_to(
-        &mut self,
-        from: &[Self::BlockId],
-        to: &Self::BlockId,
-    ) -> Self::PullBlocksFuture;
+    fn pull_blocks(&mut self, from: &[Self::BlockId], to: &Self::BlockId)
+        -> Self::PullBlocksFuture;
 
     /// Stream blocks from either of the given starting points
     /// to the server's tip.
-    fn pull_blocks_to_tip(&mut self, from: &[Self::BlockId]) -> Self::PullBlocksFuture;
+    fn pull_blocks_to_tip(&mut self, from: &[Self::BlockId]) -> Self::PullBlocksToTipFuture;
 
     /// Get block headers, walking forward in a range between any of the given
     /// starting points, and the ending point.
-    fn pull_headers_to(
+    fn pull_headers(
         &mut self,
         from: &[Self::BlockId],
         to: &Self::BlockId,

--- a/network-grpc/proto/node.proto
+++ b/network-grpc/proto/node.proto
@@ -24,6 +24,15 @@ message MessageIds {
   repeated bytes ids = 1;
 }
 
+// Request message for method PullHeaders.
+message PullHeadersRequest {
+  // The identifiers of blocks to consider as the
+  // starting point, in order of appearance.
+  repeated bytes from = 1;
+  // The identifier of the end block.
+  bytes to = 2;
+}
+
 // Request message for method PullBlocksToTip.
 message PullBlocksToTipRequest {
   // The identifiers of blocks to consider as the
@@ -79,6 +88,14 @@ service Node {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
   rpc GetMessages(MessageIds) returns (stream Message) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+
+  // Requests headers of blocks in the chain in the chronological order,
+  // given a selection of possible starting blocks known by the requester,
+  // and the identifier of the end block to be included in the returned
+  // sequence.
+  rpc PullHeaders(PullHeadersRequest) returns (stream Header) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
 

--- a/network-ntt/src/client.rs
+++ b/network-ntt/src/client.rs
@@ -168,8 +168,10 @@ where
 {
     type Block = T;
     type TipFuture = RequestFuture<T::Header>;
-    type PullBlocksToTipStream = RequestStream<T>;
+    type PullBlocksStream = RequestStream<T>;
     type PullBlocksToTipFuture = PullBlocksToTip<T>;
+    type PullHeadersStream = RequestStream<T::Header>;
+    type PullHeadersFuture = RequestFuture<RequestStream<T::Header>>;
     type GetBlocksStream = RequestStream<T>;
     type GetBlocksFuture = RequestFuture<RequestStream<T>>;
     type UploadBlocksFuture = RequestFuture<()>;
@@ -198,6 +200,14 @@ where
             from: from[0].clone(),
             command_channel: self.channel.clone(),
         }
+    }
+
+    fn pull_headers(
+        &mut self,
+        _from: &[<Self::Block as Block>::Id],
+        _to: &<Self::Block as Block>::Id,
+    ) -> Self::PullHeadersFuture {
+        unimplemented!()
     }
 
     fn get_blocks(&mut self, _ids: &[<Self::Block as Block>::Id]) -> Self::GetBlocksFuture {

--- a/network-ntt/src/server.rs
+++ b/network-ntt/src/server.rs
@@ -171,7 +171,7 @@ where
                             .block_service()
                             .expect("block service is not implemented");
                         match get_block_header.to {
-                            Some(to) => service.pull_headers_to(&get_block_header.from, &to),
+                            Some(to) => service.pull_headers(&get_block_header.from, &to),
                             None => service.pull_headers_to_tip(&get_block_header.from),
                         }
                         .map_err(|err| err.to_string())
@@ -206,7 +206,7 @@ where
                             .node
                             .block_service()
                             .expect("block service is not implemented")
-                            .pull_blocks_to(&vec![get_blocks.from], &get_blocks.to)
+                            .pull_blocks(&vec![get_blocks.from], &get_blocks.to)
                             .map_err(|err| err.to_string())
                             .and_then(move |blocks| {
                                 let inner1 = sink.clone();


### PR DESCRIPTION
Reusing some NTT prior art, add a method that pulls blockchain headers between one of the checkpoint IDs of blocks present at the requester, and the ID of a block, ostensibly discovered from a new block announcement, up to which the chain needs to be retrieved.

Also lay some ground for a possible `PullBlocks` method (it already existed in the NTT support APIs as `pull_blocks_to`, now renamed) that does not need to have a different response stream than the one `PullBlocksToTip` produces, but may return a different future type to accommodate the different protocol exchange.