### PR TITLE
chain-storage: Get rid of excessive boxing and dynamism

### DIFF
--- a/chain-storage-sqlite/examples/import.rs
+++ b/chain-storage-sqlite/examples/import.rs
@@ -38,9 +38,7 @@ fn main() {
             .as_bytes(),
     ));
 
-    // Test whether using BlockStore as a trait object works.
-    let mut store: Box<dyn BlockStore<Block = cardano::block::Block>> =
-        Box::new(chain_storage_sqlite::SQLiteBlockStore::new(db_path));
+    let mut store = chain_storage_sqlite::SQLiteBlockStore::new(db_path);
 
     /* Convert a chain using old-school storage to a SQLiteBlockStore. */
     let now = Instant::now();

--- a/chain-storage-sqlite/src/lib.rs
+++ b/chain-storage-sqlite/src/lib.rs
@@ -217,10 +217,6 @@ where
             Err(err) => Err(Error::BackendError(Box::new(err))),
         }
     }
-
-    fn as_trait(&self) -> &BlockStore<Block = Self::Block> {
-        self as &BlockStore<Block = Self::Block>
-    }
 }
 
 #[cfg(test)]

--- a/chain-storage/src/memory.rs
+++ b/chain-storage/src/memory.rs
@@ -70,10 +70,6 @@ where
             Ok(None)
         }
     }
-
-    fn as_trait(&self) -> &BlockStore<Block = Self::Block> {
-        self as &BlockStore<Block = Self::Block>
-    }
 }
 
 #[cfg(test)]

--- a/chain-storage/src/store.rs
+++ b/chain-storage/src/store.rs
@@ -246,13 +246,13 @@ where
     }
 }
 
-// Like `BlockStore::get_nth_ancestor`, but calls the closure 'callback' with
-// each intermediate block encountered while travelling from
-// 'block_hash' to its n'th ancestor.
-//
-// The travelling algorithm uses back links to skip over parts of the chain,
-// so the callback will not be invoked for all blocks linearly.
-fn for_path_to_nth_ancestor<S, F>(
+/// Like `BlockStore::get_nth_ancestor`, but calls the closure 'callback' with
+/// each intermediate block encountered while travelling from
+/// 'block_hash' to its n'th ancestor.
+///
+/// The travelling algorithm uses back links to skip over parts of the chain,
+/// so the callback will not be invoked for all blocks in the linear sequence.
+pub fn for_path_to_nth_ancestor<S, F>(
     store: &S,
     block_hash: &<S::Block as Block>::Id,
     distance: u64,


### PR DESCRIPTION
Remove the boxed closures and dynamic trait objects.
The BlockStore trait loses object safety, but it should never
have required it.

`get_path_to_nth_accessor` is removed from the trait methods and turned into a free helper fn `for_path_to_nth_accessor`.