### PR TITLE
Send + 'static bounds for types returned by the network service implementation

### DIFF
--- a/network-core/src/server.rs
+++ b/network-core/src/server.rs
@@ -43,7 +43,7 @@ pub trait Node {
 /// distinguish subscription streams.
 pub trait P2pService {
     /// Network node identifier.
-    type NodeId: NodeId;
+    type NodeId: NodeId + Send + 'static;
 
     /// Returns the identifier of this node.
     fn node_id(&self) -> Self::NodeId;

--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -26,7 +26,7 @@ pub trait BlockService: P2pService {
     ///
     /// The future resolves to the block identifier and the block date
     /// of the current chain tip as known by the serving node.
-    type TipFuture: Future<Item = Self::Header, Error = Error>;
+    type TipFuture: Future<Item = Self::Header, Error = Error> + Send + 'static;
 
     /// The type of an asynchronous stream that provides blocks in
     /// response to `pull_blocks_to_*` methods.
@@ -36,7 +36,7 @@ pub trait BlockService: P2pService {
     ///
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a server-streamed response.
-    type PullBlocksFuture: Future<Item = Self::PullBlocksStream, Error = Error>;
+    type PullBlocksFuture: Future<Item = Self::PullBlocksStream, Error = Error> + Send + 'static;
 
     /// The type of an asynchronous stream that provides blocks in
     /// response to `get_blocks` method.
@@ -46,7 +46,7 @@ pub trait BlockService: P2pService {
     ///
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a server-streamed response.
-    type GetBlocksFuture: Future<Item = Self::GetBlocksStream, Error = Error>;
+    type GetBlocksFuture: Future<Item = Self::GetBlocksStream, Error = Error> + Send + 'static;
 
     /// The type of an asynchronous stream that provides block headers in
     /// response to `pull_headers_to_*` methods.
@@ -56,7 +56,7 @@ pub trait BlockService: P2pService {
     ///
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a server-streamed response.
-    type PullHeadersFuture: Future<Item = Self::PullHeadersStream, Error = Error>;
+    type PullHeadersFuture: Future<Item = Self::PullHeadersStream, Error = Error> + Send + 'static;
 
     /// The type of an asynchronous stream that provides block headers in
     /// response to `get_headers` methods.
@@ -66,10 +66,10 @@ pub trait BlockService: P2pService {
     ///
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a server-streamed response.
-    type GetHeadersFuture: Future<Item = Self::GetHeadersStream, Error = Error>;
+    type GetHeadersFuture: Future<Item = Self::GetHeadersStream, Error = Error> + Send + 'static;
 
     /// The type of asynchronous futures returned by method `on_uploaded_block`.
-    type OnUploadedBlockFuture: Future<Item = (), Error = Error>;
+    type OnUploadedBlockFuture: Future<Item = (), Error = Error> + Send + 'static;
 
     /// The type of an asynchronous stream that retrieves headers of new
     /// blocks as they are created.
@@ -79,7 +79,9 @@ pub trait BlockService: P2pService {
     ///
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a server-streamed response.
-    type BlockSubscriptionFuture: Future<Item = Self::BlockSubscription, Error = Error>;
+    type BlockSubscriptionFuture: Future<Item = Self::BlockSubscription, Error = Error>
+        + Send
+        + 'static;
 
     /// Request the current blockchain tip.
     /// The returned future resolves to the tip of the blockchain

--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -30,7 +30,7 @@ pub trait BlockService: P2pService {
 
     /// The type of an asynchronous stream that provides blocks in
     /// response to `pull_blocks_to_*` methods.
-    type PullBlocksStream: Stream<Item = Self::Block, Error = Error>;
+    type PullBlocksStream: Stream<Item = Self::Block, Error = Error> + Send + 'static;
 
     /// The type of asynchronous futures returned by `pull_blocks_to_*` methods.
     ///
@@ -40,7 +40,7 @@ pub trait BlockService: P2pService {
 
     /// The type of an asynchronous stream that provides blocks in
     /// response to `get_blocks` method.
-    type GetBlocksStream: Stream<Item = Self::Block, Error = Error>;
+    type GetBlocksStream: Stream<Item = Self::Block, Error = Error> + Send + 'static;
 
     /// The type of asynchronous futures returned by `get_blocks` methods.
     ///
@@ -50,7 +50,7 @@ pub trait BlockService: P2pService {
 
     /// The type of an asynchronous stream that provides block headers in
     /// response to `pull_headers_to_*` methods.
-    type PullHeadersStream: Stream<Item = Self::Header, Error = Error>;
+    type PullHeadersStream: Stream<Item = Self::Header, Error = Error> + Send + 'static;
 
     /// The type of asynchronous futures returned by `pull_headers_to*` methods.
     ///
@@ -60,7 +60,7 @@ pub trait BlockService: P2pService {
 
     /// The type of an asynchronous stream that provides block headers in
     /// response to `get_headers` methods.
-    type GetHeadersStream: Stream<Item = Self::Header, Error = Error>;
+    type GetHeadersStream: Stream<Item = Self::Header, Error = Error> + Send + 'static;
 
     /// The type of asynchronous futures returned by `get_headers` methods.
     ///
@@ -73,7 +73,7 @@ pub trait BlockService: P2pService {
 
     /// The type of an asynchronous stream that retrieves headers of new
     /// blocks as they are created.
-    type BlockSubscription: Stream<Item = BlockEvent<Self::Block>, Error = Error>;
+    type BlockSubscription: Stream<Item = BlockEvent<Self::Block>, Error = Error> + Send + 'static;
 
     /// The type of asynchronous futures returned by method `block_subscription`.
     ///

--- a/network-core/src/server/content.rs
+++ b/network-core/src/server/content.rs
@@ -25,7 +25,7 @@ pub trait ContentService: P2pService {
 
     /// The type of an asynchronous stream that provides message contents in
     /// response to `get_messages`.
-    type GetMessagesStream: Stream<Item = Self::Message, Error = Error>;
+    type GetMessagesStream: Stream<Item = Self::Message, Error = Error> + Send + 'static;
 
     /// The type of asynchronous futures returned by `get_messages`.
     ///
@@ -35,7 +35,7 @@ pub trait ContentService: P2pService {
 
     /// The type of an asynchronous stream that provides transactions announced
     /// by the peer via the bidirectional subscription.
-    type MessageSubscription: Stream<Item = Self::Message, Error = Error>;
+    type MessageSubscription: Stream<Item = Self::Message, Error = Error> + Send + 'static;
 
     /// The type of asynchronous futures returned by method `message_subscription`.
     ///

--- a/network-core/src/server/content.rs
+++ b/network-core/src/server/content.rs
@@ -17,12 +17,6 @@ pub trait ContentService: P2pService {
     /// The message identifier type for the blockchain.
     type MessageId: MessageId;
 
-    /// The type of asynchronous futures returned by method `propose_transactions`.
-    type ProposeTransactionsFuture: Future<
-        Item = ProposeTransactionsResponse<Self::MessageId>,
-        Error = Error,
-    >;
-
     /// The type of an asynchronous stream that provides message contents in
     /// response to `get_messages`.
     type GetMessagesStream: Stream<Item = Self::Message, Error = Error> + Send + 'static;
@@ -46,12 +40,6 @@ pub trait ContentService: P2pService {
     /// Get all transactions by their id.
     fn get_messages(&mut self, ids: &[Self::MessageId]) -> Self::GetMessagesFuture;
 
-    /// Given a list of transaction IDs, return status of the transactions
-    /// as known by this node.
-    ///
-    /// This method is only used by the NTT implementation.
-    fn propose_transactions(&mut self, ids: &[Self::MessageId]) -> Self::ProposeTransactionsFuture;
-
     /// Establishes a bidirectional subscription for announcing new messages.
     ///
     /// The network protocol implementation passes the node identifier of
@@ -67,10 +55,4 @@ pub trait ContentService: P2pService {
     ) -> Self::MessageSubscriptionFuture
     where
         In: Stream<Item = Self::Message, Error = Error> + Send + 'static;
-}
-
-/// Response from the `propose_transactions` method of a `TransactionService`.
-pub struct ProposeTransactionsResponse<Id> {
-    // TODO: define fully
-    _ids: Vec<Id>,
 }

--- a/network-core/src/server/content.rs
+++ b/network-core/src/server/content.rs
@@ -25,7 +25,7 @@ pub trait ContentService: P2pService {
     ///
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a server-streamed response.
-    type GetMessagesFuture: Future<Item = Self::GetMessagesStream, Error = Error>;
+    type GetMessagesFuture: Future<Item = Self::GetMessagesStream, Error = Error> + Send + 'static;
 
     /// The type of an asynchronous stream that provides transactions announced
     /// by the peer via the bidirectional subscription.
@@ -35,7 +35,9 @@ pub trait ContentService: P2pService {
     ///
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a server-streamed response.
-    type MessageSubscriptionFuture: Future<Item = Self::MessageSubscription, Error = Error>;
+    type MessageSubscriptionFuture: Future<Item = Self::MessageSubscription, Error = Error>
+        + Send
+        + 'static;
 
     /// Get all transactions by their id.
     fn get_messages(&mut self, ids: &[Self::MessageId]) -> Self::GetMessagesFuture;

--- a/network-core/src/server/gossip.rs
+++ b/network-core/src/server/gossip.rs
@@ -15,7 +15,7 @@ pub trait GossipService: P2pService {
 
     /// The type of an asynchronous stream that retrieves node gossip
     /// messages from a peer.
-    type GossipSubscription: Stream<Item = Gossip<Self::Node>, Error = Error>;
+    type GossipSubscription: Stream<Item = Gossip<Self::Node>, Error = Error> + Send + 'static;
 
     /// The type of asynchronous futures returned by method `gossip_subscription`.
     ///

--- a/network-core/src/server/gossip.rs
+++ b/network-core/src/server/gossip.rs
@@ -21,7 +21,9 @@ pub trait GossipService: P2pService {
     ///
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a server-streamed response.
-    type GossipSubscriptionFuture: Future<Item = Self::GossipSubscription, Error = Error>;
+    type GossipSubscriptionFuture: Future<Item = Self::GossipSubscription, Error = Error>
+        + Send
+        + 'static;
 
     /// Establishes a bidirectional subscription for node gossip messages.
     ///

--- a/network-grpc/Cargo.toml
+++ b/network-grpc/Cargo.toml
@@ -26,9 +26,9 @@ tower-util = "0.1"
 
 [dependencies.tower-grpc]
 git = "https://github.com/tower-rs/tower-grpc"
-rev = "0f15ae28f2a765e0cc38fe3d7e02a13aab7bdbd2"
+rev = "137e970e4b563c4e06d41d31d04cabbfd1005f85"
 
 [build-dependencies.tower-grpc-build]
 git = "https://github.com/tower-rs/tower-grpc"
-rev = "0f15ae28f2a765e0cc38fe3d7e02a13aab7bdbd2"
+rev = "137e970e4b563c4e06d41d31d04cabbfd1005f85"
 features = ["tower-h2"]

--- a/network-ntt/src/server.rs
+++ b/network-ntt/src/server.rs
@@ -232,15 +232,9 @@ where
                             .or_else(|_| Ok(())),
                     )))
                 }
-                Inbound::SendTransaction(_lwcid, tx) => {
-                    future::Either::B(future::Either::B(future::Either::B(
-                        server
-                            .node
-                            .content_service()
-                            .unwrap()
-                            .propose_transactions(&vec![tx])
-                            .then(|_| Ok(())), // FIXME handle the error
-                    )))
+                Inbound::SendTransaction(_lwcid, _tx) => {
+                    unimplemented!();
+                    future::Either::B(future::Either::B(future::Either::B(future::ok(()))))
                 }
                 _x => future::Either::A(future::ok(())),
             }


### PR DESCRIPTION
For the upcoming port of network-grpc to tower-hyper, it's convenient to add a requirement for future and stream objects returned by the network-core service implementation API to be sendable between threads.

Required for #717.

Other changes in this PR:
- Updated tower-grpc to the latest revision that supported tower-h2.
- Removed the obsolete method `propose_transactions` from `ContentService` and stubbed out its use
  in network-ntt.