### PR TITLE
network-grpc: API to poll client for readiness

### DIFF
--- a/network-core/src/client.rs
+++ b/network-core/src/client.rs
@@ -2,8 +2,9 @@
 
 pub mod block;
 pub mod gossip;
+pub mod p2p;
 
-use crate::{error::Error, gossip::NodeId};
+use crate::error::Error;
 
 use futures::prelude::*;
 use futures::try_ready;
@@ -44,11 +45,4 @@ impl<C: Client> Future for ClientReady<C> {
         try_ready!(client.poll_ready());
         Ok(Async::Ready(self.client.take().unwrap()))
     }
-}
-
-/// Base trait for the client services that use node identifiers to
-/// distinguish subscription streams.
-pub trait P2pService {
-    /// Network node identifier.
-    type NodeId: NodeId;
 }

--- a/network-core/src/client.rs
+++ b/network-core/src/client.rs
@@ -3,7 +3,48 @@
 pub mod block;
 pub mod gossip;
 
-use crate::gossip::NodeId;
+use crate::{error::Error, gossip::NodeId};
+
+use futures::prelude::*;
+use futures::try_ready;
+
+/// Basic workings of client connections.
+pub trait Client: Sized {
+    /// Poll whether this client connection is ready to send another request.
+    ///
+    /// The users should make sure the client is ready before sending
+    /// service requests.
+    fn poll_ready(&mut self) -> Poll<(), Error>;
+
+    /// Get a `Future` of when this client connection is ready to send
+    /// another request.
+    fn ready(self) -> ClientReady<Self> {
+        ClientReady::new(self)
+    }
+}
+
+/// Future that resolves to the client connection object when it is ready
+/// to send another request.
+pub struct ClientReady<C> {
+    client: Option<C>,
+}
+
+impl<C> ClientReady<C> {
+    fn new(client: C) -> Self {
+        ClientReady { client: Some(client) }
+    }
+}
+
+impl<C: Client> Future for ClientReady<C> {
+    type Item = C;
+    type Error = Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let client = self.client.as_mut().expect("polled a finished future");
+        try_ready!(client.poll_ready());
+        Ok(Async::Ready(self.client.take().unwrap()))
+    }
+}
 
 /// Base trait for the client services that use node identifiers to
 /// distinguish subscription streams.

--- a/network-core/src/client.rs
+++ b/network-core/src/client.rs
@@ -32,7 +32,9 @@ pub struct ClientReady<C> {
 
 impl<C> ClientReady<C> {
     fn new(client: C) -> Self {
-        ClientReady { client: Some(client) }
+        ClientReady {
+            client: Some(client),
+        }
     }
 }
 

--- a/network-core/src/client/block.rs
+++ b/network-core/src/client/block.rs
@@ -1,4 +1,4 @@
-use super::P2pService;
+use super::p2p::P2pService;
 use crate::{error::Error, subscription::BlockEvent};
 
 use chain_core::property::{Block, HasHeader};

--- a/network-core/src/client/gossip.rs
+++ b/network-core/src/client/gossip.rs
@@ -1,4 +1,4 @@
-use super::P2pService;
+use super::p2p::P2pService;
 use crate::{
     error::Error,
     gossip::{Gossip, Node},

--- a/network-core/src/client/p2p.rs
+++ b/network-core/src/client/p2p.rs
@@ -1,0 +1,8 @@
+use crate::gossip::NodeId;
+
+/// Base trait for the client services that use node identifiers to
+/// distinguish subscription streams.
+pub trait P2pService {
+    /// Network node identifier.
+    type NodeId: NodeId;
+}

--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -9,10 +9,10 @@ use crate::{
 };
 
 use chain_core::property;
-use network_core::client::Client;
 use network_core::client::block::BlockService;
 use network_core::client::gossip::GossipService;
 use network_core::client::p2p::P2pService;
+use network_core::client::Client;
 use network_core::error as core_error;
 use network_core::gossip::{self, Gossip, NodeId};
 use network_core::subscription::BlockEvent;

--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -311,10 +311,13 @@ where
         req
     }
 
+    /// Poll whether this client connection is ready to send another request.
     pub fn poll_ready(&mut self) -> Poll<(), core_error::Error> {
         self.service.poll_ready().map_err(error_from_grpc)
     }
 
+    /// Get a `Future` of when this client connection is ready to send
+    /// another request.
     pub fn ready(self) -> impl Future<Item = Self, Error = core_error::Error> {
         let node_id = self.node_id;
         self.service

--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -310,6 +310,18 @@ where
         }
         req
     }
+
+    pub fn poll_ready(&mut self) -> Poll<(), core_error::Error> {
+        self.service.poll_ready().map_err(error_from_grpc)
+    }
+
+    pub fn ready(self) -> impl Future<Item = Self, Error = core_error::Error> {
+        let node_id = self.node_id;
+        self.service
+            .ready()
+            .map(move |service| Connection { service, node_id })
+            .map_err(error_from_grpc)
+    }
 }
 
 impl<P> P2pService for Connection<P>

--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -9,7 +9,10 @@ use crate::{
 };
 
 use chain_core::property;
-use network_core::client::{Client, block::BlockService, gossip::GossipService, P2pService};
+use network_core::client::Client;
+use network_core::client::block::BlockService;
+use network_core::client::gossip::GossipService;
+use network_core::client::p2p::P2pService;
 use network_core::error as core_error;
 use network_core::gossip::{self, Gossip, NodeId};
 use network_core::subscription::BlockEvent;

--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -9,12 +9,10 @@ use crate::{
 };
 
 use chain_core::property;
-use network_core::{
-    client::{block::BlockService, gossip::GossipService, P2pService},
-    error as core_error,
-    gossip::{self, Gossip, NodeId},
-    subscription::BlockEvent,
-};
+use network_core::client::{Client, block::BlockService, gossip::GossipService, P2pService};
+use network_core::error as core_error;
+use network_core::gossip::{self, Gossip, NodeId};
+use network_core::subscription::BlockEvent;
 
 use tokio::prelude::*;
 use tower_grpc::{BoxBody, Code, Request, Status, Streaming};
@@ -310,20 +308,14 @@ where
         }
         req
     }
+}
 
-    /// Poll whether this client connection is ready to send another request.
-    pub fn poll_ready(&mut self) -> Poll<(), core_error::Error> {
+impl<P> Client for Connection<P>
+where
+    P: ProtocolConfig,
+{
+    fn poll_ready(&mut self) -> Poll<(), core_error::Error> {
         self.service.poll_ready().map_err(error_from_grpc)
-    }
-
-    /// Get a `Future` of when this client connection is ready to send
-    /// another request.
-    pub fn ready(self) -> impl Future<Item = Self, Error = core_error::Error> {
-        let node_id = self.node_id;
-        self.service
-            .ready()
-            .map(move |service| Connection { service, node_id })
-            .map_err(error_from_grpc)
     }
 }
 

--- a/network-ntt/src/client.rs
+++ b/network-ntt/src/client.rs
@@ -3,7 +3,7 @@ use super::gossip::NodeId;
 use chain_core::property::{Block, HasHeader, Header};
 
 use network_core::{
-    client::{block::BlockService, P2pService},
+    client::{block::BlockService, p2p::P2pService},
     error as core_error,
     subscription::BlockEvent,
 };


### PR DESCRIPTION
It is necessary to poll for the client connection object for readiness,
otherwise requests issued concurrently may fail.