### PR TITLE
Ledger serialization/deserialization

### DIFF
--- a/chain-addr/Cargo.toml
+++ b/chain-addr/Cargo.toml
@@ -16,6 +16,8 @@ chain-crypto = { path = "../chain-crypto" }
 cryptoxide = "0.1"
 cfg-if = "0.1"
 quickcheck = { version = "0.8", optional = true }
+serde = "^1.0"
+serde_derive = "^1.0"
 
 [dev-dependencies]
 quickcheck = "0.8"

--- a/chain-addr/src/lib.rs
+++ b/chain-addr/src/lib.rs
@@ -51,7 +51,7 @@ cfg_if! {
 // Allow to differentiate between address in
 // production and testing setting, so that
 // one type of address is not used in another setting.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde_derive::Serialize)]
 pub enum Discrimination {
     Production,
     Test,
@@ -442,6 +442,17 @@ impl property::Deserialize for Address {
             _ => unreachable!(),
         };
         Ok(Address(discr, kind))
+    }
+}
+
+impl serde::Serialize for Address {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // FIXME: we don't want to encode as a string in binary
+        // serialization formats.
+        serializer.serialize_str(&AddressReadable::from_address(&self).as_string())
     }
 }
 

--- a/chain-addr/src/lib.rs
+++ b/chain-addr/src/lib.rs
@@ -51,7 +51,9 @@ cfg_if! {
 // Allow to differentiate between address in
 // production and testing setting, so that
 // one type of address is not used in another setting.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde_derive::Serialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, serde_derive::Serialize, serde_derive::Deserialize,
+)]
 pub enum Discrimination {
     Production,
     Test,
@@ -453,6 +455,19 @@ impl serde::Serialize for Address {
         // FIXME: we don't want to encode as a string in binary
         // serialization formats.
         serializer.serialize_str(&AddressReadable::from_address(&self).as_string())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Address {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(
+            AddressReadable::from_string(&String::deserialize(deserializer)?)
+                .unwrap()
+                .to_address(),
+        )
     }
 }
 

--- a/chain-crypto/Cargo.toml
+++ b/chain-crypto/Cargo.toml
@@ -20,6 +20,7 @@ ed25519-bip32 = "0.1"
 quickcheck = {version = "0.8", optional = true }
 rand_chacha = {version = "0.1", optional = true }
 cfg-if = "0.1"
+serde = "^1.0"
 
 [dev-dependencies]
 quickcheck = "0.8"

--- a/chain-crypto/src/key.rs
+++ b/chain-crypto/src/key.rs
@@ -248,6 +248,17 @@ impl<A: AsymmetricKey> Bech32 for SecretKey<A> {
     }
 }
 
+impl<A: AsymmetricPublicKey> serde::Serialize for PublicKey<A> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // FIXME: we don't want to encode as a string in binary
+        // serialization formats.
+        serializer.serialize_str(&self.to_bech32_str())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/chain-crypto/src/key.rs
+++ b/chain-crypto/src/key.rs
@@ -259,6 +259,15 @@ impl<A: AsymmetricPublicKey> serde::Serialize for PublicKey<A> {
     }
 }
 
+impl<'de, A: AsymmetricPublicKey> serde::Deserialize<'de> for PublicKey<A> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self::try_from_bech32_str(&String::deserialize(deserializer)?).unwrap())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/chain-impl-mockchain/Cargo.toml
+++ b/chain-impl-mockchain/Cargo.toml
@@ -12,20 +12,22 @@ edition = "2018"
 [dependencies]
 num-traits = "0.2"
 num-derive = "0.2"
-serde = { version = "^1.0", optional = true }
-serde_derive = { version = "^1.0", optional = true }
+serde = { version = "^1.0", features = ["rc"] }
+serde_derive = "^1.0"
+serde_json = "1.0"
 chain-core = { path = "../chain-core" }
 chain-addr = { path = "../chain-addr" }
 chain-crypto = { path = "../chain-crypto" }
 chain-storage = { path = "../chain-storage" }
 chain-time = { path = "../chain-time" }
-cardano = { path= "../cardano" }
+cardano = { path= "../cardano", features=["generic-serialization"] }
 rand = "0.6"
 imhamt = { path = "../imhamt" }
 lazy_static = "1.3.0"
 strum = "0.15.0"
 strum_macros = "0.15.0"
 custom_error = "1.6"
+base64 = "0.9"
 
 [dev-dependencies]
 quickcheck = "0.8"

--- a/chain-impl-mockchain/src/account.rs
+++ b/chain-impl-mockchain/src/account.rs
@@ -11,7 +11,17 @@ pub use account::{LedgerError, SpendingCounter};
 pub type AccountAlg = Ed25519;
 
 /// Account Identifier (also used as Public Key)
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde_derive::Serialize)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde_derive::Serialize,
+    serde_derive::Deserialize,
+)]
 pub struct Identifier(PublicKey<AccountAlg>);
 
 impl From<PublicKey<AccountAlg>> for Identifier {

--- a/chain-impl-mockchain/src/account.rs
+++ b/chain-impl-mockchain/src/account.rs
@@ -11,7 +11,7 @@ pub use account::{LedgerError, SpendingCounter};
 pub type AccountAlg = Ed25519;
 
 /// Account Identifier (also used as Public Key)
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde_derive::Serialize)]
 pub struct Identifier(PublicKey<AccountAlg>);
 
 impl From<PublicKey<AccountAlg>> for Identifier {

--- a/chain-impl-mockchain/src/accounting/account.rs
+++ b/chain-impl-mockchain/src/accounting/account.rs
@@ -37,7 +37,7 @@ impl From<InsertError> for LedgerError {
     }
 }
 
-#[derive(Clone, serde_derive::Serialize)]
+#[derive(Clone, PartialEq, Eq, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct AccountState<Extra> {
     counter: SpendingCounter,
     delegation: Option<StakePoolId>,
@@ -126,7 +126,7 @@ impl<Extra: Clone> AccountState<Extra> {
 /// the counter is incremented. A matching counter
 /// needs to be used in the spending phase to make
 /// sure we have non-replayability of a transaction.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde_derive::Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct SpendingCounter(u32);
 
 impl SpendingCounter {
@@ -166,7 +166,7 @@ impl<'a, ID, Extra> Iterator for Iter<'a, ID, Extra> {
 }
 
 /// The public ledger of all accounts associated with their current state
-#[derive(Clone, serde_derive::Serialize)]
+#[derive(Clone, PartialEq, Eq, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct Ledger<ID: Hash + Eq, Extra>(Hamt<DefaultHasher, ID, AccountState<Extra>>);
 
 impl<ID: Clone + Eq + Hash, Extra: Clone> Ledger<ID, Extra> {

--- a/chain-impl-mockchain/src/accounting/account.rs
+++ b/chain-impl-mockchain/src/accounting/account.rs
@@ -37,7 +37,7 @@ impl From<InsertError> for LedgerError {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, serde_derive::Serialize)]
 pub struct AccountState<Extra> {
     counter: SpendingCounter,
     delegation: Option<StakePoolId>,
@@ -126,7 +126,7 @@ impl<Extra: Clone> AccountState<Extra> {
 /// the counter is incremented. A matching counter
 /// needs to be used in the spending phase to make
 /// sure we have non-replayability of a transaction.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde_derive::Serialize)]
 pub struct SpendingCounter(u32);
 
 impl SpendingCounter {
@@ -166,7 +166,7 @@ impl<'a, ID, Extra> Iterator for Iter<'a, ID, Extra> {
 }
 
 /// The public ledger of all accounts associated with their current state
-#[derive(Clone)]
+#[derive(Clone, serde_derive::Serialize)]
 pub struct Ledger<ID: Hash + Eq, Extra>(Hamt<DefaultHasher, ID, AccountState<Extra>>);
 
 impl<ID: Clone + Eq + Hash, Extra: Clone> Ledger<ID, Extra> {

--- a/chain-impl-mockchain/src/block/header.rs
+++ b/chain-impl-mockchain/src/block/header.rs
@@ -31,7 +31,7 @@ pub struct Common {
     pub chain_length: ChainLength,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde_derive::Serialize)]
 pub struct ChainLength(pub(crate) u32);
 
 /// FIXME SECURITY : we want to sign Common + everything in proof except the signature

--- a/chain-impl-mockchain/src/block/header.rs
+++ b/chain-impl-mockchain/src/block/header.rs
@@ -31,7 +31,18 @@ pub struct Common {
     pub chain_length: ChainLength,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde_derive::Serialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde_derive::Serialize,
+    serde_derive::Deserialize,
+)]
 pub struct ChainLength(pub(crate) u32);
 
 /// FIXME SECURITY : we want to sign Common + everything in proof except the signature

--- a/chain-impl-mockchain/src/block/version.rs
+++ b/chain-impl-mockchain/src/block/version.rs
@@ -83,6 +83,7 @@ impl BlockVersion {
     PartialOrd,
     Ord,
     Hash,
+    serde_derive::Serialize,
 )]
 pub enum ConsensusVersion {
     #[strum(to_string = "bft")]

--- a/chain-impl-mockchain/src/block/version.rs
+++ b/chain-impl-mockchain/src/block/version.rs
@@ -84,6 +84,7 @@ impl BlockVersion {
     Ord,
     Hash,
     serde_derive::Serialize,
+    serde_derive::Deserialize,
 )]
 pub enum ConsensusVersion {
     #[strum(to_string = "bft")]

--- a/chain-impl-mockchain/src/config.rs
+++ b/chain-impl-mockchain/src/config.rs
@@ -42,7 +42,7 @@ impl Into<ReadError> for Error {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, serde_derive::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
 pub enum ConfigParam {
     Block0Date(Block0Date),
     Discrimination(Discrimination),
@@ -201,7 +201,7 @@ trait ConfigParamVariant: Clone + Eq + PartialEq {
 }
 
 /// Seconds elapsed since 1-Jan-1970 (unix time)
-#[derive(Debug, Clone, Copy, Eq, PartialEq, serde_derive::Serialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct Block0Date(pub u64);
 
 impl ConfigParamVariant for Block0Date {

--- a/chain-impl-mockchain/src/config.rs
+++ b/chain-impl-mockchain/src/config.rs
@@ -42,7 +42,7 @@ impl Into<ReadError> for Error {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, serde_derive::Serialize)]
 pub enum ConfigParam {
     Block0Date(Block0Date),
     Discrimination(Discrimination),
@@ -201,7 +201,7 @@ trait ConfigParamVariant: Clone + Eq + PartialEq {
 }
 
 /// Seconds elapsed since 1-Jan-1970 (unix time)
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, serde_derive::Serialize)]
 pub struct Block0Date(pub u64);
 
 impl ConfigParamVariant for Block0Date {

--- a/chain-impl-mockchain/src/date.rs
+++ b/chain-impl-mockchain/src/date.rs
@@ -6,7 +6,7 @@ use std::{error, fmt, num::ParseIntError, str};
 /// Non unique identifier of the transaction position in the
 /// blockchain. There may be many transactions related to the same
 /// `SlotId`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde_derive::Serialize)]
 pub struct BlockDate {
     pub epoch: Epoch,
     pub slot_id: SlotId,

--- a/chain-impl-mockchain/src/date.rs
+++ b/chain-impl-mockchain/src/date.rs
@@ -6,7 +6,18 @@ use std::{error, fmt, num::ParseIntError, str};
 /// Non unique identifier of the transaction position in the
 /// blockchain. There may be many transactions related to the same
 /// `SlotId`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde_derive::Serialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde_derive::Serialize,
+    serde_derive::Deserialize,
+)]
 pub struct BlockDate {
     pub epoch: Epoch,
     pub slot_id: SlotId,

--- a/chain-impl-mockchain/src/fee.rs
+++ b/chain-impl-mockchain/src/fee.rs
@@ -5,7 +5,16 @@ use chain_addr::Address;
 
 /// Linear fee using the basic affine formula
 /// `COEFFICIENT * bytes(COUNT(tx.inputs) + COUNT(tx.outputs)) + CONSTANT + CERTIFICATE*COUNT(certificates)`.
-#[derive(PartialEq, Eq, PartialOrd, Debug, Clone, Copy, serde_derive::Serialize)]
+#[derive(
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Debug,
+    Clone,
+    Copy,
+    serde_derive::Serialize,
+    serde_derive::Deserialize,
+)]
 pub struct LinearFee {
     pub constant: u64,
     pub coefficient: u64,

--- a/chain-impl-mockchain/src/fee.rs
+++ b/chain-impl-mockchain/src/fee.rs
@@ -5,7 +5,7 @@ use chain_addr::Address;
 
 /// Linear fee using the basic affine formula
 /// `COEFFICIENT * bytes(COUNT(tx.inputs) + COUNT(tx.outputs)) + CONSTANT + CERTIFICATE*COUNT(certificates)`.
-#[derive(PartialEq, Eq, PartialOrd, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, PartialOrd, Debug, Clone, Copy, serde_derive::Serialize)]
 pub struct LinearFee {
     pub constant: u64,
     pub coefficient: u64,

--- a/chain-impl-mockchain/src/key.rs
+++ b/chain-impl-mockchain/src/key.rs
@@ -6,6 +6,7 @@ use chain_core::property;
 use chain_crypto as crypto;
 use chain_crypto::{AsymmetricKey, AsymmetricPublicKey, SigningAlgorithm, VerificationAlgorithm};
 
+use base64;
 use std::str::FromStr;
 
 pub type SpendingPublicKey = crypto::PublicKey<crypto::Ed25519>;
@@ -219,6 +220,17 @@ impl property::Deserialize for Hash {
         let mut buffer = [0; crypto::Blake2b256::HASH_SIZE];
         reader.read_exact(&mut buffer)?;
         Ok(Hash(crypto::Blake2b256::from(buffer)))
+    }
+}
+
+impl serde::Serialize for Hash {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // FIXME: we don't want to encode as a string in binary
+        // serialization formats.
+        serializer.serialize_str(&base64::encode(self.as_ref()))
     }
 }
 

--- a/chain-impl-mockchain/src/key.rs
+++ b/chain-impl-mockchain/src/key.rs
@@ -6,7 +6,6 @@ use chain_core::property;
 use chain_crypto as crypto;
 use chain_crypto::{AsymmetricKey, AsymmetricPublicKey, SigningAlgorithm, VerificationAlgorithm};
 
-use base64;
 use std::str::FromStr;
 
 pub type SpendingPublicKey = crypto::PublicKey<crypto::Ed25519>;
@@ -230,7 +229,16 @@ impl serde::Serialize for Hash {
     {
         // FIXME: we don't want to encode as a string in binary
         // serialization formats.
-        serializer.serialize_str(&base64::encode(self.as_ref()))
+        serializer.serialize_str(&format!("{}", self.0))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Hash {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self::from_str(&String::deserialize(deserializer)?).unwrap())
     }
 }
 

--- a/chain-impl-mockchain/src/leadership/bft.rs
+++ b/chain-impl-mockchain/src/leadership/bft.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 pub type BftVerificationAlg = Ed25519;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde_derive::Serialize)]
 pub struct LeaderId(pub(crate) PublicKey<BftVerificationAlg>);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/chain-impl-mockchain/src/leadership/bft.rs
+++ b/chain-impl-mockchain/src/leadership/bft.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 pub type BftVerificationAlg = Ed25519;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde_derive::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct LeaderId(pub(crate) PublicKey<BftVerificationAlg>);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/chain-impl-mockchain/src/leadership/genesis/mod.rs
+++ b/chain-impl-mockchain/src/leadership/genesis/mod.rs
@@ -16,7 +16,7 @@ pub use vrfeval::{ActiveSlotsCoeff, ActiveSlotsCoeffError, Nonce, Witness, Witne
 use vrfeval::{PercentStake, VrfEvaluator};
 
 /// Praos Leader consisting of the KES public key and VRF public key
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde_derive::Serialize)]
 pub struct GenesisPraosLeader {
     pub kes_public_key: PublicKey<SumEd25519_12>,
     pub vrf_public_key: PublicKey<Curve25519_2HashDH>,

--- a/chain-impl-mockchain/src/leadership/genesis/mod.rs
+++ b/chain-impl-mockchain/src/leadership/genesis/mod.rs
@@ -16,7 +16,7 @@ pub use vrfeval::{ActiveSlotsCoeff, ActiveSlotsCoeffError, Nonce, Witness, Witne
 use vrfeval::{PercentStake, VrfEvaluator};
 
 /// Praos Leader consisting of the KES public key and VRF public key
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde_derive::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct GenesisPraosLeader {
     pub kes_public_key: PublicKey<SumEd25519_12>,
     pub vrf_public_key: PublicKey<Curve25519_2HashDH>,

--- a/chain-impl-mockchain/src/leadership/genesis/vrfeval.rs
+++ b/chain-impl-mockchain/src/leadership/genesis/vrfeval.rs
@@ -14,7 +14,7 @@ use std::error::Error;
 use std::fmt::{self, Display, Formatter};
 
 /// Nonce gathered per block
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde_derive::Serialize)]
 pub struct Nonce([u8; 32]);
 
 impl Nonce {
@@ -50,7 +50,7 @@ impl Error for ActiveSlotsCoeffError {}
 /// Active slots coefficient used for calculating minimum stake to become slot leader candidate
 /// Described in Ouroboros Praos paper, also referred to as parameter F of phi function
 /// Always in range (0, 1]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde_derive::Serialize)]
 pub struct ActiveSlotsCoeff(pub(crate) Milli);
 
 impl TryFrom<Milli> for ActiveSlotsCoeff {

--- a/chain-impl-mockchain/src/ledger.rs
+++ b/chain-impl-mockchain/src/ledger.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 // static parameters, effectively this is constant in the parameter of the blockchain
-#[derive(Clone)]
+#[derive(Clone, serde_derive::Serialize)]
 pub struct LedgerStaticParameters {
     pub block0_initial_hash: HeaderHash,
     pub block0_start_time: config::Block0Date,
@@ -40,7 +40,7 @@ pub struct LedgerParameters {
 ///
 /// The ledger can be easily and cheaply cloned despite containing reference
 /// to a lot of data (millions of utxos, thousands of accounts, ..)
-#[derive(Clone)]
+#[derive(Clone, serde_derive::Serialize)]
 pub struct Ledger {
     pub(crate) utxos: utxo::Ledger<Address>,
     pub(crate) oldutxos: utxo::Ledger<legacy::OldAddress>,

--- a/chain-impl-mockchain/src/ledger.rs
+++ b/chain-impl-mockchain/src/ledger.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 // static parameters, effectively this is constant in the parameter of the blockchain
-#[derive(Clone, serde_derive::Serialize)]
+#[derive(Clone, PartialEq, Eq, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct LedgerStaticParameters {
     pub block0_initial_hash: HeaderHash,
     pub block0_start_time: config::Block0Date,
@@ -40,7 +40,7 @@ pub struct LedgerParameters {
 ///
 /// The ledger can be easily and cheaply cloned despite containing reference
 /// to a lot of data (millions of utxos, thousands of accounts, ..)
-#[derive(Clone, serde_derive::Serialize)]
+#[derive(Clone, PartialEq, Eq, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct Ledger {
     pub(crate) utxos: utxo::Ledger<Address>,
     pub(crate) oldutxos: utxo::Ledger<legacy::OldAddress>,

--- a/chain-impl-mockchain/src/message/config.rs
+++ b/chain-impl-mockchain/src/message/config.rs
@@ -2,12 +2,7 @@ use crate::config::ConfigParam;
 use chain_core::mempack::{ReadBuf, ReadError, Readable};
 use chain_core::property;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "generic-serialization",
-    derive(serde_derive::Serialize, serde_derive::Deserialize),
-    serde(transparent)
-)]
+#[derive(Debug, Clone, PartialEq, Eq, serde_derive::Serialize)]
 pub struct ConfigParams(pub(crate) Vec<ConfigParam>);
 
 impl ConfigParams {

--- a/chain-impl-mockchain/src/message/config.rs
+++ b/chain-impl-mockchain/src/message/config.rs
@@ -2,7 +2,7 @@ use crate::config::ConfigParam;
 use chain_core::mempack::{ReadBuf, ReadError, Readable};
 use chain_core::property;
 
-#[derive(Debug, Clone, PartialEq, Eq, serde_derive::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct ConfigParams(pub(crate) Vec<ConfigParam>);
 
 impl ConfigParams {

--- a/chain-impl-mockchain/src/milli.rs
+++ b/chain-impl-mockchain/src/milli.rs
@@ -3,7 +3,18 @@ use std::{fmt, iter};
 
 const MILLI_MULTIPLIER: u64 = 1000;
 
-#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd, serde_derive::Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    serde_derive::Serialize,
+    serde_derive::Deserialize,
+)]
 pub struct Milli(u64);
 
 impl Milli {

--- a/chain-impl-mockchain/src/milli.rs
+++ b/chain-impl-mockchain/src/milli.rs
@@ -3,7 +3,7 @@ use std::{fmt, iter};
 
 const MILLI_MULTIPLIER: u64 = 1000;
 
-#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd, serde_derive::Serialize)]
 pub struct Milli(u64);
 
 impl Milli {

--- a/chain-impl-mockchain/src/multisig/declaration.rs
+++ b/chain-impl-mockchain/src/multisig/declaration.rs
@@ -5,7 +5,7 @@ use super::index::{Index, TreeIndex, LEVEL_MAXLIMIT};
 pub use crate::transaction::WitnessMultisigData;
 
 /// Account Identifier (also used as Public Key)
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde_derive::Serialize)]
 pub struct Identifier(key::Hash);
 
 impl AsRef<[u8]> for Identifier {
@@ -39,7 +39,7 @@ impl std::fmt::Display for Identifier {
 ///
 /// * a threshold that need to be between 1 and the size of owners
 /// * a bunch of owners which is either a hash of a key, or a sub declaration
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde_derive::Serialize)]
 pub struct Declaration {
     pub(crate) threshold: u8, // between 1 and len(owners)
     pub(crate) owners: Vec<DeclElement>,
@@ -55,7 +55,7 @@ impl Declaration {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde_derive::Serialize)]
 pub enum DeclElement {
     Sub(Declaration),
     Owner(key::Hash),

--- a/chain-impl-mockchain/src/multisig/declaration.rs
+++ b/chain-impl-mockchain/src/multisig/declaration.rs
@@ -5,7 +5,17 @@ use super::index::{Index, TreeIndex, LEVEL_MAXLIMIT};
 pub use crate::transaction::WitnessMultisigData;
 
 /// Account Identifier (also used as Public Key)
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde_derive::Serialize)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde_derive::Serialize,
+    serde_derive::Deserialize,
+)]
 pub struct Identifier(key::Hash);
 
 impl AsRef<[u8]> for Identifier {
@@ -39,7 +49,7 @@ impl std::fmt::Display for Identifier {
 ///
 /// * a threshold that need to be between 1 and the size of owners
 /// * a bunch of owners which is either a hash of a key, or a sub declaration
-#[derive(Debug, Clone, serde_derive::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct Declaration {
     pub(crate) threshold: u8, // between 1 and len(owners)
     pub(crate) owners: Vec<DeclElement>,
@@ -55,7 +65,7 @@ impl Declaration {
     }
 }
 
-#[derive(Debug, Clone, serde_derive::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde_derive::Serialize, serde_derive::Deserialize)]
 pub enum DeclElement {
     Sub(Declaration),
     Owner(key::Hash),

--- a/chain-impl-mockchain/src/multisig/ledger.rs
+++ b/chain-impl-mockchain/src/multisig/ledger.rs
@@ -5,7 +5,7 @@ use super::declaration::{Declaration, DeclarationError, Identifier};
 use crate::accounting::account::{self, SpendingCounter};
 use crate::value::{Value, ValueError};
 
-#[derive(Clone)]
+#[derive(Clone, serde_derive::Serialize)]
 pub struct Ledger {
     // TODO : investigate about merging the declarations and the accounts in
     // one with an extension on the account::Ledger

--- a/chain-impl-mockchain/src/multisig/ledger.rs
+++ b/chain-impl-mockchain/src/multisig/ledger.rs
@@ -5,7 +5,7 @@ use super::declaration::{Declaration, DeclarationError, Identifier};
 use crate::accounting::account::{self, SpendingCounter};
 use crate::value::{Value, ValueError};
 
-#[derive(Clone, serde_derive::Serialize)]
+#[derive(Clone, PartialEq, Eq, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct Ledger {
     // TODO : investigate about merging the declarations and the accounts in
     // one with an extension on the account::Ledger

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -14,7 +14,7 @@ use chain_time::era::TimeEra;
 use std::convert::TryFrom;
 use std::sync::Arc;
 
-#[derive(Clone, Debug, Eq, PartialEq, serde_derive::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct Settings {
     pub era: TimeEra,
     pub consensus_version: ConsensusVersion,

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -14,7 +14,7 @@ use chain_time::era::TimeEra;
 use std::convert::TryFrom;
 use std::sync::Arc;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, serde_derive::Serialize)]
 pub struct Settings {
     pub era: TimeEra,
     pub consensus_version: ConsensusVersion,

--- a/chain-impl-mockchain/src/stake/delegation.rs
+++ b/chain-impl-mockchain/src/stake/delegation.rs
@@ -7,7 +7,7 @@ use crate::transaction::AccountIdentifier;
 pub type PoolTable = Hamt<DefaultHasher, StakePoolId, StakePoolInfo>;
 
 /// A structure that keeps track of stake keys and stake pools.
-#[derive(Clone, serde_derive::Serialize)]
+#[derive(Clone, PartialEq, Eq, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct DelegationState {
     pub(crate) stake_pools: PoolTable,
 }

--- a/chain-impl-mockchain/src/stake/delegation.rs
+++ b/chain-impl-mockchain/src/stake/delegation.rs
@@ -7,7 +7,7 @@ use crate::transaction::AccountIdentifier;
 pub type PoolTable = Hamt<DefaultHasher, StakePoolId, StakePoolInfo>;
 
 /// A structure that keeps track of stake keys and stake pools.
-#[derive(Clone)]
+#[derive(Clone, serde_derive::Serialize)]
 pub struct DelegationState {
     pub(crate) stake_pools: PoolTable,
 }

--- a/chain-impl-mockchain/src/stake/role.rs
+++ b/chain-impl-mockchain/src/stake/role.rs
@@ -5,10 +5,10 @@ use crate::leadership::genesis::GenesisPraosLeader;
 use chain_core::mempack::{ReadBuf, ReadError, Readable};
 use chain_core::property;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde_derive::Serialize)]
 pub struct StakePoolId(Hash);
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde_derive::Serialize)]
 pub struct StakePoolInfo {
     pub serial: u128,
     pub owners: Vec<account::Identifier>,

--- a/chain-impl-mockchain/src/stake/role.rs
+++ b/chain-impl-mockchain/src/stake/role.rs
@@ -5,10 +5,20 @@ use crate::leadership::genesis::GenesisPraosLeader;
 use chain_core::mempack::{ReadBuf, ReadError, Readable};
 use chain_core::property;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde_derive::Serialize)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    serde_derive::Serialize,
+    serde_derive::Deserialize,
+)]
 pub struct StakePoolId(Hash);
 
-#[derive(Debug, Clone, PartialEq, Eq, serde_derive::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct StakePoolInfo {
     pub serial: u128,
     pub owners: Vec<account::Identifier>,

--- a/chain-impl-mockchain/src/transaction/transfer.rs
+++ b/chain-impl-mockchain/src/transaction/transfer.rs
@@ -183,7 +183,7 @@ impl Readable for Input {
 
 /// Information how tokens are spent.
 /// A value of tokens is sent to the address.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde_derive::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct Output<Address> {
     pub address: Address,
     pub value: Value,

--- a/chain-impl-mockchain/src/transaction/transfer.rs
+++ b/chain-impl-mockchain/src/transaction/transfer.rs
@@ -183,7 +183,7 @@ impl Readable for Input {
 
 /// Information how tokens are spent.
 /// A value of tokens is sent to the address.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde_derive::Serialize)]
 pub struct Output<Address> {
     pub address: Address,
     pub value: Value,

--- a/chain-impl-mockchain/src/update.rs
+++ b/chain-impl-mockchain/src/update.rs
@@ -7,7 +7,7 @@ use chain_crypto::{Ed25519, Ed25519Extended, PublicKey, SecretKey, Verification}
 use std::collections::{BTreeMap, HashSet};
 use std::iter;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde_derive::Serialize)]
 pub struct UpdateState {
     // Note: we use a BTreeMap to ensure that proposals are processed
     // in a well-defined (sorted) order.
@@ -132,7 +132,7 @@ impl UpdateState {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde_derive::Serialize)]
 pub struct UpdateProposalState {
     pub proposal: UpdateProposal,
     pub proposal_date: BlockDate,
@@ -215,7 +215,7 @@ impl std::error::Error for Error {}
 pub type UpdateProposalId = crate::message::MessageId;
 pub type UpdateVoterId = bft::LeaderId;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde_derive::Serialize)]
 pub struct UpdateProposal {
     pub changes: ConfigParams,
 }
@@ -446,4 +446,6 @@ mod test {
             }
         }
     }
+
+    // FIXME: add update tests
 }

--- a/chain-impl-mockchain/src/update.rs
+++ b/chain-impl-mockchain/src/update.rs
@@ -7,7 +7,7 @@ use chain_crypto::{Ed25519, Ed25519Extended, PublicKey, SecretKey, Verification}
 use std::collections::{BTreeMap, HashSet};
 use std::iter;
 
-#[derive(Clone, Debug, serde_derive::Serialize)]
+#[derive(Clone, PartialEq, Eq, Debug, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct UpdateState {
     // Note: we use a BTreeMap to ensure that proposals are processed
     // in a well-defined (sorted) order.
@@ -132,7 +132,7 @@ impl UpdateState {
     }
 }
 
-#[derive(Clone, Debug, serde_derive::Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct UpdateProposalState {
     pub proposal: UpdateProposal,
     pub proposal_date: BlockDate,
@@ -215,7 +215,7 @@ impl std::error::Error for Error {}
 pub type UpdateProposalId = crate::message::MessageId;
 pub type UpdateVoterId = bft::LeaderId;
 
-#[derive(Clone, Debug, PartialEq, Eq, serde_derive::Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct UpdateProposal {
     pub changes: ConfigParams,
 }

--- a/chain-impl-mockchain/src/utxo.rs
+++ b/chain-impl-mockchain/src/utxo.rs
@@ -44,7 +44,7 @@ impl From<RemoveError> for Error {
 }
 
 /// Hold all the individual outputs that remain unspent
-#[derive(Clone, serde_derive::Serialize)]
+#[derive(Clone, PartialEq, Eq, serde_derive::Serialize, serde_derive::Deserialize)]
 struct TransactionUnspents<OutAddress>(BTreeMap<TransactionIndex, Output<OutAddress>>);
 
 impl<OutAddress: Clone> TransactionUnspents<OutAddress> {
@@ -73,7 +73,7 @@ impl<OutAddress: Clone> TransactionUnspents<OutAddress> {
 }
 
 /// Ledger of UTXO
-#[derive(Clone, serde_derive::Serialize)]
+#[derive(Clone, PartialEq, Eq, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct Ledger<OutAddress>(Hamt<DefaultHasher, TransactionId, TransactionUnspents<OutAddress>>);
 
 pub struct Iter<'a, V> {

--- a/chain-impl-mockchain/src/utxo.rs
+++ b/chain-impl-mockchain/src/utxo.rs
@@ -44,7 +44,7 @@ impl From<RemoveError> for Error {
 }
 
 /// Hold all the individual outputs that remain unspent
-#[derive(Clone)]
+#[derive(Clone, serde_derive::Serialize)]
 struct TransactionUnspents<OutAddress>(BTreeMap<TransactionIndex, Output<OutAddress>>);
 
 impl<OutAddress: Clone> TransactionUnspents<OutAddress> {
@@ -73,7 +73,7 @@ impl<OutAddress: Clone> TransactionUnspents<OutAddress> {
 }
 
 /// Ledger of UTXO
-#[derive(Clone)]
+#[derive(Clone, serde_derive::Serialize)]
 pub struct Ledger<OutAddress>(Hamt<DefaultHasher, TransactionId, TransactionUnspents<OutAddress>>);
 
 pub struct Iter<'a, V> {

--- a/chain-impl-mockchain/src/value.rs
+++ b/chain-impl-mockchain/src/value.rs
@@ -3,7 +3,18 @@ use chain_core::property;
 use std::ops;
 
 /// Unspent transaction value.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde_derive::Serialize)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde_derive::Serialize,
+    serde_derive::Deserialize,
+)]
 pub struct Value(pub u64);
 
 impl Value {

--- a/chain-impl-mockchain/src/value.rs
+++ b/chain-impl-mockchain/src/value.rs
@@ -3,8 +3,7 @@ use chain_core::property;
 use std::ops;
 
 /// Unspent transaction value.
-#[cfg_attr(feature = "generic-serialization", derive(serde_derive::Serialize))]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde_derive::Serialize)]
 pub struct Value(pub u64);
 
 impl Value {

--- a/chain-impl-mockchain/tests/ledger/ledger_tests.rs
+++ b/chain-impl-mockchain/tests/ledger/ledger_tests.rs
@@ -80,7 +80,7 @@ pub fn utxo_to_utxo_correct_transaction() {
         address: user1_address.clone(),
         value: Value(42000),
     });
-    let (block0_hash, ledger) =
+    let (_block0_hash, ledger) =
         ledger::create_initial_fake_ledger(&[message], ConfigBuilder::new().build());
 
     let signed_tx = TransactionBuilder::new()
@@ -245,8 +245,14 @@ pub fn serialize() {
         value: Value(42000),
     });
 
-    let (_block0_hash, ledger) =
+    let (block0_hash, ledger) =
         ledger::create_initial_fake_ledger(&[message], ConfigBuilder::new().build());
 
-    println!("{}", serde_json::to_string(&ledger).unwrap());
+    let json = serde_json::to_string(&ledger).unwrap();
+    println!("{}", json);
+
+    let restored_ledger: chain_impl_mockchain::ledger::Ledger =
+        serde_json::from_str(&json).unwrap();
+
+    assert!(ledger == restored_ledger);
 }

--- a/chain-impl-mockchain/tests/ledger/ledger_tests.rs
+++ b/chain-impl-mockchain/tests/ledger/ledger_tests.rs
@@ -80,7 +80,7 @@ pub fn utxo_to_utxo_correct_transaction() {
         address: user1_address.clone(),
         value: Value(42000),
     });
-    let (_block0_hash, ledger) =
+    let (block0_hash, ledger) =
         ledger::create_initial_fake_ledger(&[message], ConfigBuilder::new().build());
 
     let signed_tx = TransactionBuilder::new()

--- a/chain-impl-mockchain/tests/ledger/ledger_tests.rs
+++ b/chain-impl-mockchain/tests/ledger/ledger_tests.rs
@@ -228,5 +228,25 @@ pub fn delegation_to_account_correct_transaction() {
 
     let dyn_params = ledger.get_ledger_parameters();
     let r = ledger.apply_transaction(&signed_tx, &dyn_params);
-    assert!(r.is_ok())
+    assert!(r.is_ok());
+}
+
+#[test]
+pub fn serialize() {
+    let discrimination = Discrimination::Test;
+
+    let mut rng = rand::thread_rng();
+    let mut delegation_rng = rand::thread_rng();
+    let (_sk1, _pk1, user1_address) =
+        accounts::make_utxo_delegation_key(&mut rng, &mut delegation_rng, &discrimination);
+
+    let (message, _utxos) = ledger::create_initial_transaction(Output {
+        address: user1_address.clone(),
+        value: Value(42000),
+    });
+
+    let (_block0_hash, ledger) =
+        ledger::create_initial_fake_ledger(&[message], ConfigBuilder::new().build());
+
+    println!("{}", serde_json::to_string(&ledger).unwrap());
 }

--- a/chain-time/Cargo.toml
+++ b/chain-time/Cargo.toml
@@ -5,3 +5,5 @@ authors = ["Vincent Hanquez <vincent.hanquez@iohk.io>"]
 edition = "2018"
 
 [dependencies]
+serde = "^1.0"
+serde_derive = "^1.0"

--- a/chain-time/src/era.rs
+++ b/chain-time/src/era.rs
@@ -3,7 +3,17 @@
 use crate::timeframe::Slot;
 
 /// Epoch number
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde_derive::Serialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde_derive::Serialize,
+    serde_derive::Deserialize,
+)]
 pub struct Epoch(pub u32);
 
 /// Slot Offset *in* a given epoch
@@ -19,7 +29,7 @@ pub struct EpochPosition {
 
 /// Describe a new era, which start at epoch_start and is associated
 /// to a specific slot. Each epoch have a constant number of slots on a given time era.
-#[derive(Debug, Clone, PartialEq, Eq, serde_derive::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct TimeEra {
     epoch_start: Epoch,
     slot_start: Slot,

--- a/chain-time/src/era.rs
+++ b/chain-time/src/era.rs
@@ -3,7 +3,7 @@
 use crate::timeframe::Slot;
 
 /// Epoch number
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde_derive::Serialize)]
 pub struct Epoch(pub u32);
 
 /// Slot Offset *in* a given epoch
@@ -19,7 +19,7 @@ pub struct EpochPosition {
 
 /// Describe a new era, which start at epoch_start and is associated
 /// to a specific slot. Each epoch have a constant number of slots on a given time era.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde_derive::Serialize)]
 pub struct TimeEra {
     epoch_start: Epoch,
     slot_start: Slot,

--- a/chain-time/src/timeframe.rs
+++ b/chain-time/src/timeframe.rs
@@ -5,7 +5,17 @@ use std::time::{Duration, SystemTime};
 ///
 /// The slots are not comparable to others slots made on a
 /// different time frame
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde_derive::Serialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde_derive::Serialize,
+    serde_derive::Deserialize,
+)]
 pub struct Slot(pub(crate) u64);
 
 impl From<Slot> for u64 {

--- a/chain-time/src/timeframe.rs
+++ b/chain-time/src/timeframe.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, SystemTime};
 ///
 /// The slots are not comparable to others slots made on a
 /// different time frame
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde_derive::Serialize)]
 pub struct Slot(pub(crate) u64);
 
 impl From<Slot> for u64 {

--- a/imhamt/Cargo.toml
+++ b/imhamt/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Vincent Hanquez <vincent.hanquez@iohk.io>"]
 edition = "2018"
 
 [dependencies]
+serde = "^1.0"
 
 [dev-dependencies]
 quickcheck = "0.8"

--- a/imhamt/src/hamt.rs
+++ b/imhamt/src/hamt.rs
@@ -242,7 +242,9 @@ impl<H: Default + Hasher, K: Eq + Hash, V: PartialEq> PartialEq for Hamt<H, K, V
         }
         for (k, v) in self.iter() {
             if let Some(v2) = other.lookup(k) {
-                if v != v2 { return false; }
+                if v != v2 {
+                    return false;
+                }
             } else {
                 return false;
             }

--- a/imhamt/src/hamt.rs
+++ b/imhamt/src/hamt.rs
@@ -237,11 +237,17 @@ impl<
 
 impl<H: Default + Hasher, K: Eq + Hash, V: PartialEq> PartialEq for Hamt<H, K, V> {
     fn eq(&self, other: &Self) -> bool {
-        // FIXME: this is inefficient but we're only using it for
-        // debug asserts at the moment.
-        let m1: std::collections::HashMap<&K, &V> = self.iter().collect();
-        let m2: std::collections::HashMap<&K, &V> = self.iter().collect();
-        return m1 == m2;
+        if self.size() != other.size() {
+            return false;
+        }
+        for (k, v) in self.iter() {
+            if let Some(v2) = other.lookup(k) {
+                if v != v2 { return false; }
+            } else {
+                return false;
+            }
+        }
+        return true;
     }
 }
 

--- a/imhamt/src/hamt.rs
+++ b/imhamt/src/hamt.rs
@@ -218,3 +218,31 @@ impl<H: Default + Hasher, K: Eq + Hash + serde::Serialize, V: serde::Serialize> 
         map.end()
     }
 }
+
+impl<
+        'de,
+        H: Default + Hasher,
+        K: Eq + Hash + serde::Deserialize<'de>,
+        V: serde::Deserialize<'de>,
+    > serde::Deserialize<'de> for Hamt<H, K, V>
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let map = std::collections::HashMap::<K, V>::deserialize(deserializer)?;
+        Ok(Self::from_iter(map.into_iter()))
+    }
+}
+
+impl<H: Default + Hasher, K: Eq + Hash, V: PartialEq> PartialEq for Hamt<H, K, V> {
+    fn eq(&self, other: &Self) -> bool {
+        // FIXME: this is inefficient but we're only using it for
+        // debug asserts at the moment.
+        let m1: std::collections::HashMap<&K, &V> = self.iter().collect();
+        let m2: std::collections::HashMap<&K, &V> = self.iter().collect();
+        return m1 == m2;
+    }
+}
+
+impl<H: Default + Hasher, K: Eq + Hash, V: Eq> Eq for Hamt<H, K, V> {}

--- a/imhamt/src/hamt.rs
+++ b/imhamt/src/hamt.rs
@@ -202,3 +202,19 @@ impl<H: Default + Hasher, K: Eq + Hash, V> FromIterator<(K, V)> for Hamt<H, K, V
         h
     }
 }
+
+impl<H: Default + Hasher, K: Eq + Hash + serde::Serialize, V: serde::Serialize> serde::Serialize
+    for Hamt<H, K, V>
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(Some(self.size()))?;
+        for (k, v) in self.iter() {
+            map.serialize_entry(k, v)?;
+        }
+        map.end()
+    }
+}


### PR DESCRIPTION
This adds serialization/deserialization of `Ledger` using serde, which can be used by jormungandr to save/restore the chain state periodically.

It also adds `PartialEq` and `Eq` to `Ledger` and its component types. This is only used by the tests to determine if `Ledger` is restored correctly.